### PR TITLE
Do not fail with an error if the configuration has references to widget that do not exist (yet)

### DIFF
--- a/main.go
+++ b/main.go
@@ -259,7 +259,6 @@ func addWidget(app *tview.Application, pages *tview.Pages, widgetName string) {
 	case "zendesk":
 		widgets = append(widgets, zendesk.NewWidget(app))
 	default:
-		panic(widgetName)
 	}
 }
 


### PR DESCRIPTION
Do not fail with an error if the configuration has references to widget that do not exist (yet)

E.g. If the user is working on new widgets adn switching back and forth on version with/without the "new" widget, the applciation crashes with an error when using the old version of the app.
I cant see that this is especially helpful