### PR TITLE
Decouple bamboohr client from widget

### DIFF
--- a/bamboohr/client.go
+++ b/bamboohr/client.go
@@ -3,9 +3,6 @@ package bamboohr
 import (
 	"encoding/xml"
 	"fmt"
-	"os"
-
-	"github.com/wtfutil/wtf/wtf"
 )
 
 // A Client represents the data required to connect to the BambooHR API
@@ -16,12 +13,12 @@ type Client struct {
 }
 
 // NewClient creates and returns a new BambooHR client
-func NewClient(url string) *Client {
+func NewClient(url string, apiKey string, subdomain string) *Client {
 	client := Client{
-		apiBase: url,
+		apiBase:   url,
+		apiKey:    apiKey,
+		subdomain: subdomain,
 	}
-
-	client.loadAPICredentials()
 
 	return &client
 }
@@ -61,16 +58,4 @@ func (client *Client) away(startDate, endDate string) (cal Calendar, err error) 
 	err = xml.Unmarshal(data, &cal)
 
 	return
-}
-
-func (client *Client) loadAPICredentials() {
-	client.apiKey = wtf.Config.UString(
-		"wtf.mods.bamboohr.apiKey",
-		os.Getenv("WTF_BAMBOO_HR_TOKEN"),
-	)
-
-	client.subdomain = wtf.Config.UString(
-		"wtf.mods.bamboohr.subdomain",
-		os.Getenv("WTF_BAMBOO_HR_SUBDOMAIN"),
-	)
 }

--- a/bamboohr/widget.go
+++ b/bamboohr/widget.go
@@ -2,6 +2,7 @@ package bamboohr
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/rivo/tview"
 	"github.com/wtfutil/wtf/wtf"
@@ -22,7 +23,17 @@ func NewWidget(app *tview.Application) *Widget {
 /* -------------------- Exported Functions -------------------- */
 
 func (widget *Widget) Refresh() {
-	client := NewClient("https://api.bamboohr.com/api/gateway.php")
+	apiKey := wtf.Config.UString(
+		"wtf.mods.bamboohr.apiKey",
+		os.Getenv("WTF_BAMBOO_HR_TOKEN"),
+	)
+
+	subdomain := wtf.Config.UString(
+		"wtf.mods.bamboohr.subdomain",
+		os.Getenv("WTF_BAMBOO_HR_SUBDOMAIN"),
+	)
+
+	client := NewClient("https://api.bamboohr.com/api/gateway.php", apiKey, subdomain)
 	todayItems := client.Away(
 		"timeOff",
 		wtf.Now().Format(wtf.DateFormat),


### PR DESCRIPTION
Have the client be in charge of API
Have the widget be in charge of widget config
This is a step in the direction of running multiple version (with their own configs)