### PR TITLE
Honor system http proxies when using non-default transport

### DIFF
--- a/gerrit/widget.go
+++ b/gerrit/widget.go
@@ -79,6 +79,7 @@ func (widget *Widget) Refresh() {
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: !verifyServerCertificate,
 		},
+		Proxy: http.ProxyFromEnvironment,
 	},
 	}
 

--- a/jenkins/client.go
+++ b/jenkins/client.go
@@ -34,6 +34,7 @@ func Create(jenkinsURL string, username string, apiKey string) (*View, error) {
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: !verifyServerCertificate,
 		},
+		Proxy: http.ProxyFromEnvironment,
 	},
 	}
 	resp, err := httpClient.Do(req)

--- a/jira/client.go
+++ b/jira/client.go
@@ -75,6 +75,7 @@ func jiraRequest(path string) (*http.Response, error) {
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: !verifyServerCertificate,
 		},
+		Proxy: http.ProxyFromEnvironment,
 	},
 	}
 	resp, err := httpClient.Do(req)


### PR DESCRIPTION
This implements the same proxy behavior as per http.DefaultTransport using HTTP proxies as directed by the $HTTP_PROXY and $NO_PROXY (or $http_proxy and $no_proxy) environment variables.