### PR TITLE
Go generate

### DIFF
--- a/generator/textwidget.go
+++ b/generator/textwidget.go
@@ -5,7 +5,7 @@
 // using the textwidget.tpl template.
 // The TextWidget generator needs one environment variable, called WTF_WIDGET_NAME, which will
 // be the name of the TextWidget it generates. If the variable hasn't been set, the generator
-// will use "NewWiNewTextWidgetdget". On Linux and macOS the command can be run as
+// will use "NewTextWidget". On Linux and macOS the command can be run as
 // 'WTF_WIDGET_NAME=MyNewWidget go generate text'.
 package main
 

--- a/generator/textwidget.go
+++ b/generator/textwidget.go
@@ -10,6 +10,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"strings"
 	"text/template"
@@ -40,7 +41,15 @@ func main() {
 		"Title": strings.Title,
 	}).ParseFiles("generator/textwidget.tpl")
 
-	out, _ := os.Create("generator/test.go")
+	err := os.Mkdir(strings.ToLower(widgetName), os.ModePerm)
+	if err != nil {
+		fmt.Println(err.Error())
+	}
+
+	out, err := os.Create(fmt.Sprintf("%s/widget.go", strings.ToLower(widgetName)))
+	if err != nil {
+		fmt.Println(err.Error())
+	}
 	defer out.Close()
 
 	tpl.Execute(out, data)

--- a/generator/textwidget.go
+++ b/generator/textwidget.go
@@ -6,7 +6,7 @@
 // The TextWidget generator needs one environment variable, called WTF_WIDGET_NAME, which will
 // be the name of the TextWidget it generates. If the variable hasn't been set, the generator
 // will use "NewTextWidget". On Linux and macOS the command can be run as
-// 'WTF_WIDGET_NAME=MyNewWidget go generate text'.
+// 'WTF_WIDGET_NAME=MyNewWidget go generate -run=text'.
 package main
 
 import (

--- a/generator/textwidget.go
+++ b/generator/textwidget.go
@@ -1,0 +1,47 @@
+// +build ignore
+
+// This package takes care of generates for empty widgets. Each generator is named after the
+// type of widget it generate, so textwidget.go will generate the skeleton for a new TextWidget
+// using the textwidget.tpl template.
+// The TextWidget generator needs one environment variable, called WTF_WIDGET_NAME, which will
+// be the name of the TextWidget it generates. If the variable hasn't been set, the generator
+// will use "NewWiNewTextWidgetdget". On Linux and macOS the command can be run as
+// 'WTF_WIDGET_NAME=MyNewWidget go generate text'.
+package main
+
+import (
+	"os"
+	"strings"
+	"text/template"
+)
+
+var (
+	widgetName string
+)
+
+const (
+	defaultWidgetName = "NewTextWidget"
+)
+
+func main() {
+	widgetName, present := os.LookupEnv("WTF_WIDGET_NAME")
+	if !present {
+		widgetName = defaultWidgetName
+	}
+
+	data := struct {
+		Name string
+	}{
+		widgetName,
+	}
+
+	tpl, _ := template.New("textwidget.tpl").Funcs(template.FuncMap{
+		"Lower": strings.ToLower,
+		"Title": strings.Title,
+	}).ParseFiles("generator/textwidget.tpl")
+
+	out, _ := os.Create("generator/test.go")
+	defer out.Close()
+
+	tpl.Execute(out, data)
+}

--- a/generator/textwidget.tpl
+++ b/generator/textwidget.tpl
@@ -1,0 +1,69 @@
+// Package {{(Lower .Name)}}
+package {{(Lower .Name)}}
+
+import (
+	"strconv"
+
+	"github.com/gdamore/tcell"
+	"github.com/rivo/tview"
+	"github.com/wtfutil/wtf/wtf"
+)
+
+const HelpText = `
+ Keyboard commands for {{(Title .Name)}}:
+`
+
+type Widget struct {
+	wtf.HelpfulWidget
+	wtf.TextWidget
+}
+
+func NewWidget(app *tview.Application, pages *tview.Pages) *Widget {
+	widget := Widget{
+		HelpfulWidget: wtf.NewHelpfulWidget(app, pages, HelpText),
+		TextWidget:    wtf.NewTextWidget(app, "{{(Title .Name)}}", "{{(Lower .Name)}}", true),
+	}
+
+	widget.HelpfulWidget.SetView(widget.View)
+	widget.unselect()
+
+	widget.View.SetScrollable(true)
+	widget.View.SetRegions(true)
+	widget.View.SetInputCapture(widget.keyboardIntercept)
+
+	return &widget
+}
+
+/* -------------------- Exported Functions -------------------- */
+
+func (widget *Widget) Refresh() {
+
+	// The last call should always be to the display function
+	widget.display()
+}
+
+/* -------------------- Unexported Functions -------------------- */
+
+func (widget *Widget) display() {
+	widget.View.SetWrap(false)
+
+	widget.View.Clear()
+	widget.View.SetTitle(widget.Name)
+	widget.View.SetText("Some Text")
+	widget.View.Highlight(strconv.Itoa(widget.selected)).ScrollToHighlight()
+}
+
+func (widget *Widget) unselect() {
+	widget.selected = -1
+	widget.display()
+}
+
+func (widget *Widget) keyboardIntercept(event *tcell.EventKey) *tcell.EventKey {
+	// This switch statement could handle alphanumeric keys
+	switch string(event.Rune()) {
+	}
+
+	// This switch statement could handle events like the "enter" key
+	switch event.Key() {
+	}
+}

--- a/main.go
+++ b/main.go
@@ -1,5 +1,10 @@
 package main
 
+// Generators
+// To generate the skeelton for a new TextWidget use 'WTF_WIDGET_NAME=bla go generate text'
+//go:generate -command text go run generator/textwidget.go
+//go:generate text
+
 import (
 	"fmt"
 	"log"

--- a/main.go
+++ b/main.go
@@ -1,7 +1,7 @@
 package main
 
 // Generators
-// To generate the skeelton for a new TextWidget use 'WTF_WIDGET_NAME=bla go generate text'
+// To generate the skeleton for a new TextWidget use 'WTF_WIDGET_NAME=MySuperAwesomeWidget go generate -run=text
 //go:generate -command text go run generator/textwidget.go
 //go:generate text
 


### PR DESCRIPTION
_as mentioned in #310_

## What problem does this solve?
Right now anyone creating a new module has to start from scratch, probably copy/pasting/chopping the guts from an existing module. This is tedious, error-prone, and not a great use of people's time.

## How does it work?
The package `generator` contains generates for empty widgets (stubs). Each generator is named after the type of widget it generate, so `textwidget.go` will generate the skeleton for a new TextWidget using the `textwidget.tpl` template. Since you can't dynamically add any arguments to `go generate`, the TextWidget generator needs one environment variable, called _**WTF_WIDGET_NAME**_, which will be the name of the TextWidget it generates. If the variable hasn't been set, the generator will use `NewTextWidget`. As an example, on macOS the command can be run as `WTF_WIDGET_NAME=MySuperAwesomeWidget go generate -run=text`, which will generate a new module based on the TextWidget generator in the folder `mysuperawesomewidget`