### PR TITLE
Changed nmcli cmd to check on AP connect to using '*' in the in-use f…

### DIFF
--- a/security/wifi.go
+++ b/security/wifi.go
@@ -43,10 +43,10 @@ func WifiName() string {
 /* -------------------- Unexported Functions -------------------- */
 
 func wifiEncryptionLinux() string {
-	cmd := exec.Command("nmcli", "-t", "-f", "active,security", "dev", "wifi")
+	cmd := exec.Command("nmcli", "-t", "-f", "in-use,security", "dev", "wifi")
 	out := wtf.ExecuteCommand(cmd)
 
-	name := wtf.FindMatch(`yes:(.+)`, out)
+	name := wtf.FindMatch(`\*:(.+)`, out)
 
 	if len(name) > 0 {
 		return name[0][1]
@@ -66,9 +66,9 @@ func wifiInfo() string {
 }
 
 func wifiNameLinux() string {
-	cmd := exec.Command("nmcli", "-t", "-f", "active,ssid", "dev", "wifi")
+	cmd := exec.Command("nmcli", "-t", "-f", "in-use,ssid", "dev", "wifi")
 	out := wtf.ExecuteCommand(cmd)
-	name := wtf.FindMatch(`yes:(.+)`, out)
+	name := wtf.FindMatch(`\*:(.+)`, out)
 	if len(name) > 0 {
 		return name[0][1]
 	}


### PR DESCRIPTION
Changed nmcli cmd to check on AP connect to using '*' in the in-use field instead of 'yes/no' from the active field. This is needed for non english language set in operating system.

This is needed because yes/no will not be the same text depending on the language configured in the operating system. Using the "in-use" field that is either set to "*" ot "" will be easier for the "wtf.FindMatch" function to match.