### PR TITLE
WTF-400 Extracting config out of modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ gcal/client_secret.json
 gspreadsheets/client_secret.json
 profile.pdf
 report.*
+.vscode
 
 # All things node
 node_modules/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "workbench.colorCustomizations": {}
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "workbench.colorCustomizations": {}
-}

--- a/cfg/common_settings.go
+++ b/cfg/common_settings.go
@@ -28,10 +28,16 @@ type Position struct {
 	Width  int
 }
 
+type Sigils struct {
+	CheckedIcon   string
+	UncheckedIcon string
+}
+
 type Common struct {
 	Colors
 	Module
 	Position
+	Sigils
 
 	Enabled         bool
 	FocusChar       int
@@ -43,6 +49,7 @@ func NewCommonSettingsFromYAML(name, configKey string, ymlConfig *config.Config)
 	colorsPath := "wtf.colors"
 	modulePath := "wtf.mods." + configKey
 	positionPath := "wtf.mods." + configKey + ".position"
+	sigilsPath := "wtf.sigils"
 
 	common := Common{
 		Colors: Colors{
@@ -50,7 +57,7 @@ func NewCommonSettingsFromYAML(name, configKey string, ymlConfig *config.Config)
 			BorderFocusable: ymlConfig.UString(colorsPath+".border.focusable", "red"),
 			BorderFocused:   ymlConfig.UString(colorsPath+".border.focused", "orange"),
 			BorderNormal:    ymlConfig.UString(colorsPath+".border.normal", "gray"),
-			Checked:         ymlConfig.UString(colorsPath+".checked", "gray"),
+			Checked:         ymlConfig.UString(colorsPath+".checked", "white"),
 			HighlightFore:   ymlConfig.UString(colorsPath+".highlight.fore", "black"),
 			HighlightBack:   ymlConfig.UString(colorsPath+".highlight.back", "green"),
 			Text:            ymlConfig.UString(modulePath+".colors.text", ymlConfig.UString(colorsPath+".text", "white")),
@@ -67,6 +74,11 @@ func NewCommonSettingsFromYAML(name, configKey string, ymlConfig *config.Config)
 			Left:   ymlConfig.UInt(positionPath + ".left"),
 			Top:    ymlConfig.UInt(positionPath + ".top"),
 			Width:  ymlConfig.UInt(positionPath + ".width"),
+		},
+
+		Sigils: Sigils{
+			CheckedIcon:   ymlConfig.UString(sigilsPath+".checkedIcon", "x"),
+			UncheckedIcon: ymlConfig.UString(sigilsPath+".uncheckedIcon", " "),
 		},
 
 		Enabled:         ymlConfig.UBool(modulePath+".enabled", false),

--- a/cfg/common_settings.go
+++ b/cfg/common_settings.go
@@ -84,7 +84,7 @@ func NewCommonSettingsFromYAML(name, configKey string, ymlConfig *config.Config)
 		Enabled:         ymlConfig.UBool(modulePath+".enabled", false),
 		FocusChar:       ymlConfig.UInt(modulePath+".focusChar", -1),
 		RefreshInterval: ymlConfig.UInt(modulePath+".refreshInterval", 300),
-		Title:           ymlConfig.UString(modulePath+".title", ""),
+		Title:           ymlConfig.UString(modulePath+".title", name),
 	}
 
 	return &common

--- a/cfg/common_settings.go
+++ b/cfg/common_settings.go
@@ -13,6 +13,7 @@ type Colors struct {
 	HighlightFore   string
 	HighlightBack   string
 	Text            string
+	Title           string
 }
 
 type Module struct {
@@ -33,21 +34,27 @@ type Common struct {
 	Position
 
 	Enabled         bool
+	FocusChar       int
 	RefreshInterval int
 	Title           string
 }
 
 func NewCommonSettingsFromYAML(name, configKey string, ymlConfig *config.Config) *Common {
+	colorsPath := "wtf.colors"
+	modulePath := "wtf.mods." + configKey
+	positionPath := "wtf.mods." + configKey + ".position"
+
 	common := Common{
 		Colors: Colors{
-			Background:      ymlConfig.UString("wtf.colors.background", "black"),
-			BorderFocusable: ymlConfig.UString("wtf.colors.border.focusable"),
-			BorderFocused:   ymlConfig.UString("wtf.colors.border.focused"),
-			BorderNormal:    ymlConfig.UString("wtf.colors.border.normal"),
-			Checked:         ymlConfig.UString("wtf.colors.checked"),
-			HighlightFore:   ymlConfig.UString("wtf.colors.highlight.fore"),
-			HighlightBack:   ymlConfig.UString("wtf.colors.highlight.back"),
-			Text:            ymlConfig.UString("wtf.colors.text", "white"),
+			Background:      ymlConfig.UString(modulePath+".colors.background", ymlConfig.UString(colorsPath+".background", "black")),
+			BorderFocusable: ymlConfig.UString(colorsPath+".border.focusable", "red"),
+			BorderFocused:   ymlConfig.UString(colorsPath+".border.focused", "orange"),
+			BorderNormal:    ymlConfig.UString(colorsPath+".border.normal", "gray"),
+			Checked:         ymlConfig.UString(colorsPath+".checked", "gray"),
+			HighlightFore:   ymlConfig.UString(colorsPath+".highlight.fore", "black"),
+			HighlightBack:   ymlConfig.UString(colorsPath+".highlight.back", "green"),
+			Text:            ymlConfig.UString(modulePath+".colors.text", ymlConfig.UString(colorsPath+".text", "white")),
+			Title:           ymlConfig.UString(modulePath+".colors.title", ymlConfig.UString(colorsPath+".title", "white")),
 		},
 
 		Module: Module{
@@ -55,7 +62,17 @@ func NewCommonSettingsFromYAML(name, configKey string, ymlConfig *config.Config)
 			Name:      name,
 		},
 
-		Position: Position{},
+		Position: Position{
+			Height: ymlConfig.UInt(positionPath + ".height"),
+			Left:   ymlConfig.UInt(positionPath + ".left"),
+			Top:    ymlConfig.UInt(positionPath + ".top"),
+			Width:  ymlConfig.UInt(positionPath + ".width"),
+		},
+
+		Enabled:         ymlConfig.UBool(modulePath+".enabled", false),
+		FocusChar:       ymlConfig.UInt(modulePath+".focusChar", -1),
+		RefreshInterval: ymlConfig.UInt(modulePath+".refreshInterval", 300),
+		Title:           ymlConfig.UString(modulePath+".title", name),
 	}
 
 	return &common

--- a/cfg/common_settings.go
+++ b/cfg/common_settings.go
@@ -15,6 +15,11 @@ type Colors struct {
 	Text            string
 }
 
+type Module struct {
+	ConfigKey string
+	Name      string
+}
+
 type Position struct {
 	Height int
 	Left   int
@@ -24,6 +29,7 @@ type Position struct {
 
 type Common struct {
 	Colors
+	Module
 	Position
 
 	Enabled         bool
@@ -31,7 +37,7 @@ type Common struct {
 	Title           string
 }
 
-func NewCommonSettingsFromYAML(ymlConfig *config.Config) *Common {
+func NewCommonSettingsFromYAML(name, configKey string, ymlConfig *config.Config) *Common {
 	common := Common{
 		Colors: Colors{
 			Background:      ymlConfig.UString("wtf.colors.background", "black"),
@@ -43,6 +49,12 @@ func NewCommonSettingsFromYAML(ymlConfig *config.Config) *Common {
 			HighlightBack:   ymlConfig.UString("wtf.colors.highlight.back"),
 			Text:            ymlConfig.UString("wtf.colors.text", "white"),
 		},
+
+		Module: Module{
+			ConfigKey: configKey,
+			Name:      name,
+		},
+
 		Position: Position{},
 	}
 

--- a/cfg/common_settings.go
+++ b/cfg/common_settings.go
@@ -1,0 +1,50 @@
+package cfg
+
+import (
+	"github.com/olebedev/config"
+)
+
+type Colors struct {
+	Background      string
+	BorderFocusable string
+	BorderFocused   string
+	BorderNormal    string
+	Checked         string
+	HighlightFore   string
+	HighlightBack   string
+	Text            string
+}
+
+type Position struct {
+	Height int
+	Left   int
+	Top    int
+	Width  int
+}
+
+type Common struct {
+	Colors
+	Position
+
+	Enabled         bool
+	RefreshInterval int
+	Title           string
+}
+
+func NewCommonSettingsFromYAML(ymlConfig *config.Config) *Common {
+	common := Common{
+		Colors: Colors{
+			Background:      ymlConfig.UString("wtf.colors.background", "black"),
+			BorderFocusable: ymlConfig.UString("wtf.colors.border.focusable"),
+			BorderFocused:   ymlConfig.UString("wtf.colors.border.focused"),
+			BorderNormal:    ymlConfig.UString("wtf.colors.border.normal"),
+			Checked:         ymlConfig.UString("wtf.colors.checked"),
+			HighlightFore:   ymlConfig.UString("wtf.colors.highlight.fore"),
+			HighlightBack:   ymlConfig.UString("wtf.colors.highlight.back"),
+			Text:            ymlConfig.UString("wtf.colors.text", "white"),
+		},
+		Position: Position{},
+	}
+
+	return &common
+}

--- a/cfg/common_settings.go
+++ b/cfg/common_settings.go
@@ -84,7 +84,7 @@ func NewCommonSettingsFromYAML(name, configKey string, ymlConfig *config.Config)
 		Enabled:         ymlConfig.UBool(modulePath+".enabled", false),
 		FocusChar:       ymlConfig.UInt(modulePath+".focusChar", -1),
 		RefreshInterval: ymlConfig.UInt(modulePath+".refreshInterval", 300),
-		Title:           ymlConfig.UString(modulePath+".title", name),
+		Title:           ymlConfig.UString(modulePath+".title", ""),
 	}
 
 	return &common

--- a/cfg/config_files.go
+++ b/cfg/config_files.go
@@ -6,7 +6,6 @@ import (
 	"os"
 
 	"github.com/olebedev/config"
-	// "github.com/wtfutil/wtf/logger"
 	"github.com/wtfutil/wtf/wtf"
 )
 

--- a/cfg/config_files.go
+++ b/cfg/config_files.go
@@ -1,12 +1,14 @@
 package cfg
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
+	"os/user"
+	"path/filepath"
 
 	"github.com/olebedev/config"
-	"github.com/wtfutil/wtf/wtf"
 )
 
 // ConfigDirV1 defines the path to the first version of configuration. Do not use this
@@ -20,8 +22,8 @@ const ConfigDirV2 = "~/.config/wtf/"
 // MigrateOldConfig copies any existing configuration from the old location
 // to the new, XDG-compatible location
 func MigrateOldConfig() {
-	srcDir, _ := wtf.ExpandHomeDir(ConfigDirV1)
-	destDir, _ := wtf.ExpandHomeDir(ConfigDirV2)
+	srcDir, _ := expandHomeDir(ConfigDirV1)
+	destDir, _ := expandHomeDir(ConfigDirV2)
 
 	// If the old config directory doesn't exist, do not move
 	if _, err := os.Stat(srcDir); os.IsNotExist(err) {
@@ -52,7 +54,7 @@ func MigrateOldConfig() {
 
 // ConfigDir returns the absolute path to the configuration directory
 func ConfigDir() (string, error) {
-	configDir, err := wtf.ExpandHomeDir(ConfigDirV2)
+	configDir, err := expandHomeDir(ConfigDirV2)
 	if err != nil {
 		return "", err
 	}
@@ -120,7 +122,7 @@ func CreateFile(fileName string) (string, error) {
 
 // LoadConfigFile loads the config.yml file to configure the app
 func LoadConfigFile(filePath string) *config.Config {
-	absPath, _ := wtf.ExpandHomeDir(filePath)
+	absPath, _ := expandHomeDir(filePath)
 
 	cfg, err := config.ParseYamlFile(absPath)
 	if err != nil {
@@ -196,3 +198,43 @@ const simpleConfig = `wtf:
         width: 1
       refreshInterval: 30
 `
+
+/* -------------------- Unexported Functions -------------------- */
+
+// Expand expands the path to include the home directory if the path
+// is prefixed with `~`. If it isn't prefixed with `~`, the path is
+// returned as-is.
+func expandHomeDir(path string) (string, error) {
+	if len(path) == 0 {
+		return path, nil
+	}
+
+	if path[0] != '~' {
+		return path, nil
+	}
+
+	if len(path) > 1 && path[1] != '/' && path[1] != '\\' {
+		return "", errors.New("cannot expand user-specific home dir")
+	}
+
+	dir, err := home()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(dir, path[1:]), nil
+}
+
+// Dir returns the home directory for the executing user.
+// An error is returned if a home directory cannot be detected.
+func home() (string, error) {
+	currentUser, err := user.Current()
+	if err != nil {
+		return "", err
+	}
+	if currentUser.HomeDir == "" {
+		return "", errors.New("cannot find user-specific home dir")
+	}
+
+	return currentUser.HomeDir, nil
+}

--- a/cfg/config_files.go
+++ b/cfg/config_files.go
@@ -6,7 +6,7 @@ import (
 	"os"
 
 	"github.com/olebedev/config"
-	"github.com/wtfutil/wtf/logger"
+	// "github.com/wtfutil/wtf/logger"
 	"github.com/wtfutil/wtf/wtf"
 )
 
@@ -38,15 +38,13 @@ func MigrateOldConfig() {
 	err := Copy(srcDir, destDir)
 	if err != nil {
 		panic(err)
-	} else {
-		logger.Log(fmt.Sprintf("Copied old config from %s to %s", srcDir, destDir))
 	}
 
 	// Delete the old directory if the new one exists
 	if _, err := os.Stat(destDir); err == nil {
 		err := os.RemoveAll(srcDir)
 		if err != nil {
-			logger.Log(err.Error())
+			fmt.Println(err)
 		}
 	}
 }

--- a/checklist/checklist.go
+++ b/checklist/checklist.go
@@ -3,14 +3,18 @@ package checklist
 // Checklist is a module for creating generic checklist implementations
 // See 'Todo' for an implementation example
 type Checklist struct {
-	Selected int
-
 	Items []*ChecklistItem
+
+	checkedIcon   string
+	selected      int
+	uncheckedIcon string
 }
 
-func NewChecklist() Checklist {
+func NewChecklist(checkedIcon, uncheckedIcon string) Checklist {
 	list := Checklist{
-		Selected: -1,
+		checkedIcon:   checkedIcon,
+		selected:      -1,
+		uncheckedIcon: uncheckedIcon,
 	}
 
 	return list
@@ -20,12 +24,14 @@ func NewChecklist() Checklist {
 
 // Add creates a new item in the checklist
 func (list *Checklist) Add(checked bool, text string) {
-	item := ChecklistItem{
-		Checked: checked,
-		Text:    text,
-	}
+	item := NewChecklistItem(
+		checked,
+		text,
+		list.checkedIcon,
+		list.uncheckedIcon,
+	)
 
-	list.Items = append([]*ChecklistItem{&item}, list.Items...)
+	list.Items = append([]*ChecklistItem{item}, list.Items...)
 }
 
 // CheckedItems returns a slice of all the checked items
@@ -43,7 +49,7 @@ func (list *Checklist) CheckedItems() []*ChecklistItem {
 
 // Delete removes the selected item from the checklist
 func (list *Checklist) Delete() {
-	list.Items = append(list.Items[:list.Selected], list.Items[list.Selected+1:]...)
+	list.Items = append(list.Items[:list.selected], list.Items[list.selected+1:]...)
 	list.Prev()
 }
 
@@ -53,18 +59,18 @@ func (list *Checklist) Demote() {
 		return
 	}
 
-	j := list.Selected + 1
+	j := list.selected + 1
 	if j >= len(list.Items) {
 		j = 0
 	}
 
-	list.Swap(list.Selected, j)
-	list.Selected = j
+	list.Swap(list.selected, j)
+	list.selected = j
 }
 
 // IsSelectable returns true if the checklist has selectable items, false if it does not
 func (list *Checklist) IsSelectable() bool {
-	return list.Selected >= 0 && list.Selected < len(list.Items)
+	return list.selected >= 0 && list.selected < len(list.Items)
 }
 
 // IsUnselectable returns true if the checklist has no selectable items, false if it does
@@ -74,9 +80,9 @@ func (list *Checklist) IsUnselectable() bool {
 
 // Next selects the next item in the checklist
 func (list *Checklist) Next() {
-	list.Selected = list.Selected + 1
-	if list.Selected >= len(list.Items) {
-		list.Selected = 0
+	list.selected = list.selected + 1
+	if list.selected >= len(list.Items) {
+		list.selected = 0
 	}
 }
 
@@ -95,9 +101,9 @@ func (list *Checklist) LongestLine() int {
 
 // Prev selects the previous item in the checklist
 func (list *Checklist) Prev() {
-	list.Selected = list.Selected - 1
-	if list.Selected < 0 {
-		list.Selected = len(list.Items) - 1
+	list.selected = list.selected - 1
+	if list.selected < 0 {
+		list.selected = len(list.Items) - 1
 	}
 }
 
@@ -107,13 +113,17 @@ func (list *Checklist) Promote() {
 		return
 	}
 
-	j := list.Selected - 1
+	j := list.selected - 1
 	if j < 0 {
 		j = len(list.Items) - 1
 	}
 
-	list.Swap(list.Selected, j)
-	list.Selected = j
+	list.Swap(list.selected, j)
+	list.selected = j
+}
+
+func (list *Checklist) Selected() int {
+	return list.selected
 }
 
 // SelectedItem returns the currently-selected checklist item or nil if no item is selected
@@ -122,13 +132,13 @@ func (list *Checklist) SelectedItem() *ChecklistItem {
 		return nil
 	}
 
-	return list.Items[list.Selected]
+	return list.Items[list.selected]
 }
 
 func (list *Checklist) SetSelectedByItem(selectableItem *ChecklistItem) {
 	for idx, item := range list.Items {
 		if item == selectableItem {
-			list.Selected = idx
+			list.selected = idx
 			break
 		}
 	}
@@ -158,7 +168,7 @@ func (list *Checklist) UncheckedItems() []*ChecklistItem {
 
 // Unselect removes the current select such that no item is selected
 func (list *Checklist) Unselect() {
-	list.Selected = -1
+	list.selected = -1
 }
 
 // Update sets the text of the currently-selected item to the provided text

--- a/checklist/checklist_item.go
+++ b/checklist/checklist_item.go
@@ -1,23 +1,34 @@
 package checklist
 
-import (
-	"github.com/wtfutil/wtf/wtf"
-)
+import ()
 
 // ChecklistItem is a module for creating generic checklist implementations
 // See 'Todo' for an implementation example
 type ChecklistItem struct {
-	Checked bool
-	Text    string
+	Checked       bool
+	CheckedIcon   string
+	Text          string
+	UncheckedIcon string
+}
+
+func NewChecklistItem(checked bool, text string, checkedIcon, uncheckedIcon string) *ChecklistItem {
+	item := &ChecklistItem{
+		Checked:       checked,
+		CheckedIcon:   checkedIcon,
+		Text:          text,
+		UncheckedIcon: uncheckedIcon,
+	}
+
+	return item
 }
 
 // CheckMark returns the string used to indicate a ChecklistItem is checked or unchecked
 func (item *ChecklistItem) CheckMark() string {
 	if item.Checked {
-		return wtf.Config.UString("wtf.mods.todo.checkedIcon", "x")
+		return item.CheckedIcon
 	}
 
-	return " "
+	return item.UncheckedIcon
 }
 
 // Toggle changes the checked state of the ChecklistItem

--- a/checklist/checklist_item.go
+++ b/checklist/checklist_item.go
@@ -24,6 +24,8 @@ func NewChecklistItem(checked bool, text string, checkedIcon, uncheckedIcon stri
 
 // CheckMark returns the string used to indicate a ChecklistItem is checked or unchecked
 func (item *ChecklistItem) CheckMark() string {
+	item.ensureItemIcons()
+
 	if item.Checked {
 		return item.CheckedIcon
 	}
@@ -35,4 +37,16 @@ func (item *ChecklistItem) CheckMark() string {
 // If checked, it is unchecked. If unchecked, it is checked
 func (item *ChecklistItem) Toggle() {
 	item.Checked = !item.Checked
+}
+
+/* -------------------- Unexported Functions -------------------- */
+
+func (item *ChecklistItem) ensureItemIcons() {
+	if item.CheckedIcon == "" {
+		item.CheckedIcon = "x"
+	}
+
+	if item.UncheckedIcon == "" {
+		item.UncheckedIcon = " "
+	}
 }

--- a/generator/textwidget.tpl
+++ b/generator/textwidget.tpl
@@ -16,12 +16,16 @@ const HelpText = `
 type Widget struct {
 	wtf.HelpfulWidget
 	wtf.TextWidget
+
+	settings *Settings
 }
 
-func NewWidget(app *tview.Application, pages *tview.Pages) *Widget {
+func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
 		HelpfulWidget: wtf.NewHelpfulWidget(app, pages, HelpText),
 		TextWidget:    wtf.NewTextWidget(app, "{{(Title .Name)}}", "{{(Lower .Name)}}", true),
+
+		settings: settings,
 	}
 
 	widget.HelpfulWidget.SetView(widget.View)

--- a/logger/log.go
+++ b/logger/log.go
@@ -2,7 +2,6 @@ package logger
 
 import (
 	"fmt"
-	//"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -18,13 +17,15 @@ type Widget struct {
 	wtf.TextWidget
 
 	filePath string
+	settings *Settings
 }
 
-func NewWidget(app *tview.Application) *Widget {
+func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
 		TextWidget: wtf.NewTextWidget(app, "Logs", "logger", true),
 
 		filePath: logFilePath(),
+		settings: settings,
 	}
 
 	return &widget

--- a/logger/log.go
+++ b/logger/log.go
@@ -22,7 +22,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, "Logs", "logger", true),
+		TextWidget: wtf.NewTextWidget(app, settings.common, true),
 
 		filePath: logFilePath(),
 		settings: settings,

--- a/logger/settings.go
+++ b/logger/settings.go
@@ -7,8 +7,6 @@ import (
 
 type Settings struct {
 	common *cfg.Common
-
-	filePath string
 }
 
 func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {

--- a/logger/settings.go
+++ b/logger/settings.go
@@ -1,0 +1,20 @@
+package logger
+
+import (
+	"github.com/olebedev/config"
+	"github.com/wtfutil/wtf/cfg"
+)
+
+type Settings struct {
+	common *cfg.Common
+
+	filePath string
+}
+
+func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
+	settings := Settings{
+		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+	}
+
+	return &settings
+}

--- a/logger/settings.go
+++ b/logger/settings.go
@@ -5,13 +5,15 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
+const configKey = "logger"
+
 type Settings struct {
 	common *cfg.Common
 }
 
-func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
+func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
 	}
 
 	return &settings

--- a/main.go
+++ b/main.go
@@ -220,7 +220,8 @@ func makeWidget(app *tview.Application, pages *tview.Pages, widgetName string) w
 		settings := github.NewSettingsFromYAML(wtf.Config)
 		widget = github.NewWidget(app, pages, settings)
 	case "gitlab":
-		widget = gitlab.NewWidget(app, pages)
+		settings := gitlab.NewSettingsFromYAML(wtf.Config)
+		widget = gitlab.NewWidget(app, pages, settings)
 	case "gitter":
 		widget = gitter.NewWidget(app, pages)
 	case "gspreadsheets":

--- a/main.go
+++ b/main.go
@@ -261,7 +261,8 @@ func makeWidget(app *tview.Application, pages *tview.Pages, widgetName string) w
 	case "pagerduty":
 		widget = pagerduty.NewWidget(app)
 	case "power":
-		widget = power.NewWidget(app)
+		settings := power.NewSettingsFromYAML(wtf.Config)
+		widget = power.NewWidget(app, settings)
 	case "prettyweather":
 		widget = prettyweather.NewWidget(app)
 	case "resourceusage":

--- a/main.go
+++ b/main.go
@@ -301,7 +301,8 @@ func makeWidget(app *tview.Application, pages *tview.Pages, widgetName string) w
 		settings := travisci.NewSettingsFromYAML(wtf.Config)
 		widget = travisci.NewWidget(app, pages, settings)
 	case "trello":
-		widget = trello.NewWidget(app)
+		settings := trello.NewSettingsFromYAML(wtf.Config)
+		widget = trello.NewWidget(app, settings)
 	case "twitter":
 		widget = twitter.NewWidget(app, pages)
 	case "victorops":

--- a/main.go
+++ b/main.go
@@ -298,7 +298,8 @@ func makeWidget(app *tview.Application, pages *tview.Pages, widgetName string) w
 		settings := todoist.NewSettingsFromYAML(wtf.Config)
 		widget = todoist.NewWidget(app, pages, settings)
 	case "travisci":
-		widget = travisci.NewWidget(app, pages)
+		settings := travisci.NewSettingsFromYAML(wtf.Config)
+		widget = travisci.NewWidget(app, pages, settings)
 	case "trello":
 		widget = trello.NewWidget(app)
 	case "twitter":

--- a/main.go
+++ b/main.go
@@ -182,141 +182,141 @@ func makeWidget(app *tview.Application, pages *tview.Pages, widgetName string) w
 	// Always in alphabetical order
 	switch widgetName {
 	case "bamboohr":
-		settings := bamboohr.NewSettingsFromYAML(wtf.Config)
+		settings := bamboohr.NewSettingsFromYAML("BambooHR", wtf.Config)
 		widget = bamboohr.NewWidget(app, settings)
 	case "bargraph":
 		widget = bargraph.NewWidget(app)
 	case "bittrex":
-		settings := bittrex.NewSettingsFromYAML(wtf.Config)
+		settings := bittrex.NewSettingsFromYAML("Bittrex", wtf.Config)
 		widget = bittrex.NewWidget(app, settings)
 	case "blockfolio":
-		settings := blockfolio.NewSettingsFromYAML(wtf.Config)
+		settings := blockfolio.NewSettingsFromYAML("Blockfolio", wtf.Config)
 		widget = blockfolio.NewWidget(app, settings)
 	case "circleci":
-		settings := circleci.NewSettingsFromYAML(wtf.Config)
+		settings := circleci.NewSettingsFromYAML("CircleCI", wtf.Config)
 		widget = circleci.NewWidget(app, settings)
 	case "clocks":
-		settings := clocks.NewSettingsFromYAML(wtf.Config)
+		settings := clocks.NewSettingsFromYAML("Clocks", wtf.Config)
 		widget = clocks.NewWidget(app, settings)
 	case "cmdrunner":
-		settings := cmdrunner.NewSettingsFromYAML(wtf.Config)
+		settings := cmdrunner.NewSettingsFromYAML("CmdRunner", wtf.Config)
 		widget = cmdrunner.NewWidget(app, settings)
 	case "cryptolive":
-		settings := cryptolive.NewSettingsFromYAML(wtf.Config)
+		settings := cryptolive.NewSettingsFromYAML("CryptoLive", wtf.Config)
 		widget = cryptolive.NewWidget(app, settings)
 	case "datadog":
-		settings := datadog.NewSettingsFromYAML(wtf.Config)
+		settings := datadog.NewSettingsFromYAML("DataDog", wtf.Config)
 		widget = datadog.NewWidget(app, settings)
 	case "gcal":
-		settings := gcal.NewSettingsFromYAML(wtf.Config)
+		settings := gcal.NewSettingsFromYAML("Calendar", wtf.Config)
 		widget = gcal.NewWidget(app, settings)
 	case "gerrit":
-		settings := gerrit.NewSettingsFromYAML(wtf.Config)
+		settings := gerrit.NewSettingsFromYAML("Gerrit", wtf.Config)
 		widget = gerrit.NewWidget(app, pages, settings)
 	case "git":
-		settings := git.NewSettingsFromYAML(wtf.Config)
+		settings := git.NewSettingsFromYAML("Git", wtf.Config)
 		widget = git.NewWidget(app, pages, settings)
 	case "github":
-		settings := github.NewSettingsFromYAML(wtf.Config)
+		settings := github.NewSettingsFromYAML("GitHub", wtf.Config)
 		widget = github.NewWidget(app, pages, settings)
 	case "gitlab":
-		settings := gitlab.NewSettingsFromYAML(wtf.Config)
+		settings := gitlab.NewSettingsFromYAML("GitLab", wtf.Config)
 		widget = gitlab.NewWidget(app, pages, settings)
 	case "gitter":
-		settings := gitter.NewSettingsFromYAML(wtf.Config)
+		settings := gitter.NewSettingsFromYAML("Gitter", wtf.Config)
 		widget = gitter.NewWidget(app, pages, settings)
 	case "gspreadsheets":
-		settings := gspreadsheets.NewSettingsFromYAML(wtf.Config)
+		settings := gspreadsheets.NewSettingsFromYAML("Google Spreadsheets", wtf.Config)
 		widget = gspreadsheets.NewWidget(app, settings)
 	case "hackernews":
-		settings := hackernews.NewSettingsFromYAML(wtf.Config)
+		settings := hackernews.NewSettingsFromYAML("HackerNews", wtf.Config)
 		widget = hackernews.NewWidget(app, pages, settings)
 	case "ipapi":
-		settings := ipapi.NewSettingsFromYAML(wtf.Config)
+		settings := ipapi.NewSettingsFromYAML("IPAPI", wtf.Config)
 		widget = ipapi.NewWidget(app, settings)
 	case "ipinfo":
-		settings := ipinfo.NewSettingsFromYAML(wtf.Config)
+		settings := ipinfo.NewSettingsFromYAML("IPInfo", wtf.Config)
 		widget = ipinfo.NewWidget(app, settings)
 	case "jenkins":
-		settings := jenkins.NewSettingsFromYAML(wtf.Config)
+		settings := jenkins.NewSettingsFromYAML("Jenkins", wtf.Config)
 		widget = jenkins.NewWidget(app, pages, settings)
 	case "jira":
-		settings := jira.NewSettingsFromYAML(wtf.Config)
+		settings := jira.NewSettingsFromYAML("Jira", wtf.Config)
 		widget = jira.NewWidget(app, pages, settings)
 	case "logger":
-		settings := logger.NewSettingsFromYAML(wtf.Config)
+		settings := logger.NewSettingsFromYAML("Log", wtf.Config)
 		widget = logger.NewWidget(app, settings)
 	case "mercurial":
-		settings := mercurial.NewSettingsFromYAML(wtf.Config)
+		settings := mercurial.NewSettingsFromYAML("Mercurial", wtf.Config)
 		widget = mercurial.NewWidget(app, pages, settings)
 	case "nbascore":
-		settings := nbascore.NewSettingsFromYAML(wtf.Config)
+		settings := nbascore.NewSettingsFromYAML("NBA Score", wtf.Config)
 		widget = nbascore.NewWidget(app, pages, settings)
 	case "newrelic":
-		settings := newrelic.NewSettingsFromYAML(wtf.Config)
+		settings := newrelic.NewSettingsFromYAML("NewRelic", wtf.Config)
 		widget = newrelic.NewWidget(app, settings)
 	case "opsgenie":
-		settings := opsgenie.NewSettingsFromYAML(wtf.Config)
+		settings := opsgenie.NewSettingsFromYAML("OpsGenie", wtf.Config)
 		widget = opsgenie.NewWidget(app, settings)
 	case "pagerduty":
-		settings := pagerduty.NewSettingsFromYAML(wtf.Config)
+		settings := pagerduty.NewSettingsFromYAML("PagerDuty", wtf.Config)
 		widget = pagerduty.NewWidget(app, settings)
 	case "power":
-		settings := power.NewSettingsFromYAML(wtf.Config)
+		settings := power.NewSettingsFromYAML("Power", wtf.Config)
 		widget = power.NewWidget(app, settings)
 	case "prettyweather":
-		settings := prettyweather.NewSettingsFromYAML(wtf.Config)
+		settings := prettyweather.NewSettingsFromYAML("Pretty Weather", wtf.Config)
 		widget = prettyweather.NewWidget(app, settings)
 	case "resourceusage":
-		settings := resourceusage.NewSettingsFromYAML(wtf.Config)
+		settings := resourceusage.NewSettingsFromYAML("Resource Usage", wtf.Config)
 		widget = resourceusage.NewWidget(app, settings)
 	case "rollbar":
-		settings := rollbar.NewSettingsFromYAML(wtf.Config)
+		settings := rollbar.NewSettingsFromYAML("Rollbar", wtf.Config)
 		widget = rollbar.NewWidget(app, pages, settings)
 	case "security":
-		settings := security.NewSettingsFromYAML(wtf.Config)
+		settings := security.NewSettingsFromYAML("Security", wtf.Config)
 		widget = security.NewWidget(app, settings)
 	case "spotify":
-		settings := spotify.NewSettingsFromYAML(wtf.Config)
+		settings := spotify.NewSettingsFromYAML("Spotify", wtf.Config)
 		widget = spotify.NewWidget(app, pages, settings)
 	case "spotifyweb":
-		settings := spotifyweb.NewSettingsFromYAML(wtf.Config)
+		settings := spotifyweb.NewSettingsFromYAML("Spotify Web", wtf.Config)
 		widget = spotifyweb.NewWidget(app, pages, settings)
 	case "status":
-		settings := status.NewSettingsFromYAML(wtf.Config)
+		settings := status.NewSettingsFromYAML("Status", wtf.Config)
 		widget = status.NewWidget(app, settings)
 	case "system":
-		settings := system.NewSettingsFromYAML(wtf.Config)
+		settings := system.NewSettingsFromYAML("System", wtf.Config)
 		widget = system.NewWidget(app, date, version, settings)
 	case "textfile":
-		settings := textfile.NewSettingsFromYAML(wtf.Config)
+		settings := textfile.NewSettingsFromYAML("Textfile", wtf.Config)
 		widget = textfile.NewWidget(app, pages, settings)
 	case "todo":
-		settings := todo.NewSettingsFromYAML(wtf.Config)
+		settings := todo.NewSettingsFromYAML("Todo", wtf.Config)
 		widget = todo.NewWidget(app, pages, settings)
 	case "todoist":
-		settings := todoist.NewSettingsFromYAML(wtf.Config)
+		settings := todoist.NewSettingsFromYAML("Todoist", wtf.Config)
 		widget = todoist.NewWidget(app, pages, settings)
 	case "travisci":
-		settings := travisci.NewSettingsFromYAML(wtf.Config)
+		settings := travisci.NewSettingsFromYAML("TravisCI", wtf.Config)
 		widget = travisci.NewWidget(app, pages, settings)
 	case "trello":
-		settings := trello.NewSettingsFromYAML(wtf.Config)
+		settings := trello.NewSettingsFromYAML("Trello", wtf.Config)
 		widget = trello.NewWidget(app, settings)
 	case "twitter":
-		settings := twitter.NewSettingsFromYAML(wtf.Config)
+		settings := twitter.NewSettingsFromYAML("Twitter", wtf.Config)
 		widget = twitter.NewWidget(app, pages, settings)
 	case "victorops":
-		settings := victorops.NewSettingsFromYAML(wtf.Config)
+		settings := victorops.NewSettingsFromYAML("VictorOps - OnCall", wtf.Config)
 		widget = victorops.NewWidget(app, settings)
 	case "weather":
-		settings := weather.NewSettingsFromYAML(wtf.Config)
+		settings := weather.NewSettingsFromYAML("Weather", wtf.Config)
 		widget = weather.NewWidget(app, pages, settings)
 	case "zendesk":
-		settings := zendesk.NewSettingsFromYAML(wtf.Config)
+		settings := zendesk.NewSettingsFromYAML("Zendesk", wtf.Config)
 		widget = zendesk.NewWidget(app, settings)
 	default:
-		settings := unknown.NewSettingsFromYAML(wtf.Config)
+		settings := unknown.NewSettingsFromYAML(widgetName, wtf.Config)
 		widget = unknown.NewWidget(app, widgetName, settings)
 	}
 

--- a/main.go
+++ b/main.go
@@ -265,7 +265,8 @@ func makeWidget(app *tview.Application, pages *tview.Pages, widgetName string) w
 		settings := power.NewSettingsFromYAML(wtf.Config)
 		widget = power.NewWidget(app, settings)
 	case "prettyweather":
-		widget = prettyweather.NewWidget(app)
+		settings := prettyweather.NewSettingsFromYAML(wtf.Config)
+		widget = prettyweather.NewWidget(app, settings)
 	case "resourceusage":
 		widget = resourceusage.NewWidget(app)
 	case "security":

--- a/main.go
+++ b/main.go
@@ -151,7 +151,7 @@ func watchForConfigChanges(app *tview.Application, configFilePath string, grid *
 				loadConfigFile(absPath)
 
 				widgets := makeWidgets(app, pages)
-				validateWidgets(widgets)
+				wtf.ValidateWidgets(widgets)
 
 				initializeFocusTracker(app, widgets)
 
@@ -342,15 +342,15 @@ func makeWidgets(app *tview.Application, pages *tview.Pages) []wtf.Wtfable {
 	return widgets
 }
 
-// Check that all the loaded widgets are valid for display
-func validateWidgets(widgets []wtf.Wtfable) {
-	for _, widget := range widgets {
-		if widget.Enabled() && !widget.IsPositionable() {
-			errStr := fmt.Sprintf("Widget config has invalid values: %s", widget.Key())
-			log.Fatalln(errStr)
-		}
-	}
-}
+// // Check that all the loaded widgets are valid for display
+// func validateWidgets(widgets []wtf.Wtfable) {
+// 	for _, widget := range widgets {
+// 		if widget.Enabled() && !widget.IsPositionable() {
+// 			errStr := fmt.Sprintf("Widget config has invalid values: %s", widget.Key())
+// 			log.Fatalln(errStr)
+// 		}
+// 	}
+// }
 
 /* -------------------- Main -------------------- */
 
@@ -376,7 +376,7 @@ func main() {
 	pages := tview.NewPages()
 
 	widgets := makeWidgets(app, pages)
-	validateWidgets(widgets)
+	wtf.ValidateWidgets(widgets)
 
 	initializeFocusTracker(app, widgets)
 

--- a/main.go
+++ b/main.go
@@ -208,7 +208,8 @@ func makeWidget(app *tview.Application, pages *tview.Pages, widgetName string) w
 		cfg := datadog.NewSettingsFromYAML(wtf.Config)
 		widget = datadog.NewWidget(app, cfg)
 	case "gcal":
-		widget = gcal.NewWidget(app)
+		cfg := gcal.NewSettingsFromYAML(wtf.Config)
+		widget = gcal.NewWidget(app, cfg)
 	case "gerrit":
 		widget = gerrit.NewWidget(app, pages)
 	case "git":

--- a/main.go
+++ b/main.go
@@ -241,7 +241,8 @@ func makeWidget(app *tview.Application, pages *tview.Pages, widgetName string) w
 		settings := jenkins.NewSettingsFromYAML(wtf.Config)
 		widget = jenkins.NewWidget(app, pages, settings)
 	case "jira":
-		widget = jira.NewWidget(app, pages)
+		settings := jira.NewSettingsFromYAML(wtf.Config)
+		widget = jira.NewWidget(app, pages, settings)
 	case "logger":
 		widget = logger.NewWidget(app)
 	case "mercurial":

--- a/main.go
+++ b/main.go
@@ -259,7 +259,8 @@ func makeWidget(app *tview.Application, pages *tview.Pages, widgetName string) w
 		settings := opsgenie.NewSettingsFromYAML(wtf.Config)
 		widget = opsgenie.NewWidget(app, settings)
 	case "pagerduty":
-		widget = pagerduty.NewWidget(app)
+		settings := pagerduty.NewSettingsFromYAML(wtf.Config)
+		widget = pagerduty.NewWidget(app, settings)
 	case "power":
 		settings := power.NewSettingsFromYAML(wtf.Config)
 		widget = power.NewWidget(app, settings)

--- a/main.go
+++ b/main.go
@@ -199,7 +199,8 @@ func makeWidget(app *tview.Application, pages *tview.Pages, widgetName string) w
 		cfg := clocks.NewSettingsFromYAML(wtf.Config)
 		widget = clocks.NewWidget(app, cfg)
 	case "cmdrunner":
-		widget = cmdrunner.NewWidget(app)
+		cfg := cmdrunner.NewSettingsFromYAML(wtf.Config)
+		widget = cmdrunner.NewWidget(app, cfg)
 	case "cryptolive":
 		widget = cryptolive.NewWidget(app)
 	case "datadog":

--- a/main.go
+++ b/main.go
@@ -202,7 +202,8 @@ func makeWidget(app *tview.Application, pages *tview.Pages, widgetName string) w
 		cfg := cmdrunner.NewSettingsFromYAML(wtf.Config)
 		widget = cmdrunner.NewWidget(app, cfg)
 	case "cryptolive":
-		widget = cryptolive.NewWidget(app)
+		cfg := cryptolive.NewSettingsFromYAML(wtf.Config)
+		widget = cryptolive.NewWidget(app, cfg)
 	case "datadog":
 		widget = datadog.NewWidget(app)
 	case "gcal":

--- a/main.go
+++ b/main.go
@@ -238,7 +238,8 @@ func makeWidget(app *tview.Application, pages *tview.Pages, widgetName string) w
 		settings := ipinfo.NewSettingsFromYAML(wtf.Config)
 		widget = ipinfo.NewWidget(app, settings)
 	case "jenkins":
-		widget = jenkins.NewWidget(app, pages)
+		settings := jenkins.NewSettingsFromYAML(wtf.Config)
+		widget = jenkins.NewWidget(app, pages, settings)
 	case "jira":
 		widget = jira.NewWidget(app, pages)
 	case "logger":

--- a/main.go
+++ b/main.go
@@ -283,7 +283,8 @@ func makeWidget(app *tview.Application, pages *tview.Pages, widgetName string) w
 		settings := spotifyweb.NewSettingsFromYAML(wtf.Config)
 		widget = spotifyweb.NewWidget(app, pages, settings)
 	case "status":
-		widget = status.NewWidget(app)
+		settings := status.NewSettingsFromYAML(wtf.Config)
+		widget = status.NewWidget(app, settings)
 	case "system":
 		widget = system.NewWidget(app, date, version)
 	case "textfile":

--- a/main.go
+++ b/main.go
@@ -270,8 +270,11 @@ func makeWidget(app *tview.Application, pages *tview.Pages, widgetName string) w
 	case "resourceusage":
 		settings := resourceusage.NewSettingsFromYAML(wtf.Config)
 		widget = resourceusage.NewWidget(app, settings)
+	case "rollbar":
+		widget = rollbar.NewWidget(app, pages)
 	case "security":
-		widget = security.NewWidget(app)
+		settings := security.NewSettingsFromYAML(wtf.Config)
+		widget = security.NewWidget(app, settings)
 	case "status":
 		widget = status.NewWidget(app)
 	case "system":
@@ -289,8 +292,6 @@ func makeWidget(app *tview.Application, pages *tview.Pages, widgetName string) w
 		widget = todoist.NewWidget(app, pages)
 	case "travisci":
 		widget = travisci.NewWidget(app, pages)
-	case "rollbar":
-		widget = rollbar.NewWidget(app, pages)
 	case "trello":
 		widget = trello.NewWidget(app)
 	case "twitter":

--- a/main.go
+++ b/main.go
@@ -280,7 +280,8 @@ func makeWidget(app *tview.Application, pages *tview.Pages, widgetName string) w
 		settings := spotify.NewSettingsFromYAML(wtf.Config)
 		widget = spotify.NewWidget(app, pages, settings)
 	case "spotifyweb":
-		widget = spotifyweb.NewWidget(app, pages)
+		settings := spotifyweb.NewSettingsFromYAML(wtf.Config)
+		widget = spotifyweb.NewWidget(app, pages, settings)
 	case "status":
 		widget = status.NewWidget(app)
 	case "system":

--- a/main.go
+++ b/main.go
@@ -247,7 +247,8 @@ func makeWidget(app *tview.Application, pages *tview.Pages, widgetName string) w
 		settings := logger.NewSettingsFromYAML(wtf.Config)
 		widget = logger.NewWidget(app, settings)
 	case "mercurial":
-		widget = mercurial.NewWidget(app, pages)
+		settings := mercurial.NewSettingsFromYAML(wtf.Config)
+		widget = mercurial.NewWidget(app, pages, settings)
 	case "nbascore":
 		widget = nbascore.NewWidget(app, pages)
 	case "newrelic":

--- a/main.go
+++ b/main.go
@@ -310,7 +310,8 @@ func makeWidget(app *tview.Application, pages *tview.Pages, widgetName string) w
 		settings := victorops.NewSettingsFromYAML(wtf.Config)
 		widget = victorops.NewWidget(app, settings)
 	case "weather":
-		widget = weather.NewWidget(app, pages)
+		settings := weather.NewSettingsFromYAML(wtf.Config)
+		widget = weather.NewWidget(app, pages, settings)
 	case "zendesk":
 		widget = zendesk.NewWidget(app)
 	default:

--- a/main.go
+++ b/main.go
@@ -254,7 +254,8 @@ func makeWidget(app *tview.Application, pages *tview.Pages, widgetName string) w
 	case "textfile":
 		widget = textfile.NewWidget(app, pages)
 	case "todo":
-		widget = todo.NewWidget(app, pages)
+		cfg := todo.NewSettingsFromYAML(wtf.Config)
+		widget = todo.NewWidget(app, pages, cfg)
 	case "todoist":
 		widget = todoist.NewWidget(app, pages)
 	case "travisci":

--- a/main.go
+++ b/main.go
@@ -286,7 +286,8 @@ func makeWidget(app *tview.Application, pages *tview.Pages, widgetName string) w
 		settings := status.NewSettingsFromYAML(wtf.Config)
 		widget = status.NewWidget(app, settings)
 	case "system":
-		widget = system.NewWidget(app, date, version)
+		settings := system.NewSettingsFromYAML(wtf.Config)
+		widget = system.NewWidget(app, date, version, settings)
 	case "textfile":
 		widget = textfile.NewWidget(app, pages)
 	case "todo":

--- a/main.go
+++ b/main.go
@@ -268,7 +268,8 @@ func makeWidget(app *tview.Application, pages *tview.Pages, widgetName string) w
 		settings := prettyweather.NewSettingsFromYAML(wtf.Config)
 		widget = prettyweather.NewWidget(app, settings)
 	case "resourceusage":
-		widget = resourceusage.NewWidget(app)
+		settings := resourceusage.NewSettingsFromYAML(wtf.Config)
+		widget = resourceusage.NewWidget(app, settings)
 	case "security":
 		widget = security.NewWidget(app)
 	case "status":

--- a/main.go
+++ b/main.go
@@ -232,7 +232,8 @@ func makeWidget(app *tview.Application, pages *tview.Pages, widgetName string) w
 		settings := hackernews.NewSettingsFromYAML(wtf.Config)
 		widget = hackernews.NewWidget(app, pages, settings)
 	case "ipapi":
-		widget = ipapi.NewWidget(app)
+		settings := ipapi.NewSettingsFromYAML(wtf.Config)
+		widget = ipapi.NewWidget(app, settings)
 	case "ipinfo":
 		widget = ipinfo.NewWidget(app)
 	case "jenkins":

--- a/main.go
+++ b/main.go
@@ -235,7 +235,8 @@ func makeWidget(app *tview.Application, pages *tview.Pages, widgetName string) w
 		settings := ipapi.NewSettingsFromYAML(wtf.Config)
 		widget = ipapi.NewWidget(app, settings)
 	case "ipinfo":
-		widget = ipinfo.NewWidget(app)
+		settings := ipinfo.NewSettingsFromYAML(wtf.Config)
+		widget = ipinfo.NewWidget(app, settings)
 	case "jenkins":
 		widget = jenkins.NewWidget(app, pages)
 	case "jira":

--- a/main.go
+++ b/main.go
@@ -229,7 +229,8 @@ func makeWidget(app *tview.Application, pages *tview.Pages, widgetName string) w
 		settings := gspreadsheets.NewSettingsFromYAML(wtf.Config)
 		widget = gspreadsheets.NewWidget(app, settings)
 	case "hackernews":
-		widget = hackernews.NewWidget(app, pages)
+		settings := hackernews.NewSettingsFromYAML(wtf.Config)
+		widget = hackernews.NewWidget(app, pages, settings)
 	case "ipapi":
 		widget = ipapi.NewWidget(app)
 	case "ipinfo":

--- a/main.go
+++ b/main.go
@@ -190,7 +190,8 @@ func makeWidget(app *tview.Application, pages *tview.Pages, widgetName string) w
 		cfg := bittrex.NewSettingsFromYAML(wtf.Config)
 		widget = bittrex.NewWidget(app, cfg)
 	case "blockfolio":
-		widget = blockfolio.NewWidget(app)
+		cfg := blockfolio.NewSettingsFromYAML(wtf.Config)
+		widget = blockfolio.NewWidget(app, cfg)
 	case "circleci":
 		cfg := circleci.NewSettingsFromYAML(wtf.Config)
 		widget = circleci.NewWidget(app, cfg)

--- a/main.go
+++ b/main.go
@@ -226,7 +226,8 @@ func makeWidget(app *tview.Application, pages *tview.Pages, widgetName string) w
 		settings := gitter.NewSettingsFromYAML(wtf.Config)
 		widget = gitter.NewWidget(app, pages, settings)
 	case "gspreadsheets":
-		widget = gspreadsheets.NewWidget(app)
+		settings := gspreadsheets.NewSettingsFromYAML(wtf.Config)
+		widget = gspreadsheets.NewWidget(app, settings)
 	case "hackernews":
 		widget = hackernews.NewWidget(app, pages)
 	case "ipapi":

--- a/main.go
+++ b/main.go
@@ -276,14 +276,15 @@ func makeWidget(app *tview.Application, pages *tview.Pages, widgetName string) w
 	case "security":
 		settings := security.NewSettingsFromYAML(wtf.Config)
 		widget = security.NewWidget(app, settings)
+	case "spotify":
+		settings := spotify.NewSettingsFromYAML(wtf.Config)
+		widget = spotify.NewWidget(app, pages, settings)
+	case "spotifyweb":
+		widget = spotifyweb.NewWidget(app, pages)
 	case "status":
 		widget = status.NewWidget(app)
 	case "system":
 		widget = system.NewWidget(app, date, version)
-	case "spotify":
-		widget = spotify.NewWidget(app, pages)
-	case "spotifyweb":
-		widget = spotifyweb.NewWidget(app, pages)
 	case "textfile":
 		widget = textfile.NewWidget(app, pages)
 	case "todo":

--- a/main.go
+++ b/main.go
@@ -187,7 +187,8 @@ func makeWidget(app *tview.Application, pages *tview.Pages, widgetName string) w
 	case "bargraph":
 		widget = bargraph.NewWidget(app)
 	case "bittrex":
-		widget = bittrex.NewWidget(app)
+		cfg := bittrex.NewSettingsFromYAML(wtf.Config)
+		widget = bittrex.NewWidget(app, cfg)
 	case "blockfolio":
 		widget = blockfolio.NewWidget(app)
 	case "circleci":

--- a/main.go
+++ b/main.go
@@ -244,7 +244,8 @@ func makeWidget(app *tview.Application, pages *tview.Pages, widgetName string) w
 		settings := jira.NewSettingsFromYAML(wtf.Config)
 		widget = jira.NewWidget(app, pages, settings)
 	case "logger":
-		widget = logger.NewWidget(app)
+		settings := logger.NewSettingsFromYAML(wtf.Config)
+		widget = logger.NewWidget(app, settings)
 	case "mercurial":
 		widget = mercurial.NewWidget(app, pages)
 	case "nbascore":

--- a/main.go
+++ b/main.go
@@ -292,10 +292,11 @@ func makeWidget(app *tview.Application, pages *tview.Pages, widgetName string) w
 		settings := textfile.NewSettingsFromYAML(wtf.Config)
 		widget = textfile.NewWidget(app, pages, settings)
 	case "todo":
-		cfg := todo.NewSettingsFromYAML(wtf.Config)
-		widget = todo.NewWidget(app, pages, cfg)
+		settings := todo.NewSettingsFromYAML(wtf.Config)
+		widget = todo.NewWidget(app, pages, settings)
 	case "todoist":
-		widget = todoist.NewWidget(app, pages)
+		settings := todoist.NewSettingsFromYAML(wtf.Config)
+		widget = todoist.NewWidget(app, pages, settings)
 	case "travisci":
 		widget = travisci.NewWidget(app, pages)
 	case "trello":

--- a/main.go
+++ b/main.go
@@ -205,7 +205,8 @@ func makeWidget(app *tview.Application, pages *tview.Pages, widgetName string) w
 		cfg := cryptolive.NewSettingsFromYAML(wtf.Config)
 		widget = cryptolive.NewWidget(app, cfg)
 	case "datadog":
-		widget = datadog.NewWidget(app)
+		cfg := datadog.NewSettingsFromYAML(wtf.Config)
+		widget = datadog.NewWidget(app, cfg)
 	case "gcal":
 		widget = gcal.NewWidget(app)
 	case "gerrit":

--- a/main.go
+++ b/main.go
@@ -256,7 +256,8 @@ func makeWidget(app *tview.Application, pages *tview.Pages, widgetName string) w
 		settings := newrelic.NewSettingsFromYAML(wtf.Config)
 		widget = newrelic.NewWidget(app, settings)
 	case "opsgenie":
-		widget = opsgenie.NewWidget(app)
+		settings := opsgenie.NewSettingsFromYAML(wtf.Config)
+		widget = opsgenie.NewWidget(app, settings)
 	case "pagerduty":
 		widget = pagerduty.NewWidget(app)
 	case "power":

--- a/main.go
+++ b/main.go
@@ -271,7 +271,8 @@ func makeWidget(app *tview.Application, pages *tview.Pages, widgetName string) w
 		settings := resourceusage.NewSettingsFromYAML(wtf.Config)
 		widget = resourceusage.NewWidget(app, settings)
 	case "rollbar":
-		widget = rollbar.NewWidget(app, pages)
+		settings := rollbar.NewSettingsFromYAML(wtf.Config)
+		widget = rollbar.NewWidget(app, pages, settings)
 	case "security":
 		settings := security.NewSettingsFromYAML(wtf.Config)
 		widget = security.NewWidget(app, settings)

--- a/main.go
+++ b/main.go
@@ -182,42 +182,43 @@ func makeWidget(app *tview.Application, pages *tview.Pages, widgetName string) w
 	// Always in alphabetical order
 	switch widgetName {
 	case "bamboohr":
-		cfg := bamboohr.NewSettingsFromYAML(wtf.Config)
-		widget = bamboohr.NewWidget(app, cfg)
+		settings := bamboohr.NewSettingsFromYAML(wtf.Config)
+		widget = bamboohr.NewWidget(app, settings)
 	case "bargraph":
 		widget = bargraph.NewWidget(app)
 	case "bittrex":
-		cfg := bittrex.NewSettingsFromYAML(wtf.Config)
-		widget = bittrex.NewWidget(app, cfg)
+		settings := bittrex.NewSettingsFromYAML(wtf.Config)
+		widget = bittrex.NewWidget(app, settings)
 	case "blockfolio":
-		cfg := blockfolio.NewSettingsFromYAML(wtf.Config)
-		widget = blockfolio.NewWidget(app, cfg)
+		settings := blockfolio.NewSettingsFromYAML(wtf.Config)
+		widget = blockfolio.NewWidget(app, settings)
 	case "circleci":
-		cfg := circleci.NewSettingsFromYAML(wtf.Config)
-		widget = circleci.NewWidget(app, cfg)
+		settings := circleci.NewSettingsFromYAML(wtf.Config)
+		widget = circleci.NewWidget(app, settings)
 	case "clocks":
-		cfg := clocks.NewSettingsFromYAML(wtf.Config)
-		widget = clocks.NewWidget(app, cfg)
+		settings := clocks.NewSettingsFromYAML(wtf.Config)
+		widget = clocks.NewWidget(app, settings)
 	case "cmdrunner":
-		cfg := cmdrunner.NewSettingsFromYAML(wtf.Config)
-		widget = cmdrunner.NewWidget(app, cfg)
+		settings := cmdrunner.NewSettingsFromYAML(wtf.Config)
+		widget = cmdrunner.NewWidget(app, settings)
 	case "cryptolive":
-		cfg := cryptolive.NewSettingsFromYAML(wtf.Config)
-		widget = cryptolive.NewWidget(app, cfg)
+		settings := cryptolive.NewSettingsFromYAML(wtf.Config)
+		widget = cryptolive.NewWidget(app, settings)
 	case "datadog":
-		cfg := datadog.NewSettingsFromYAML(wtf.Config)
-		widget = datadog.NewWidget(app, cfg)
+		settings := datadog.NewSettingsFromYAML(wtf.Config)
+		widget = datadog.NewWidget(app, settings)
 	case "gcal":
-		cfg := gcal.NewSettingsFromYAML(wtf.Config)
-		widget = gcal.NewWidget(app, cfg)
+		settings := gcal.NewSettingsFromYAML(wtf.Config)
+		widget = gcal.NewWidget(app, settings)
 	case "gerrit":
-		cfg := gerrit.NewSettingsFromYAML(wtf.Config)
-		widget = gerrit.NewWidget(app, pages, cfg)
+		settings := gerrit.NewSettingsFromYAML(wtf.Config)
+		widget = gerrit.NewWidget(app, pages, settings)
 	case "git":
-		cfg := git.NewSettingsFromYAML(wtf.Config)
-		widget = git.NewWidget(app, pages, cfg)
+		settings := git.NewSettingsFromYAML(wtf.Config)
+		widget = git.NewWidget(app, pages, settings)
 	case "github":
-		widget = github.NewWidget(app, pages)
+		settings := github.NewSettingsFromYAML(wtf.Config)
+		widget = github.NewWidget(app, pages, settings)
 	case "gitlab":
 		widget = gitlab.NewWidget(app, pages)
 	case "gitter":

--- a/main.go
+++ b/main.go
@@ -313,7 +313,8 @@ func makeWidget(app *tview.Application, pages *tview.Pages, widgetName string) w
 		settings := weather.NewSettingsFromYAML(wtf.Config)
 		widget = weather.NewWidget(app, pages, settings)
 	case "zendesk":
-		widget = zendesk.NewWidget(app)
+		settings := zendesk.NewSettingsFromYAML(wtf.Config)
+		widget = zendesk.NewWidget(app, settings)
 	default:
 		widget = unknown.NewWidget(app, widgetName)
 	}

--- a/main.go
+++ b/main.go
@@ -253,7 +253,8 @@ func makeWidget(app *tview.Application, pages *tview.Pages, widgetName string) w
 		settings := nbascore.NewSettingsFromYAML(wtf.Config)
 		widget = nbascore.NewWidget(app, pages, settings)
 	case "newrelic":
-		widget = newrelic.NewWidget(app)
+		settings := newrelic.NewSettingsFromYAML(wtf.Config)
+		widget = newrelic.NewWidget(app, settings)
 	case "opsgenie":
 		widget = opsgenie.NewWidget(app)
 	case "pagerduty":

--- a/main.go
+++ b/main.go
@@ -196,7 +196,8 @@ func makeWidget(app *tview.Application, pages *tview.Pages, widgetName string) w
 		cfg := circleci.NewSettingsFromYAML(wtf.Config)
 		widget = circleci.NewWidget(app, cfg)
 	case "clocks":
-		widget = clocks.NewWidget(app)
+		cfg := clocks.NewSettingsFromYAML(wtf.Config)
+		widget = clocks.NewWidget(app, cfg)
 	case "cmdrunner":
 		widget = cmdrunner.NewWidget(app)
 	case "cryptolive":

--- a/main.go
+++ b/main.go
@@ -211,7 +211,8 @@ func makeWidget(app *tview.Application, pages *tview.Pages, widgetName string) w
 		cfg := gcal.NewSettingsFromYAML(wtf.Config)
 		widget = gcal.NewWidget(app, cfg)
 	case "gerrit":
-		widget = gerrit.NewWidget(app, pages)
+		cfg := gerrit.NewSettingsFromYAML(wtf.Config)
+		widget = gerrit.NewWidget(app, pages, cfg)
 	case "git":
 		widget = git.NewWidget(app, pages)
 	case "github":

--- a/main.go
+++ b/main.go
@@ -316,7 +316,8 @@ func makeWidget(app *tview.Application, pages *tview.Pages, widgetName string) w
 		settings := zendesk.NewSettingsFromYAML(wtf.Config)
 		widget = zendesk.NewWidget(app, settings)
 	default:
-		widget = unknown.NewWidget(app, widgetName)
+		settings := unknown.NewSettingsFromYAML(wtf.Config)
+		widget = unknown.NewWidget(app, widgetName, settings)
 	}
 
 	return widget

--- a/main.go
+++ b/main.go
@@ -214,7 +214,8 @@ func makeWidget(app *tview.Application, pages *tview.Pages, widgetName string) w
 		cfg := gerrit.NewSettingsFromYAML(wtf.Config)
 		widget = gerrit.NewWidget(app, pages, cfg)
 	case "git":
-		widget = git.NewWidget(app, pages)
+		cfg := git.NewSettingsFromYAML(wtf.Config)
+		widget = git.NewWidget(app, pages, cfg)
 	case "github":
 		widget = github.NewWidget(app, pages)
 	case "gitlab":

--- a/main.go
+++ b/main.go
@@ -304,7 +304,8 @@ func makeWidget(app *tview.Application, pages *tview.Pages, widgetName string) w
 		settings := trello.NewSettingsFromYAML(wtf.Config)
 		widget = trello.NewWidget(app, settings)
 	case "twitter":
-		widget = twitter.NewWidget(app, pages)
+		settings := twitter.NewSettingsFromYAML(wtf.Config)
+		widget = twitter.NewWidget(app, pages, settings)
 	case "victorops":
 		widget = victorops.NewWidget(app)
 	case "weather":

--- a/main.go
+++ b/main.go
@@ -182,7 +182,8 @@ func makeWidget(app *tview.Application, pages *tview.Pages, widgetName string) w
 	// Always in alphabetical order
 	switch widgetName {
 	case "bamboohr":
-		widget = bamboohr.NewWidget(app)
+		cfg := bamboohr.NewSettingsFromYAML(wtf.Config)
+		widget = bamboohr.NewWidget(app, cfg)
 	case "bargraph":
 		widget = bargraph.NewWidget(app)
 	case "bittrex":

--- a/main.go
+++ b/main.go
@@ -289,7 +289,8 @@ func makeWidget(app *tview.Application, pages *tview.Pages, widgetName string) w
 		settings := system.NewSettingsFromYAML(wtf.Config)
 		widget = system.NewWidget(app, date, version, settings)
 	case "textfile":
-		widget = textfile.NewWidget(app, pages)
+		settings := textfile.NewSettingsFromYAML(wtf.Config)
+		widget = textfile.NewWidget(app, pages, settings)
 	case "todo":
 		cfg := todo.NewSettingsFromYAML(wtf.Config)
 		widget = todo.NewWidget(app, pages, cfg)

--- a/main.go
+++ b/main.go
@@ -307,7 +307,8 @@ func makeWidget(app *tview.Application, pages *tview.Pages, widgetName string) w
 		settings := twitter.NewSettingsFromYAML(wtf.Config)
 		widget = twitter.NewWidget(app, pages, settings)
 	case "victorops":
-		widget = victorops.NewWidget(app)
+		settings := victorops.NewSettingsFromYAML(wtf.Config)
+		widget = victorops.NewWidget(app, settings)
 	case "weather":
 		widget = weather.NewWidget(app, pages)
 	case "zendesk":

--- a/main.go
+++ b/main.go
@@ -191,7 +191,8 @@ func makeWidget(app *tview.Application, pages *tview.Pages, widgetName string) w
 	case "blockfolio":
 		widget = blockfolio.NewWidget(app)
 	case "circleci":
-		widget = circleci.NewWidget(app)
+		cfg := circleci.NewSettingsFromYAML(wtf.Config)
+		widget = circleci.NewWidget(app, cfg)
 	case "clocks":
 		widget = clocks.NewWidget(app)
 	case "cmdrunner":

--- a/main.go
+++ b/main.go
@@ -223,7 +223,8 @@ func makeWidget(app *tview.Application, pages *tview.Pages, widgetName string) w
 		settings := gitlab.NewSettingsFromYAML(wtf.Config)
 		widget = gitlab.NewWidget(app, pages, settings)
 	case "gitter":
-		widget = gitter.NewWidget(app, pages)
+		settings := gitter.NewSettingsFromYAML(wtf.Config)
+		widget = gitter.NewWidget(app, pages, settings)
 	case "gspreadsheets":
 		widget = gspreadsheets.NewWidget(app)
 	case "hackernews":

--- a/main.go
+++ b/main.go
@@ -250,7 +250,8 @@ func makeWidget(app *tview.Application, pages *tview.Pages, widgetName string) w
 		settings := mercurial.NewSettingsFromYAML(wtf.Config)
 		widget = mercurial.NewWidget(app, pages, settings)
 	case "nbascore":
-		widget = nbascore.NewWidget(app, pages)
+		settings := nbascore.NewSettingsFromYAML(wtf.Config)
+		widget = nbascore.NewWidget(app, pages, settings)
 	case "newrelic":
 		widget = newrelic.NewWidget(app)
 	case "opsgenie":

--- a/modules/bamboohr/settings.go
+++ b/modules/bamboohr/settings.go
@@ -1,0 +1,27 @@
+package bamboohr
+
+import (
+	"os"
+
+	"github.com/olebedev/config"
+	"github.com/wtfutil/wtf/cfg"
+)
+
+type Settings struct {
+	Common *cfg.Common
+
+	APIKey    string
+	Subdomain string
+}
+
+func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
+	localConfig, _ := ymlConfig.Get("wtf.mods.bamboohr")
+
+	settings := Settings{
+		Common:    cfg.NewCommonSettingsFromYAML(ymlConfig),
+		APIKey:    localConfig.UString("apiKey", os.Getenv("WTF_BAMBOO_HR_TOKEN")),
+		Subdomain: localConfig.UString("subdomain", os.Getenv("WTF_BAMBOO_HR_SUBDOMAIN")),
+	}
+
+	return &settings
+}

--- a/modules/bamboohr/settings.go
+++ b/modules/bamboohr/settings.go
@@ -7,20 +7,23 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-type Settings struct {
-	Common *cfg.Common
+const configKey = "bamboohr"
 
-	APIKey    string
-	Subdomain string
+type Settings struct {
+	common *cfg.Common
+
+	apiKey    string
+	subdomain string
 }
 
-func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
-	localConfig, _ := ymlConfig.Get("wtf.mods.bamboohr")
+func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
+	localConfig, _ := ymlConfig.Get("wtf.mods." + configKey)
 
 	settings := Settings{
-		Common:    cfg.NewCommonSettingsFromYAML(ymlConfig),
-		APIKey:    localConfig.UString("apiKey", os.Getenv("WTF_BAMBOO_HR_TOKEN")),
-		Subdomain: localConfig.UString("subdomain", os.Getenv("WTF_BAMBOO_HR_SUBDOMAIN")),
+		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
+
+		apiKey:    localConfig.UString("apiKey", os.Getenv("WTF_BAMBOO_HR_TOKEN")),
+		subdomain: localConfig.UString("subdomain", os.Getenv("WTF_BAMBOO_HR_SUBDOMAIN")),
 	}
 
 	return &settings

--- a/modules/bamboohr/widget.go
+++ b/modules/bamboohr/widget.go
@@ -17,7 +17,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, "BambooHR", "bamboohr", false),
+		TextWidget: wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, false),
 
 		settings: settings,
 	}
@@ -30,8 +30,8 @@ func NewWidget(app *tview.Application, settings *Settings) *Widget {
 func (widget *Widget) Refresh() {
 	client := NewClient(
 		APIURI,
-		widget.settings.APIKey,
-		widget.settings.Subdomain,
+		widget.settings.apiKey,
+		widget.settings.subdomain,
 	)
 
 	todayItems := client.Away(

--- a/modules/bamboohr/widget.go
+++ b/modules/bamboohr/widget.go
@@ -2,7 +2,6 @@ package bamboohr
 
 import (
 	"fmt"
-	// "os"
 
 	"github.com/rivo/tview"
 	"github.com/wtfutil/wtf/wtf"

--- a/modules/bamboohr/widget.go
+++ b/modules/bamboohr/widget.go
@@ -2,19 +2,25 @@ package bamboohr
 
 import (
 	"fmt"
-	"os"
+	// "os"
 
 	"github.com/rivo/tview"
 	"github.com/wtfutil/wtf/wtf"
 )
 
+const APIURI = "https://api.bamboohr.com/api/gateway.php"
+
 type Widget struct {
 	wtf.TextWidget
+
+	settings *Settings
 }
 
-func NewWidget(app *tview.Application) *Widget {
+func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
 		TextWidget: wtf.NewTextWidget(app, "BambooHR", "bamboohr", false),
+
+		settings: settings,
 	}
 
 	return &widget
@@ -23,17 +29,12 @@ func NewWidget(app *tview.Application) *Widget {
 /* -------------------- Exported Functions -------------------- */
 
 func (widget *Widget) Refresh() {
-	apiKey := wtf.Config.UString(
-		"wtf.mods.bamboohr.apiKey",
-		os.Getenv("WTF_BAMBOO_HR_TOKEN"),
+	client := NewClient(
+		APIURI,
+		widget.settings.APIKey,
+		widget.settings.Subdomain,
 	)
 
-	subdomain := wtf.Config.UString(
-		"wtf.mods.bamboohr.subdomain",
-		os.Getenv("WTF_BAMBOO_HR_SUBDOMAIN"),
-	)
-
-	client := NewClient("https://api.bamboohr.com/api/gateway.php", apiKey, subdomain)
 	todayItems := client.Away(
 		"timeOff",
 		wtf.Now().Format(wtf.DateFormat),

--- a/modules/bamboohr/widget.go
+++ b/modules/bamboohr/widget.go
@@ -17,7 +17,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, false),
+		TextWidget: wtf.NewTextWidget(app, settings.common, false),
 
 		settings: settings,
 	}

--- a/modules/circleci/settings.go
+++ b/modules/circleci/settings.go
@@ -7,17 +7,20 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
+const configKey = "circleci"
+
 type Settings struct {
-	Common *cfg.Common
+	common *cfg.Common
 
 	apiKey string
 }
 
-func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
-	localConfig, _ := ymlConfig.Get("wtf.mods.circleci")
+func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
+	localConfig, _ := ymlConfig.Get("wtf.mods." + configKey)
 
 	settings := Settings{
-		Common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
+
 		apiKey: localConfig.UString("apiKey", os.Getenv("WTF_CIRCLE_API_KEY")),
 	}
 

--- a/modules/circleci/settings.go
+++ b/modules/circleci/settings.go
@@ -1,0 +1,25 @@
+package circleci
+
+import (
+	"os"
+
+	"github.com/olebedev/config"
+	"github.com/wtfutil/wtf/cfg"
+)
+
+type Settings struct {
+	Common *cfg.Common
+
+	APIKey string
+}
+
+func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
+	localConfig, _ := ymlConfig.Get("wtf.mods.circleci")
+
+	settings := Settings{
+		Common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+		APIKey: localConfig.UString("apiKey", os.Getenv("WTF_CIRCLE_API_KEY")),
+	}
+
+	return &settings
+}

--- a/modules/circleci/widget.go
+++ b/modules/circleci/widget.go
@@ -2,7 +2,7 @@ package circleci
 
 import (
 	"fmt"
-	"os"
+	// "os"
 
 	"github.com/rivo/tview"
 	"github.com/wtfutil/wtf/wtf"
@@ -11,19 +11,16 @@ import (
 type Widget struct {
 	wtf.TextWidget
 	*Client
+
+	settings *Settings
 }
 
-const apiEnvKey = "WTF_CIRCLE_API_KEY"
-
-func NewWidget(app *tview.Application) *Widget {
-	apiKey := wtf.Config.UString(
-		"wtf.mods.circleci.apiKey",
-		os.Getenv(apiEnvKey),
-	)
-
+func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
 		TextWidget: wtf.NewTextWidget(app, "CircleCI", "circleci", false),
-		Client:     NewClient(apiKey),
+		Client:     NewClient(settings.APIKey),
+
+		settings: settings,
 	}
 
 	return &widget

--- a/modules/circleci/widget.go
+++ b/modules/circleci/widget.go
@@ -2,7 +2,6 @@ package circleci
 
 import (
 	"fmt"
-	// "os"
 
 	"github.com/rivo/tview"
 	"github.com/wtfutil/wtf/wtf"

--- a/modules/circleci/widget.go
+++ b/modules/circleci/widget.go
@@ -16,7 +16,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, false),
+		TextWidget: wtf.NewTextWidget(app, settings.common, false),
 		Client:     NewClient(settings.apiKey),
 
 		settings: settings,

--- a/modules/circleci/widget.go
+++ b/modules/circleci/widget.go
@@ -17,7 +17,7 @@ type Widget struct {
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
 		TextWidget: wtf.NewTextWidget(app, "CircleCI", "circleci", false),
-		Client:     NewClient(settings.APIKey),
+		Client:     NewClient(settings.apiKey),
 
 		settings: settings,
 	}

--- a/modules/circleci/widget.go
+++ b/modules/circleci/widget.go
@@ -16,7 +16,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, "CircleCI", "circleci", false),
+		TextWidget: wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, false),
 		Client:     NewClient(settings.apiKey),
 
 		settings: settings,

--- a/modules/clocks/clock_collection.go
+++ b/modules/clocks/clock_collection.go
@@ -3,16 +3,14 @@ package clocks
 import (
 	"sort"
 	"time"
-
-	"github.com/wtfutil/wtf/wtf"
 )
 
 type ClockCollection struct {
 	Clocks []Clock
 }
 
-func (clocks *ClockCollection) Sorted() []Clock {
-	if "chronological" == wtf.Config.UString("wtf.mods.clocks.sort", "alphabetical") {
+func (clocks *ClockCollection) Sorted(sortOrder string) []Clock {
+	if sortOrder == "chronological" {
 		clocks.SortedChronologically()
 	} else {
 		clocks.SortedAlphabetically()

--- a/modules/clocks/display.go
+++ b/modules/clocks/display.go
@@ -2,8 +2,6 @@ package clocks
 
 import (
 	"fmt"
-
-	"github.com/wtfutil/wtf/wtf"
 )
 
 func (widget *Widget) display(clocks []Clock, dateFormat string, timeFormat string) {
@@ -14,9 +12,15 @@ func (widget *Widget) display(clocks []Clock, dateFormat string, timeFormat stri
 
 	str := ""
 	for idx, clock := range clocks {
+		rowColor := widget.settings.colors.rows.odd
+
+		if idx%2 == 0 {
+			rowColor = widget.settings.colors.rows.even
+		}
+
 		str = str + fmt.Sprintf(
 			" [%s]%-12s %-10s %7s[white]\n",
-			wtf.RowColor("clocks", idx),
+			rowColor,
 			clock.Label,
 			clock.Time(timeFormat),
 			clock.Date(dateFormat),

--- a/modules/clocks/setting.go
+++ b/modules/clocks/setting.go
@@ -1,0 +1,42 @@
+package clocks
+
+import (
+	"github.com/olebedev/config"
+	"github.com/wtfutil/wtf/cfg"
+	"github.com/wtfutil/wtf/wtf"
+)
+
+type colors struct {
+	rows struct {
+		even string
+		odd  string
+	}
+}
+
+type Settings struct {
+	colors
+	common *cfg.Common
+
+	dateFormat string
+	timeFormat string
+	locations  map[string]interface{}
+	sort       string
+}
+
+func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
+	localConfig, _ := ymlConfig.Get("wtf.mods.clocks")
+
+	settings := Settings{
+		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+
+		dateFormat: localConfig.UString("dateFormat", wtf.SimpleDateFormat),
+		timeFormat: localConfig.UString("timeFormat", wtf.SimpleTimeFormat),
+		locations:  localConfig.UMap("locations"),
+		sort:       localConfig.UString("sort"),
+	}
+
+	settings.colors.rows.even = localConfig.UString("colors.rows.even", "white")
+	settings.colors.rows.odd = localConfig.UString("colors.rows.odd", "blue")
+
+	return &settings
+}

--- a/modules/clocks/setting.go
+++ b/modules/clocks/setting.go
@@ -6,6 +6,8 @@ import (
 	"github.com/wtfutil/wtf/wtf"
 )
 
+const configKey = "clocks"
+
 type colors struct {
 	rows struct {
 		even string
@@ -23,11 +25,11 @@ type Settings struct {
 	sort       string
 }
 
-func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
-	localConfig, _ := ymlConfig.Get("wtf.mods.clocks")
+func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
+	localConfig, _ := ymlConfig.Get("wtf.mods." + configKey)
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
 
 		dateFormat: localConfig.UString("dateFormat", wtf.SimpleDateFormat),
 		timeFormat: localConfig.UString("timeFormat", wtf.SimpleTimeFormat),

--- a/modules/clocks/widget.go
+++ b/modules/clocks/widget.go
@@ -14,17 +14,19 @@ type Widget struct {
 	clockColl  ClockCollection
 	dateFormat string
 	timeFormat string
+	settings   *Settings
 }
 
-func NewWidget(app *tview.Application) *Widget {
+func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
 		TextWidget: wtf.NewTextWidget(app, "World Clocks", "clocks", false),
+
+		settings:   settings,
+		dateFormat: settings.dateFormat,
+		timeFormat: settings.timeFormat,
 	}
 
-	widget.clockColl = widget.buildClockCollection(wtf.Config.UMap("wtf.mods.clocks.locations"))
-
-	widget.dateFormat = wtf.Config.UString("wtf.mods.clocks.dateFormat", wtf.SimpleDateFormat)
-	widget.timeFormat = wtf.Config.UString("wtf.mods.clocks.timeFormat", wtf.SimpleTimeFormat)
+	widget.clockColl = widget.buildClockCollection(settings.locations)
 
 	return &widget
 }

--- a/modules/clocks/widget.go
+++ b/modules/clocks/widget.go
@@ -19,7 +19,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, false),
+		TextWidget: wtf.NewTextWidget(app, settings.common, false),
 
 		settings:   settings,
 		dateFormat: settings.dateFormat,

--- a/modules/clocks/widget.go
+++ b/modules/clocks/widget.go
@@ -34,7 +34,7 @@ func NewWidget(app *tview.Application, settings *Settings) *Widget {
 /* -------------------- Exported Functions -------------------- */
 
 func (widget *Widget) Refresh() {
-	widget.display(widget.clockColl.Sorted(), widget.dateFormat, widget.timeFormat)
+	widget.display(widget.clockColl.Sorted(widget.settings.sort), widget.dateFormat, widget.timeFormat)
 }
 
 /* -------------------- Unexported Functions -------------------- */

--- a/modules/clocks/widget.go
+++ b/modules/clocks/widget.go
@@ -19,7 +19,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, "World Clocks", "clocks", false),
+		TextWidget: wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, false),
 
 		settings:   settings,
 		dateFormat: settings.dateFormat,

--- a/modules/cmdrunner/settings.go
+++ b/modules/cmdrunner/settings.go
@@ -6,6 +6,8 @@ import (
 	"github.com/wtfutil/wtf/wtf"
 )
 
+const configKey = "cmdrunner"
+
 type Settings struct {
 	common *cfg.Common
 
@@ -13,11 +15,11 @@ type Settings struct {
 	cmd  string
 }
 
-func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
-	localConfig, _ := ymlConfig.Get("wtf.mods.cmdrunner")
+func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
+	localConfig, _ := ymlConfig.Get("wtf.mods." + configKey)
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
 
 		args: wtf.ToStrs(localConfig.UList("args")),
 		cmd:  localConfig.UString("cmd"),

--- a/modules/cmdrunner/settings.go
+++ b/modules/cmdrunner/settings.go
@@ -19,7 +19,7 @@ func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
 	settings := Settings{
 		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
 
-		args: wtf.ToStrs(wtf.Config.UList("args")),
+		args: wtf.ToStrs(localConfig.UList("args")),
 		cmd:  localConfig.UString("cmd"),
 	}
 

--- a/modules/cmdrunner/settings.go
+++ b/modules/cmdrunner/settings.go
@@ -1,0 +1,27 @@
+package cmdrunner
+
+import (
+	"github.com/olebedev/config"
+	"github.com/wtfutil/wtf/cfg"
+	"github.com/wtfutil/wtf/wtf"
+)
+
+type Settings struct {
+	common *cfg.Common
+
+	args []string
+	cmd  string
+}
+
+func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
+	localConfig, _ := ymlConfig.Get("wtf.mods.cmdrunner")
+
+	settings := Settings{
+		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+
+		args: wtf.ToStrs(wtf.Config.UList("args")),
+		cmd:  localConfig.UString("cmd"),
+	}
+
+	return &settings
+}

--- a/modules/cmdrunner/widget.go
+++ b/modules/cmdrunner/widget.go
@@ -20,7 +20,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, false),
+		TextWidget: wtf.NewTextWidget(app, settings.common, false),
 
 		args:     settings.args,
 		cmd:      settings.cmd,

--- a/modules/cmdrunner/widget.go
+++ b/modules/cmdrunner/widget.go
@@ -12,17 +12,19 @@ import (
 type Widget struct {
 	wtf.TextWidget
 
-	args   []string
-	cmd    string
-	result string
+	args     []string
+	cmd      string
+	result   string
+	settings *Settings
 }
 
-func NewWidget(app *tview.Application) *Widget {
+func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
 		TextWidget: wtf.NewTextWidget(app, "CmdRunner", "cmdrunner", false),
 
-		args: wtf.ToStrs(wtf.Config.UList("wtf.mods.cmdrunner.args")),
-		cmd:  wtf.Config.UString("wtf.mods.cmdrunner.cmd"),
+		args:     settings.args,
+		cmd:      settings.cmd,
+		settings: settings,
 	}
 
 	widget.View.SetWrap(true)

--- a/modules/cmdrunner/widget.go
+++ b/modules/cmdrunner/widget.go
@@ -35,8 +35,12 @@ func NewWidget(app *tview.Application, settings *Settings) *Widget {
 func (widget *Widget) Refresh() {
 	widget.execute()
 
-	title := tview.TranslateANSI(wtf.Config.UString("wtf.mods.cmdrunner.title", widget.String()))
-	widget.View.SetTitle(title)
+	title := widget.settings.common.Title
+	if title == "" {
+		title = widget.String()
+	}
+
+	widget.View.SetTitle(tview.TranslateANSI(title))
 
 	widget.View.SetText(widget.result)
 }

--- a/modules/cmdrunner/widget.go
+++ b/modules/cmdrunner/widget.go
@@ -35,12 +35,8 @@ func NewWidget(app *tview.Application, settings *Settings) *Widget {
 func (widget *Widget) Refresh() {
 	widget.execute()
 
-	title := widget.settings.common.Title
-	if title == "" {
-		title = widget.String()
-	}
-
-	widget.View.SetTitle(tview.TranslateANSI(title))
+	widget.CommonSettings.Title = widget.String()
+	widget.View.SetTitle(tview.TranslateANSI(widget.CommonSettings.Title))
 
 	widget.View.SetText(widget.result)
 }

--- a/modules/cmdrunner/widget.go
+++ b/modules/cmdrunner/widget.go
@@ -20,7 +20,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, "CmdRunner", "cmdrunner", false),
+		TextWidget: wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, false),
 
 		args:     settings.args,
 		cmd:      settings.cmd,

--- a/modules/cryptoexchanges/bittrex/display.go
+++ b/modules/cryptoexchanges/bittrex/display.go
@@ -12,14 +12,21 @@ func (widget *Widget) display() {
 		return
 	}
 
-	widget.View.SetText(summaryText(&widget.summaryList, &widget.TextColors))
+	summaryText := widget.summaryText(&widget.summaryList)
+	widget.View.SetText(summaryText)
 }
 
-func summaryText(list *summaryList, colors *TextColors) string {
+func (widget *Widget) summaryText(list *summaryList) string {
 	str := ""
 
 	for _, baseCurrency := range list.items {
-		str += fmt.Sprintf(" [%s]%s[%s] (%s)\n\n", colors.base.displayName, baseCurrency.displayName, colors.base.name, baseCurrency.name)
+		str += fmt.Sprintf(
+			" [%s]%s[%s] (%s)\n\n",
+			widget.settings.colors.base.displayName,
+			baseCurrency.displayName,
+			widget.settings.colors.base.name,
+			baseCurrency.name,
+		)
 
 		resultTemplate := template.New("bittrex")
 
@@ -38,9 +45,9 @@ func summaryText(list *summaryList, colors *TextColors) string {
 			)
 
 			strTemplate.Execute(writer, map[string]string{
-				"nameColor":      colors.market.name,
-				"fieldColor":     colors.market.field,
-				"valueColor":     colors.market.value,
+				"nameColor":      widget.settings.colors.market.name,
+				"fieldColor":     widget.settings.colors.market.field,
+				"valueColor":     widget.settings.colors.market.value,
 				"mName":          marketCurrency.name,
 				"High":           marketCurrency.High,
 				"Low":            marketCurrency.Low,

--- a/modules/cryptoexchanges/bittrex/settings.go
+++ b/modules/cryptoexchanges/bittrex/settings.go
@@ -5,6 +5,8 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
+const configKey = "bittrex"
+
 type colors struct {
 	base struct {
 		name        string
@@ -24,11 +26,11 @@ type Settings struct {
 	summary map[string]interface{}
 }
 
-func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
-	localConfig, _ := ymlConfig.Get("wtf.mods.bittrex")
+func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
+	localConfig, _ := ymlConfig.Get("wtf.mods." + configKey)
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
 	}
 
 	settings.colors.base.name = localConfig.UString("colors.base.name")

--- a/modules/cryptoexchanges/bittrex/settings.go
+++ b/modules/cryptoexchanges/bittrex/settings.go
@@ -19,11 +19,19 @@ type colors struct {
 	}
 }
 
+type currency struct {
+	displayName string
+	market      []interface{}
+}
+
+type summary struct {
+	currencies map[string]*currency
+}
+
 type Settings struct {
 	colors
 	common *cfg.Common
-
-	summary map[string]interface{}
+	summary
 }
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
@@ -40,8 +48,17 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
 	settings.colors.market.field = localConfig.UString("colors.market.field")
 	settings.colors.market.value = localConfig.UString("colors.market.value")
 
-	summaryMap, _ := ymlConfig.Map("summary")
-	settings.summary = summaryMap
+	settings.summary.currencies = make(map[string]*currency)
+	for key, val := range localConfig.UMap("summary") {
+		coercedVal := val.(map[string]interface{})
+
+		currency := &currency{
+			displayName: coercedVal["displayName"].(string),
+			market:      coercedVal["market"].([]interface{}),
+		}
+
+		settings.currencies[key] = currency
+	}
 
 	return &settings
 }

--- a/modules/cryptoexchanges/bittrex/settings.go
+++ b/modules/cryptoexchanges/bittrex/settings.go
@@ -57,7 +57,7 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
 			market:      coercedVal["market"].([]interface{}),
 		}
 
-		settings.currencies[key] = currency
+		settings.summary.currencies[key] = currency
 	}
 
 	return &settings

--- a/modules/cryptoexchanges/bittrex/settings.go
+++ b/modules/cryptoexchanges/bittrex/settings.go
@@ -1,0 +1,45 @@
+package bittrex
+
+import (
+	"github.com/olebedev/config"
+	"github.com/wtfutil/wtf/cfg"
+)
+
+type colors struct {
+	base struct {
+		name        string
+		displayName string
+	}
+	market struct {
+		name  string
+		field string
+		value string
+	}
+}
+
+type Settings struct {
+	colors
+	common *cfg.Common
+
+	summary map[string]interface{}
+}
+
+func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
+	localConfig, _ := ymlConfig.Get("wtf.mods.bittrex")
+
+	settings := Settings{
+		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+	}
+
+	settings.colors.base.name = localConfig.UString("colors.base.name")
+	settings.colors.base.displayName = localConfig.UString("colors.base.displayName")
+
+	settings.colors.market.name = localConfig.UString("colors.market.name")
+	settings.colors.market.field = localConfig.UString("colors.market.field")
+	settings.colors.market.value = localConfig.UString("colors.market.value")
+
+	summaryMap, _ := ymlConfig.Map("summary")
+	settings.summary = summaryMap
+
+	return &settings
+}

--- a/modules/cryptoexchanges/bittrex/widget.go
+++ b/modules/cryptoexchanges/bittrex/widget.go
@@ -42,20 +42,17 @@ func NewWidget(app *tview.Application, settings *Settings) *Widget {
 }
 
 func (widget *Widget) setSummaryList() {
-	sCurrencies := widget.settings.summary
-	for baseCurrencyName := range sCurrencies {
-		displayName, _ := wtf.Config.String("wtf.mods.bittrex.summary." + baseCurrencyName + ".displayName")
-		mCurrencyList := makeSummaryMarketList(baseCurrencyName)
-		widget.summaryList.addSummaryItem(baseCurrencyName, displayName, mCurrencyList)
+	for symbol, currency := range widget.settings.summary.currencies {
+		mCurrencyList := widget.makeSummaryMarketList(symbol, currency.market)
+		widget.summaryList.addSummaryItem(symbol, currency.displayName, mCurrencyList)
 	}
 }
 
-func makeSummaryMarketList(currencyName string) []*mCurrency {
+func (widget *Widget) makeSummaryMarketList(currencySymbol string, market []interface{}) []*mCurrency {
 	mCurrencyList := []*mCurrency{}
 
-	configMarketList, _ := wtf.Config.List("wtf.mods.bittrex.summary." + currencyName + ".market")
-	for _, mCurrencyName := range configMarketList {
-		mCurrencyList = append(mCurrencyList, makeMarketCurrency(mCurrencyName.(string)))
+	for _, marketSymbol := range market {
+		mCurrencyList = append(mCurrencyList, makeMarketCurrency(marketSymbol.(string)))
 	}
 
 	return mCurrencyList

--- a/modules/cryptoexchanges/bittrex/widget.go
+++ b/modules/cryptoexchanges/bittrex/widget.go
@@ -27,7 +27,7 @@ type Widget struct {
 // NewWidget Make new instance of widget
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, "Bittrex", "bittrex", false),
+		TextWidget: wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, false),
 
 		settings:    settings,
 		summaryList: summaryList{},

--- a/modules/cryptoexchanges/bittrex/widget.go
+++ b/modules/cryptoexchanges/bittrex/widget.go
@@ -27,7 +27,7 @@ type Widget struct {
 // NewWidget Make new instance of widget
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, false),
+		TextWidget: wtf.NewTextWidget(app, settings.common, false),
 
 		settings:    settings,
 		summaryList: summaryList{},

--- a/modules/cryptoexchanges/bittrex/widget.go
+++ b/modules/cryptoexchanges/bittrex/widget.go
@@ -11,56 +11,38 @@ import (
 	"github.com/wtfutil/wtf/wtf"
 )
 
-type TextColors struct {
-	base struct {
-		name        string
-		displayName string
-	}
-	market struct {
-		name  string
-		field string
-		value string
-	}
-}
-
 var ok = true
 var errorText = ""
 
-var baseURL = "https://bittrex.com/api/v1.1/public/getmarketsummary"
+const baseURL = "https://bittrex.com/api/v1.1/public/getmarketsummary"
 
 // Widget define wtf widget to register widget later
 type Widget struct {
 	wtf.TextWidget
+
+	settings *Settings
 	summaryList
-	TextColors
 }
 
 // NewWidget Make new instance of widget
-func NewWidget(app *tview.Application) *Widget {
+func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget:  wtf.NewTextWidget(app, "Bittrex", "bittrex", false),
+		TextWidget: wtf.NewTextWidget(app, "Bittrex", "bittrex", false),
+
+		settings:    settings,
 		summaryList: summaryList{},
 	}
 
 	ok = true
 	errorText = ""
 
-	widget.config()
 	widget.setSummaryList()
 
 	return &widget
 }
 
-func (widget *Widget) config() {
-	widget.TextColors.base.name = wtf.Config.UString("wtf.mods.bittrex.colors.base.name", "red")
-	widget.TextColors.base.displayName = wtf.Config.UString("wtf.mods.bittrex.colors.base.displayName", "grey")
-	widget.TextColors.market.name = wtf.Config.UString("wtf.mods.bittrex.colors.market.name", "red")
-	widget.TextColors.market.field = wtf.Config.UString("wtf.mods.bittrex.colors.market.field", "coral")
-	widget.TextColors.market.value = wtf.Config.UString("wtf.mods.bittrex.colors.market.value", "white")
-}
-
 func (widget *Widget) setSummaryList() {
-	sCurrencies, _ := wtf.Config.Map("wtf.mods.bittrex.summary")
+	sCurrencies := widget.settings.summary
 	for baseCurrencyName := range sCurrencies {
 		displayName, _ := wtf.Config.String("wtf.mods.bittrex.summary." + baseCurrencyName + ".displayName")
 		mCurrencyList := makeSummaryMarketList(baseCurrencyName)

--- a/modules/cryptoexchanges/blockfolio/settings.go
+++ b/modules/cryptoexchanges/blockfolio/settings.go
@@ -1,0 +1,33 @@
+package blockfolio
+
+import (
+	"github.com/olebedev/config"
+	"github.com/wtfutil/wtf/cfg"
+)
+
+type colors struct {
+	name  string
+	grows string
+	drop  string
+}
+
+type Settings struct {
+	colors
+	common *cfg.Common
+
+	deviceToken     string
+	displayHoldings bool
+}
+
+func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
+	localConfig, _ := ymlConfig.Get("wtf.mods.todo")
+
+	settings := Settings{
+		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+
+		deviceToken:     localConfig.UString("device_token"),
+		displayHoldings: localConfig.UBool("displayHoldings", true),
+	}
+
+	return &settings
+}

--- a/modules/cryptoexchanges/blockfolio/settings.go
+++ b/modules/cryptoexchanges/blockfolio/settings.go
@@ -5,6 +5,8 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
+const configKey = "blockfolio"
+
 type colors struct {
 	name  string
 	grows string
@@ -19,11 +21,11 @@ type Settings struct {
 	displayHoldings bool
 }
 
-func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
-	localConfig, _ := ymlConfig.Get("wtf.mods.blockfolio")
+func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
+	localConfig, _ := ymlConfig.Get("wtf.mods." + configKey)
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
 
 		deviceToken:     localConfig.UString("device_token"),
 		displayHoldings: localConfig.UBool("displayHoldings", true),

--- a/modules/cryptoexchanges/blockfolio/settings.go
+++ b/modules/cryptoexchanges/blockfolio/settings.go
@@ -20,7 +20,7 @@ type Settings struct {
 }
 
 func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
-	localConfig, _ := ymlConfig.Get("wtf.mods.todo")
+	localConfig, _ := ymlConfig.Get("wtf.mods.blockfolio")
 
 	settings := Settings{
 		common: cfg.NewCommonSettingsFromYAML(ymlConfig),

--- a/modules/cryptoexchanges/blockfolio/widget.go
+++ b/modules/cryptoexchanges/blockfolio/widget.go
@@ -15,12 +15,15 @@ type Widget struct {
 	wtf.TextWidget
 
 	device_token string
+	settings     *Settings
 }
 
-func NewWidget(app *tview.Application) *Widget {
+func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget:   wtf.NewTextWidget(app, "Blockfolio", "blockfolio", false),
-		device_token: wtf.Config.UString("wtf.mods.blockfolio.device_token"),
+		TextWidget: wtf.NewTextWidget(app, "Blockfolio", "blockfolio", false),
+
+		device_token: settings.deviceToken,
+		settings:     settings,
 	}
 
 	return &widget
@@ -36,31 +39,50 @@ func (widget *Widget) Refresh() {
 		return
 	}
 
-	widget.View.SetText(contentFrom(positions))
+	content := widget.contentFrom(positions)
+	widget.View.SetText(content)
 }
 
 /* -------------------- Unexported Functions -------------------- */
-func contentFrom(positions *AllPositionsResponse) string {
+func (widget *Widget) contentFrom(positions *AllPositionsResponse) string {
 	res := ""
-	colorName := wtf.Config.UString("wtf.mods.blockfolio.colors.name")
-	colorGrows := wtf.Config.UString("wtf.mods.blockfolio.colors.grows")
-	colorDrop := wtf.Config.UString("wtf.mods.blockfolio.colors.drop")
-	displayHoldings := wtf.Config.UBool("wtf.mods.blockfolio.displayHoldings")
-	var totalFiat float32
-	totalFiat = 0.0
+	totalFiat := float32(0.0)
+
 	for i := 0; i < len(positions.PositionList); i++ {
-		colorForChange := colorGrows
+		colorForChange := widget.settings.colors.grows
+
 		if positions.PositionList[i].TwentyFourHourPercentChangeFiat <= 0 {
-			colorForChange = colorDrop
+			colorForChange = widget.settings.colors.drop
 		}
+
 		totalFiat += positions.PositionList[i].HoldingValueFiat
-		if displayHoldings {
-			res = res + fmt.Sprintf("[%s]%-6s - %5.2f ([%s]%.3fk [%s]%.2f%s)\n", colorName, positions.PositionList[i].Coin, positions.PositionList[i].Quantity, colorForChange, positions.PositionList[i].HoldingValueFiat/1000, colorForChange, positions.PositionList[i].TwentyFourHourPercentChangeFiat, "%")
+
+		if widget.settings.displayHoldings {
+			res = res + fmt.Sprintf(
+				"[%s]%-6s - %5.2f ([%s]%.3fk [%s]%.2f%s)\n",
+				widget.settings.colors.name,
+				positions.PositionList[i].Coin,
+				positions.PositionList[i].Quantity,
+				colorForChange,
+				positions.PositionList[i].HoldingValueFiat/1000,
+				colorForChange,
+				positions.PositionList[i].TwentyFourHourPercentChangeFiat,
+				"%",
+			)
 		} else {
-			res = res + fmt.Sprintf("[%s]%-6s - %5.2f ([%s]%.2f%s)\n", colorName, positions.PositionList[i].Coin, positions.PositionList[i].Quantity, colorForChange, positions.PositionList[i].TwentyFourHourPercentChangeFiat, "%")
+			res = res + fmt.Sprintf(
+				"[%s]%-6s - %5.2f ([%s]%.2f%s)\n",
+				widget.settings.colors.name,
+				positions.PositionList[i].Coin,
+				positions.PositionList[i].Quantity,
+				colorForChange,
+				positions.PositionList[i].TwentyFourHourPercentChangeFiat,
+				"%",
+			)
 		}
 	}
-	if displayHoldings {
+
+	if widget.settings.displayHoldings {
 		res = res + fmt.Sprintf("\n[%s]Total value: $%.3fk", "green", totalFiat/1000)
 	}
 

--- a/modules/cryptoexchanges/blockfolio/widget.go
+++ b/modules/cryptoexchanges/blockfolio/widget.go
@@ -20,7 +20,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, "Blockfolio", "blockfolio", false),
+		TextWidget: wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, false),
 
 		device_token: settings.deviceToken,
 		settings:     settings,

--- a/modules/cryptoexchanges/blockfolio/widget.go
+++ b/modules/cryptoexchanges/blockfolio/widget.go
@@ -20,7 +20,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, false),
+		TextWidget: wtf.NewTextWidget(app, settings.common, false),
 
 		device_token: settings.deviceToken,
 		settings:     settings,

--- a/modules/cryptoexchanges/cryptolive/price/settings.go
+++ b/modules/cryptoexchanges/cryptolive/price/settings.go
@@ -1,0 +1,63 @@
+package price
+
+import (
+	"github.com/olebedev/config"
+	"github.com/wtfutil/wtf/cfg"
+)
+
+type colors struct {
+	from struct {
+		name        string
+		displayName string
+	}
+	to struct {
+		name  string
+		price string
+	}
+	top struct {
+		from struct {
+			name        string
+			displayName string
+		}
+		to struct {
+			name  string
+			field string
+			value string
+		}
+	}
+}
+
+type Settings struct {
+	colors
+	common     *cfg.Common
+	currencies map[string]interface{}
+	top        map[string]interface{}
+}
+
+func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
+	localConfig, _ := ymlConfig.Get("wtf.mods.cryptolive")
+
+	currencies, _ := localConfig.Map("currencies")
+	top, _ := localConfig.Map("top")
+
+	settings := Settings{
+		common:     cfg.NewCommonSettingsFromYAML(ymlConfig),
+		currencies: currencies,
+		top:        top,
+	}
+
+	settings.colors.from.name = localConfig.UString("colors.from.name")
+	settings.colors.from.displayName = localConfig.UString("colors.from.displayName")
+
+	settings.colors.to.name = localConfig.UString("colors.to.name")
+	settings.colors.to.price = localConfig.UString("colors.to.price")
+
+	settings.colors.top.from.name = localConfig.UString("colors.top.from.name")
+	settings.colors.top.from.displayName = localConfig.UString("colors.top.from.displayName")
+
+	settings.colors.top.to.name = localConfig.UString("colors.top.to.name")
+	settings.colors.top.to.field = localConfig.UString("colors.top.to.field")
+	settings.colors.top.to.value = localConfig.UString("colors.top.to.value")
+
+	return &settings
+}

--- a/modules/cryptoexchanges/cryptolive/price/settings.go
+++ b/modules/cryptoexchanges/cryptolive/price/settings.go
@@ -5,6 +5,8 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
+const configKey = "price"
+
 type colors struct {
 	from struct {
 		name        string
@@ -34,14 +36,14 @@ type Settings struct {
 	top        map[string]interface{}
 }
 
-func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
-	localConfig, _ := ymlConfig.Get("wtf.mods.cryptolive")
+func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
+	localConfig, _ := ymlConfig.Get("wtf.mods." + configKey)
 
 	currencies, _ := localConfig.Map("currencies")
 	top, _ := localConfig.Map("top")
 
 	settings := Settings{
-		common:     cfg.NewCommonSettingsFromYAML(ymlConfig),
+		common:     cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
 		currencies: currencies,
 		top:        top,
 	}

--- a/modules/cryptoexchanges/cryptolive/price/settings.go
+++ b/modules/cryptoexchanges/cryptolive/price/settings.go
@@ -5,7 +5,7 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const configKey = "price"
+const configKey = "cryptolive"
 
 type colors struct {
 	from struct {
@@ -29,23 +29,22 @@ type colors struct {
 	}
 }
 
+type currency struct {
+	displayName string
+	to          []interface{}
+}
+
 type Settings struct {
 	colors
 	common     *cfg.Common
-	currencies map[string]interface{}
-	top        map[string]interface{}
+	currencies map[string]*currency
 }
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
 	localConfig, _ := ymlConfig.Get("wtf.mods." + configKey)
 
-	currencies, _ := localConfig.Map("currencies")
-	top, _ := localConfig.Map("top")
-
 	settings := Settings{
-		common:     cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
-		currencies: currencies,
-		top:        top,
+		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
 	}
 
 	settings.colors.from.name = localConfig.UString("colors.from.name")
@@ -60,6 +59,19 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
 	settings.colors.top.to.name = localConfig.UString("colors.top.to.name")
 	settings.colors.top.to.field = localConfig.UString("colors.top.to.field")
 	settings.colors.top.to.value = localConfig.UString("colors.top.to.value")
+
+	settings.currencies = make(map[string]*currency)
+
+	for key, val := range localConfig.UMap("currencies") {
+		coercedVal := val.(map[string]interface{})
+
+		currency := &currency{
+			displayName: coercedVal["displayName"].(string),
+			to:          coercedVal["to"].([]interface{}),
+		}
+
+		settings.currencies[key] = currency
+	}
 
 	return &settings
 }

--- a/modules/cryptoexchanges/cryptolive/price/widget.go
+++ b/modules/cryptoexchanges/cryptolive/price/widget.go
@@ -16,6 +16,7 @@ var ok = true
 // Widget define wtf widget to register widget later
 type Widget struct {
 	*list
+	settings *Settings
 
 	Result string
 
@@ -23,8 +24,10 @@ type Widget struct {
 }
 
 // NewWidget Make new instance of widget
-func NewWidget() *Widget {
-	widget := Widget{}
+func NewWidget(settings *Settings) *Widget {
+	widget := Widget{
+		settings: settings,
+	}
 
 	widget.setList()
 
@@ -32,11 +35,9 @@ func NewWidget() *Widget {
 }
 
 func (widget *Widget) setList() {
-	currenciesMap, _ := wtf.Config.Map("wtf.mods.cryptolive.currencies")
-
 	widget.list = &list{}
 
-	for currency := range currenciesMap {
+	for currency := range widget.settings.currencies {
 		displayName, _ := wtf.Config.String("wtf.mods.cryptolive.currencies." + currency + ".displayName")
 		toList := getToList(currency)
 		widget.list.addItem(currency, displayName, toList)
@@ -66,16 +67,23 @@ func (widget *Widget) Refresh(wg *sync.WaitGroup) {
 
 func (widget *Widget) display() {
 	str := ""
-	var (
-		fromNameColor        = wtf.Config.UString("wtf.mods.cryptolive.colors.from.name", "coral")
-		fromDisplayNameColor = wtf.Config.UString("wtf.mods.cryptolive.colors.from.displayName", "grey")
-		toNameColor          = wtf.Config.UString("wtf.mods.cryptolive.colors.to.name", "white")
-		toPriceColor         = wtf.Config.UString("wtf.mods.cryptolive.colors.to.price", "green")
-	)
+
 	for _, item := range widget.list.items {
-		str += fmt.Sprintf(" [%s]%s[%s] (%s)\n", fromNameColor, item.displayName, fromDisplayNameColor, item.name)
+		str += fmt.Sprintf(
+			" [%s]%s[%s] (%s)\n",
+			widget.settings.colors.from.name,
+			item.displayName,
+			widget.settings.colors.from.name,
+			item.name,
+		)
 		for _, toItem := range item.to {
-			str += fmt.Sprintf("\t[%s]%s: [%s]%f\n", toNameColor, toItem.name, toPriceColor, toItem.price)
+			str += fmt.Sprintf(
+				"\t[%s]%s: [%s]%f\n",
+				widget.settings.colors.to.name,
+				toItem.name,
+				widget.settings.colors.to.price,
+				toItem.price,
+			)
 		}
 		str += "\n"
 	}

--- a/modules/cryptoexchanges/cryptolive/price/widget.go
+++ b/modules/cryptoexchanges/cryptolive/price/widget.go
@@ -6,8 +6,6 @@ import (
 	"net/http"
 	"sync"
 	"time"
-
-	"github.com/wtfutil/wtf/wtf"
 )
 
 var baseURL = "https://min-api.cryptocompare.com/data/price"
@@ -37,12 +35,10 @@ func NewWidget(settings *Settings) *Widget {
 func (widget *Widget) setList() {
 	widget.list = &list{}
 
-	for currency := range widget.settings.currencies {
-		displayName, _ := wtf.Config.String("wtf.mods.cryptolive.currencies." + currency + ".displayName")
-		toList := getToList(currency)
-		widget.list.addItem(currency, displayName, toList)
+	for symbol, currency := range widget.settings.currencies {
+		toList := widget.getToList(symbol)
+		widget.list.addItem(symbol, currency.displayName, toList)
 	}
-
 }
 
 /* -------------------- Exported Functions -------------------- */
@@ -91,12 +87,10 @@ func (widget *Widget) display() {
 	widget.Result = fmt.Sprintf("\n%s", str)
 }
 
-func getToList(fromName string) []*toCurrency {
-	toNames, _ := wtf.Config.List("wtf.mods.cryptolive.currencies." + fromName + ".to")
-
+func (widget *Widget) getToList(symbol string) []*toCurrency {
 	var toList []*toCurrency
 
-	for _, to := range toNames {
+	for _, to := range widget.settings.currencies[symbol].to {
 		toList = append(toList, &toCurrency{
 			name:  to.(string),
 			price: 0,

--- a/modules/cryptoexchanges/cryptolive/settings.go
+++ b/modules/cryptoexchanges/cryptolive/settings.go
@@ -1,0 +1,71 @@
+package cryptolive
+
+import (
+	"github.com/olebedev/config"
+	"github.com/wtfutil/wtf/cfg"
+	"github.com/wtfutil/wtf/modules/cryptoexchanges/cryptolive/price"
+	"github.com/wtfutil/wtf/modules/cryptoexchanges/cryptolive/toplist"
+)
+
+type colors struct {
+	from struct {
+		name        string
+		displayName string
+	}
+	to struct {
+		name  string
+		price string
+	}
+	top struct {
+		from struct {
+			name        string
+			displayName string
+		}
+		to struct {
+			name  string
+			field string
+			value string
+		}
+	}
+}
+
+type Settings struct {
+	colors
+	common     *cfg.Common
+	currencies map[string]interface{}
+	top        map[string]interface{}
+
+	priceSettings   *price.Settings
+	toplistSettings *toplist.Settings
+}
+
+func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
+	localConfig, _ := ymlConfig.Get("wtf.mods.cryptolive")
+
+	currencies, _ := localConfig.Map("currencies")
+	top, _ := localConfig.Map("top")
+
+	settings := Settings{
+		common:     cfg.NewCommonSettingsFromYAML(ymlConfig),
+		currencies: currencies,
+		top:        top,
+
+		priceSettings:   price.NewSettingsFromYAML(ymlConfig),
+		toplistSettings: toplist.NewSettingsFromYAML(ymlConfig),
+	}
+
+	settings.colors.from.name = localConfig.UString("colors.from.name")
+	settings.colors.from.displayName = localConfig.UString("colors.from.displayName")
+
+	settings.colors.to.name = localConfig.UString("colors.to.name")
+	settings.colors.to.price = localConfig.UString("colors.to.price")
+
+	settings.colors.top.from.name = localConfig.UString("colors.top.from.name")
+	settings.colors.top.from.displayName = localConfig.UString("colors.top.from.displayName")
+
+	settings.colors.top.to.name = localConfig.UString("colors.top.to.name")
+	settings.colors.top.to.field = localConfig.UString("colors.top.to.field")
+	settings.colors.top.to.value = localConfig.UString("colors.top.to.value")
+
+	return &settings
+}

--- a/modules/cryptoexchanges/cryptolive/settings.go
+++ b/modules/cryptoexchanges/cryptolive/settings.go
@@ -7,6 +7,8 @@ import (
 	"github.com/wtfutil/wtf/modules/cryptoexchanges/cryptolive/toplist"
 )
 
+const configKey = "cryptolive"
+
 type colors struct {
 	from struct {
 		name        string
@@ -31,7 +33,8 @@ type colors struct {
 
 type Settings struct {
 	colors
-	common     *cfg.Common
+	common *cfg.Common
+
 	currencies map[string]interface{}
 	top        map[string]interface{}
 
@@ -39,19 +42,20 @@ type Settings struct {
 	toplistSettings *toplist.Settings
 }
 
-func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
-	localConfig, _ := ymlConfig.Get("wtf.mods.cryptolive")
+func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
+	localConfig, _ := ymlConfig.Get("wtf.mods." + configKey)
 
 	currencies, _ := localConfig.Map("currencies")
 	top, _ := localConfig.Map("top")
 
 	settings := Settings{
-		common:     cfg.NewCommonSettingsFromYAML(ymlConfig),
+		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
+
 		currencies: currencies,
 		top:        top,
 
-		priceSettings:   price.NewSettingsFromYAML(ymlConfig),
-		toplistSettings: toplist.NewSettingsFromYAML(ymlConfig),
+		priceSettings:   price.NewSettingsFromYAML(name, ymlConfig),
+		toplistSettings: toplist.NewSettingsFromYAML(name, ymlConfig),
 	}
 
 	settings.colors.from.name = localConfig.UString("colors.from.name")

--- a/modules/cryptoexchanges/cryptolive/toplist/display.go
+++ b/modules/cryptoexchanges/cryptolive/toplist/display.go
@@ -7,49 +7,54 @@ func (widget *Widget) display() {
 	for _, fromCurrency := range widget.list.items {
 		str += fmt.Sprintf(
 			"[%s]%s [%s](%s)\n",
-			widget.colors.from.displayName,
+			widget.settings.colors.from.displayName,
 			fromCurrency.displayName,
-			widget.colors.from.name,
+			widget.settings.colors.from.name,
 			fromCurrency.name,
 		)
-		str += makeToListText(fromCurrency.to, widget.colors)
+		str += widget.makeToListText(fromCurrency.to)
 	}
 
 	widget.Result = str
 }
 
-func makeToListText(toList []*tCurrency, colors textColors) string {
+func (widget *Widget) makeToListText(toList []*tCurrency) string {
 	str := ""
 	for _, toCurrency := range toList {
-		str += makeToText(toCurrency, colors)
+		str += widget.makeToText(toCurrency)
 	}
 
 	return str
 }
 
-func makeToText(toCurrency *tCurrency, colors textColors) string {
+func (widget *Widget) makeToText(toCurrency *tCurrency) string {
 	str := ""
-	str += fmt.Sprintf("  [%s]%s\n", colors.to.name, toCurrency.name)
+	str += fmt.Sprintf(
+		"  [%s]%s\n",
+		widget.settings.colors.to.name,
+		toCurrency.name,
+	)
+
 	for _, info := range toCurrency.info {
-		str += makeInfoText(info, colors)
+		str += widget.makeInfoText(info)
 		str += "\n\n"
 	}
 	return str
 }
 
-func makeInfoText(info tInfo, colors textColors) string {
+func (widget *Widget) makeInfoText(info tInfo) string {
 	return fmt.Sprintf(
 		"    [%s]Exchange: [%s]%s\n",
-		colors.to.field,
-		colors.to.value,
+		widget.settings.colors.top.to.field,
+		widget.settings.colors.top.to.value,
 		info.exchange,
 	) +
 		fmt.Sprintf(
 			"    [%s]Volume(24h): [%s]%f-[%s]%f",
-			colors.to.field,
-			colors.to.value,
+			widget.settings.colors.top.to.field,
+			widget.settings.colors.top.to.value,
 			info.volume24h,
-			colors.to.value,
+			widget.settings.colors.top.to.value,
 			info.volume24hTo,
 		)
 }

--- a/modules/cryptoexchanges/cryptolive/toplist/settings.go
+++ b/modules/cryptoexchanges/cryptolive/toplist/settings.go
@@ -5,6 +5,8 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
+const configKey = "toplist"
+
 type colors struct {
 	from struct {
 		name        string
@@ -34,14 +36,14 @@ type Settings struct {
 	top        map[string]interface{}
 }
 
-func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
-	localConfig, _ := ymlConfig.Get("wtf.mods.cryptolive")
+func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
+	localConfig, _ := ymlConfig.Get("wtf.mods." + configKey)
 
 	currencies, _ := localConfig.Map("currencies")
 	top, _ := localConfig.Map("top")
 
 	settings := Settings{
-		common:     cfg.NewCommonSettingsFromYAML(ymlConfig),
+		common:     cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
 		currencies: currencies,
 		top:        top,
 	}

--- a/modules/cryptoexchanges/cryptolive/toplist/settings.go
+++ b/modules/cryptoexchanges/cryptolive/toplist/settings.go
@@ -1,0 +1,63 @@
+package toplist
+
+import (
+	"github.com/olebedev/config"
+	"github.com/wtfutil/wtf/cfg"
+)
+
+type colors struct {
+	from struct {
+		name        string
+		displayName string
+	}
+	to struct {
+		name  string
+		price string
+	}
+	top struct {
+		from struct {
+			name        string
+			displayName string
+		}
+		to struct {
+			name  string
+			field string
+			value string
+		}
+	}
+}
+
+type Settings struct {
+	colors
+	common     *cfg.Common
+	currencies map[string]interface{}
+	top        map[string]interface{}
+}
+
+func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
+	localConfig, _ := ymlConfig.Get("wtf.mods.cryptolive")
+
+	currencies, _ := localConfig.Map("currencies")
+	top, _ := localConfig.Map("top")
+
+	settings := Settings{
+		common:     cfg.NewCommonSettingsFromYAML(ymlConfig),
+		currencies: currencies,
+		top:        top,
+	}
+
+	settings.colors.from.name = localConfig.UString("colors.from.name")
+	settings.colors.from.displayName = localConfig.UString("colors.from.displayName")
+
+	settings.colors.to.name = localConfig.UString("colors.to.name")
+	settings.colors.to.price = localConfig.UString("colors.to.price")
+
+	settings.colors.top.from.name = localConfig.UString("colors.top.from.name")
+	settings.colors.top.from.displayName = localConfig.UString("colors.top.from.displayName")
+
+	settings.colors.top.to.name = localConfig.UString("colors.top.to.name")
+	settings.colors.top.to.field = localConfig.UString("colors.top.to.field")
+	settings.colors.top.to.value = localConfig.UString("colors.top.to.value")
+
+	return &settings
+}

--- a/modules/cryptoexchanges/cryptolive/toplist/settings.go
+++ b/modules/cryptoexchanges/cryptolive/toplist/settings.go
@@ -5,7 +5,7 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const configKey = "toplist"
+const configKey = "cryptolive"
 
 type colors struct {
 	from struct {
@@ -29,23 +29,24 @@ type colors struct {
 	}
 }
 
+type currency struct {
+	displayName string
+	limit       int
+	to          []interface{}
+}
+
 type Settings struct {
 	colors
 	common     *cfg.Common
-	currencies map[string]interface{}
-	top        map[string]interface{}
+	currencies map[string]*currency
+	top        map[string]*currency
 }
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
 	localConfig, _ := ymlConfig.Get("wtf.mods." + configKey)
 
-	currencies, _ := localConfig.Map("currencies")
-	top, _ := localConfig.Map("top")
-
 	settings := Settings{
-		common:     cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
-		currencies: currencies,
-		top:        top,
+		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
 	}
 
 	settings.colors.from.name = localConfig.UString("colors.from.name")
@@ -60,6 +61,36 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
 	settings.colors.top.to.name = localConfig.UString("colors.top.to.name")
 	settings.colors.top.to.field = localConfig.UString("colors.top.to.field")
 	settings.colors.top.to.value = localConfig.UString("colors.top.to.value")
+
+	settings.currencies = make(map[string]*currency)
+
+	for key, val := range localConfig.UMap("currencies") {
+		coercedVal := val.(map[string]interface{})
+
+		limit, _ := coercedVal["limit"].(int)
+
+		currency := &currency{
+			displayName: coercedVal["displayName"].(string),
+			limit:       limit,
+			to:          coercedVal["to"].([]interface{}),
+		}
+
+		settings.currencies[key] = currency
+	}
+
+	for key, val := range localConfig.UMap("top") {
+		coercedVal := val.(map[string]interface{})
+
+		limit, _ := coercedVal["limit"].(int)
+
+		currency := &currency{
+			displayName: coercedVal["displayName"].(string),
+			limit:       limit,
+			to:          coercedVal["to"].([]interface{}),
+		}
+
+		settings.currencies[key] = currency
+	}
 
 	return &settings
 }

--- a/modules/cryptoexchanges/cryptolive/toplist/widget.go
+++ b/modules/cryptoexchanges/cryptolive/toplist/widget.go
@@ -7,8 +7,6 @@ import (
 	"os"
 	"sync"
 	"time"
-
-	"github.com/wtfutil/wtf/wtf"
 )
 
 var baseURL = "https://min-api.cryptocompare.com/data/top/exchanges"
@@ -36,19 +34,16 @@ func NewWidget(settings *Settings) *Widget {
 }
 
 func (widget *Widget) setList() {
-	for fromCurrency := range widget.settings.top {
-		displayName := wtf.Config.UString("wtf.mods.cryptolive.top."+fromCurrency+".displayName", "")
-		limit := wtf.Config.UInt("wtf.mods.cryptolive.top."+fromCurrency+".limit", 1)
-		widget.list.addItem(fromCurrency, displayName, limit, makeToList(fromCurrency, limit))
+	for symbol, currency := range widget.settings.top {
+		toList := widget.makeToList(symbol, currency.limit)
+		widget.list.addItem(symbol, currency.displayName, currency.limit, toList)
 	}
 }
 
-func makeToList(fCurrencyName string, limit int) (list []*tCurrency) {
-	toList, _ := wtf.Config.List("wtf.mods.cryptolive.top." + fCurrencyName + ".to")
-
-	for _, toCurrency := range toList {
+func (widget *Widget) makeToList(symbol string, limit int) (list []*tCurrency) {
+	for _, to := range widget.settings.top[symbol].to {
 		list = append(list, &tCurrency{
-			name: toCurrency.(string),
+			name: to.(string),
 			info: make([]tInfo, limit),
 		})
 	}

--- a/modules/cryptoexchanges/cryptolive/toplist/widget.go
+++ b/modules/cryptoexchanges/cryptolive/toplist/widget.go
@@ -13,44 +13,30 @@ import (
 
 var baseURL = "https://min-api.cryptocompare.com/data/top/exchanges"
 
-type textColors struct {
-	from struct {
-		name        string
-		displayName string
-	}
-	to struct {
-		name  string
-		field string
-		value string
-	}
-}
-
 // Widget Toplist Widget
 type Widget struct {
 	Result string
 
 	RefreshInterval int
 
-	list *cList
-
-	colors textColors
+	list     *cList
+	settings *Settings
 }
 
 // NewWidget Make new toplist widget
-func NewWidget() *Widget {
-	widget := Widget{}
+func NewWidget(settings *Settings) *Widget {
+	widget := Widget{
+		settings: settings,
+	}
 
 	widget.list = &cList{}
 	widget.setList()
-	widget.config()
 
 	return &widget
 }
 
 func (widget *Widget) setList() {
-	currenciesMap, _ := wtf.Config.Map("wtf.mods.cryptolive.top")
-
-	for fromCurrency := range currenciesMap {
+	for fromCurrency := range widget.settings.top {
 		displayName := wtf.Config.UString("wtf.mods.cryptolive.top."+fromCurrency+".displayName", "")
 		limit := wtf.Config.UInt("wtf.mods.cryptolive.top."+fromCurrency+".limit", 1)
 		widget.list.addItem(fromCurrency, displayName, limit, makeToList(fromCurrency, limit))
@@ -68,15 +54,6 @@ func makeToList(fCurrencyName string, limit int) (list []*tCurrency) {
 	}
 
 	return
-}
-
-func (widget *Widget) config() {
-	// set colors
-	widget.colors.from.name = wtf.Config.UString("wtf.mods.cryptolive.colors.top.from.name", "coral")
-	widget.colors.from.displayName = wtf.Config.UString("wtf.mods.cryptolive.colors.top.from.displayName", "grey")
-	widget.colors.to.name = wtf.Config.UString("wtf.mods.cryptolive.colors.top.to.name", "red")
-	widget.colors.to.field = wtf.Config.UString("wtf.mods.cryptolive.colors.top.to.field", "white")
-	widget.colors.to.value = wtf.Config.UString("wtf.mods.cryptolive.colors.top.to.value", "value")
 }
 
 /* -------------------- Exported Functions -------------------- */

--- a/modules/cryptoexchanges/cryptolive/widget.go
+++ b/modules/cryptoexchanges/cryptolive/widget.go
@@ -13,16 +13,20 @@ import (
 // Widget define wtf widget to register widget later
 type Widget struct {
 	wtf.TextWidget
+
 	priceWidget   *price.Widget
 	toplistWidget *toplist.Widget
+	settings      *Settings
 }
 
 // NewWidget Make new instance of widget
-func NewWidget(app *tview.Application) *Widget {
+func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget:    wtf.NewTextWidget(app, "CryptoLive", "cryptolive", false),
-		priceWidget:   price.NewWidget(),
-		toplistWidget: toplist.NewWidget(),
+		TextWidget: wtf.NewTextWidget(app, "CryptoLive", "cryptolive", false),
+
+		priceWidget:   price.NewWidget(settings.priceSettings),
+		toplistWidget: toplist.NewWidget(settings.toplistSettings),
+		settings:      settings,
 	}
 
 	widget.priceWidget.RefreshInterval = widget.RefreshInterval()

--- a/modules/cryptoexchanges/cryptolive/widget.go
+++ b/modules/cryptoexchanges/cryptolive/widget.go
@@ -22,7 +22,7 @@ type Widget struct {
 // NewWidget Make new instance of widget
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, false),
+		TextWidget: wtf.NewTextWidget(app, settings.common, false),
 
 		priceWidget:   price.NewWidget(settings.priceSettings),
 		toplistWidget: toplist.NewWidget(settings.toplistSettings),

--- a/modules/cryptoexchanges/cryptolive/widget.go
+++ b/modules/cryptoexchanges/cryptolive/widget.go
@@ -22,7 +22,7 @@ type Widget struct {
 // NewWidget Make new instance of widget
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, "CryptoLive", "cryptolive", false),
+		TextWidget: wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, false),
 
 		priceWidget:   price.NewWidget(settings.priceSettings),
 		toplistWidget: toplist.NewWidget(settings.toplistSettings),

--- a/modules/datadog/client.go
+++ b/modules/datadog/client.go
@@ -1,34 +1,23 @@
 package datadog
 
 import (
-	"os"
-
 	"github.com/wtfutil/wtf/wtf"
 	datadog "github.com/zorkian/go-datadog-api"
 )
 
 // Monitors returns a list of newrelic monitors
-func Monitors() ([]datadog.Monitor, error) {
-	client := datadog.NewClient(apiKey(), applicationKey())
+func (widget *Widget) Monitors() ([]datadog.Monitor, error) {
+	client := datadog.NewClient(
+		widget.settings.apiKey,
+		widget.settings.applicationKey,
+	)
 
-	monitors, err := client.GetMonitorsByTags(wtf.ToStrs(wtf.Config.UList("wtf.mods.datadog.monitors.tags")))
+	tags := wtf.ToStrs(widget.settings.tags)
+
+	monitors, err := client.GetMonitorsByTags(tags)
 	if err != nil {
 		return nil, err
 	}
 
 	return monitors, nil
-}
-
-func apiKey() string {
-	return wtf.Config.UString(
-		"wtf.mods.datadog.apiKey",
-		os.Getenv("WTF_DATADOG_API_KEY"),
-	)
-}
-
-func applicationKey() string {
-	return wtf.Config.UString(
-		"wtf.mods.datadog.applicationKey",
-		os.Getenv("WTF_DATADOG_APPLICATION_KEY"),
-	)
 }

--- a/modules/datadog/settings.go
+++ b/modules/datadog/settings.go
@@ -7,6 +7,8 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
+const configKey = "datadog"
+
 type Settings struct {
 	common *cfg.Common
 
@@ -15,11 +17,12 @@ type Settings struct {
 	tags           []interface{}
 }
 
-func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
-	localConfig, _ := ymlConfig.Get("wtf.mods.datadog")
+func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
+	localConfig, _ := ymlConfig.Get("wtf.mods." + configKey)
 
 	settings := Settings{
-		common:         cfg.NewCommonSettingsFromYAML(ymlConfig),
+		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
+
 		apiKey:         localConfig.UString("apiKey", os.Getenv("WTF_DATADOG_API_KEY")),
 		applicationKey: localConfig.UString("applicationKey", os.Getenv("WTF_DATADOG_APPLICATION_KEY")),
 		tags:           localConfig.UList("monitors.tags"),

--- a/modules/datadog/settings.go
+++ b/modules/datadog/settings.go
@@ -1,0 +1,29 @@
+package datadog
+
+import (
+	"os"
+
+	"github.com/olebedev/config"
+	"github.com/wtfutil/wtf/cfg"
+)
+
+type Settings struct {
+	common *cfg.Common
+
+	apiKey         string
+	applicationKey string
+	tags           []interface{}
+}
+
+func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
+	localConfig, _ := ymlConfig.Get("wtf.mods.todo")
+
+	settings := Settings{
+		common:         cfg.NewCommonSettingsFromYAML(ymlConfig),
+		apiKey:         localConfig.UString("apiKey", os.Getenv("WTF_DATADOG_API_KEY")),
+		applicationKey: localConfig.UString("applicationKey", os.Getenv("WTF_DATADOG_APPLICATION_KEY")),
+		tags:           localConfig.UList("monitors.tags"),
+	}
+
+	return &settings
+}

--- a/modules/datadog/settings.go
+++ b/modules/datadog/settings.go
@@ -16,7 +16,7 @@ type Settings struct {
 }
 
 func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
-	localConfig, _ := ymlConfig.Get("wtf.mods.todo")
+	localConfig, _ := ymlConfig.Get("wtf.mods.datadog")
 
 	settings := Settings{
 		common:         cfg.NewCommonSettingsFromYAML(ymlConfig),

--- a/modules/datadog/widget.go
+++ b/modules/datadog/widget.go
@@ -16,7 +16,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, "Datadog", "datadog", false),
+		TextWidget: wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, false),
 
 		settings: settings,
 	}

--- a/modules/datadog/widget.go
+++ b/modules/datadog/widget.go
@@ -10,11 +10,15 @@ import (
 
 type Widget struct {
 	wtf.TextWidget
+
+	settings *Settings
 }
 
-func NewWidget(app *tview.Application) *Widget {
+func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
 		TextWidget: wtf.NewTextWidget(app, "Datadog", "datadog", false),
+
+		settings: settings,
 	}
 
 	return &widget
@@ -23,7 +27,7 @@ func NewWidget(app *tview.Application) *Widget {
 /* -------------------- Exported Functions -------------------- */
 
 func (widget *Widget) Refresh() {
-	monitors, monitorErr := Monitors()
+	monitors, monitorErr := widget.Monitors()
 
 	widget.View.SetTitle(widget.ContextualTitle(fmt.Sprintf("%s", widget.Name())))
 	widget.View.Clear()

--- a/modules/datadog/widget.go
+++ b/modules/datadog/widget.go
@@ -16,7 +16,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, false),
+		TextWidget: wtf.NewTextWidget(app, settings.common, false),
 
 		settings: settings,
 	}

--- a/modules/gcal/display.go
+++ b/modules/gcal/display.go
@@ -44,8 +44,8 @@ func (widget *Widget) contentFrom(calEvents []*CalEvent) string {
 	var str string
 	var prevEvent *CalEvent
 
-	if !wtf.Config.UBool("wtf.mods.gcal.showDeclined", false) {
-		calEvents = removeDeclined(calEvents)
+	if !widget.settings.showDeclined {
+		calEvents = widget.removeDeclined(calEvents)
 	}
 
 	for _, calEvent := range calEvents {
@@ -101,7 +101,7 @@ func (widget *Widget) dayDivider(event, prevEvent *CalEvent) string {
 	if !eventStartDay.Equal(prevStartDay) {
 
 		return fmt.Sprintf("[%s::b]",
-			wtf.Config.UString("wtf.mods.gcal.colors.day", "forestgreen")) +
+			widget.settings.colors.day) +
 			event.Start().Format(wtf.FullDateFormat) +
 			"\n"
 	}
@@ -111,10 +111,10 @@ func (widget *Widget) dayDivider(event, prevEvent *CalEvent) string {
 
 func (widget *Widget) descriptionColor(calEvent *CalEvent) string {
 	if calEvent.Past() {
-		return wtf.Config.UString("wtf.mods.gcal.colors.past", "gray")
+		return widget.settings.colors.past
 	}
 
-	return wtf.Config.UString("wtf.mods.gcal.colors.description", "white")
+	return widget.settings.colors.description
 }
 
 func (widget *Widget) eventSummary(calEvent *CalEvent, conflict bool) string {
@@ -123,13 +123,13 @@ func (widget *Widget) eventSummary(calEvent *CalEvent, conflict bool) string {
 	if calEvent.Now() {
 		summary = fmt.Sprintf(
 			"%s %s",
-			wtf.Config.UString("wtf.mods.gcal.currentIcon", "🔸"),
+			widget.settings.currentIcon,
 			summary,
 		)
 	}
 
 	if conflict {
-		return fmt.Sprintf("%s %s", wtf.Config.UString("wtf.mods.gcal.conflictIcon", "🚨"), summary)
+		return fmt.Sprintf("%s %s", widget.settings.conflictIcon, summary)
 	}
 
 	return summary
@@ -170,9 +170,9 @@ func (widget *Widget) timeUntil(calEvent *CalEvent) string {
 }
 
 func (widget *Widget) titleColor(calEvent *CalEvent) string {
-	color := wtf.Config.UString("wtf.mods.gcal.colors.title", "white")
+	color := widget.settings.colors.title
 
-	for _, untypedArr := range wtf.Config.UList("wtf.mods.gcal.colors.highlights") {
+	for _, untypedArr := range widget.settings.highlights {
 		highlightElements := wtf.ToStrs(untypedArr.([]interface{}))
 
 		match, _ := regexp.MatchString(
@@ -186,14 +186,14 @@ func (widget *Widget) titleColor(calEvent *CalEvent) string {
 	}
 
 	if calEvent.Past() {
-		color = wtf.Config.UString("wtf.mods.gcal.colors.past", "gray")
+		color = widget.settings.colors.past
 	}
 
 	return color
 }
 
 func (widget *Widget) location(calEvent *CalEvent) string {
-	if wtf.Config.UBool("wtf.mods.gcal.displayLocation", true) == false {
+	if widget.settings.withLocation == false {
 		return ""
 	}
 
@@ -209,13 +209,13 @@ func (widget *Widget) location(calEvent *CalEvent) string {
 }
 
 func (widget *Widget) responseIcon(calEvent *CalEvent) string {
-	if false == wtf.Config.UBool("wtf.mods.gcal.displayResponseStatus", true) {
+	if widget.settings.displayResponseStatus == false {
 		return ""
 	}
 
 	icon := "[gray]"
 
-	switch calEvent.ResponseFor(wtf.Config.UString("wtf.mods.gcal.email")) {
+	switch calEvent.ResponseFor(widget.settings.email) {
 	case "accepted":
 		return icon + "✔︎"
 	case "declined":
@@ -229,10 +229,10 @@ func (widget *Widget) responseIcon(calEvent *CalEvent) string {
 	}
 }
 
-func removeDeclined(events []*CalEvent) []*CalEvent {
+func (widget *Widget) removeDeclined(events []*CalEvent) []*CalEvent {
 	var ret []*CalEvent
 	for _, e := range events {
-		if e.ResponseFor(wtf.Config.UString("wtf.mods.gcal.email")) != "declined" {
+		if e.ResponseFor(widget.settings.email) != "declined" {
 			ret = append(ret, e)
 		}
 	}

--- a/modules/gcal/display.go
+++ b/modules/gcal/display.go
@@ -32,7 +32,7 @@ func (widget *Widget) display() {
 	widget.mutex.Lock()
 	defer widget.mutex.Unlock()
 
-	widget.View.SetTitle(widget.ContextualTitle(widget.Name()))
+	widget.View.SetTitle(widget.ContextualTitle(widget.settings.common.Title))
 	widget.View.SetText(widget.contentFrom(widget.calEvents))
 }
 

--- a/modules/gcal/settings.go
+++ b/modules/gcal/settings.go
@@ -1,0 +1,57 @@
+package gcal
+
+import (
+	"github.com/olebedev/config"
+	"github.com/wtfutil/wtf/cfg"
+)
+
+type colors struct {
+	day         string
+	description string
+	past        string
+	title       string
+
+	highlights []interface{}
+}
+
+type Settings struct {
+	colors
+	common *cfg.Common
+
+	conflictIcon          string
+	currentIcon           string
+	displayResponseStatus bool
+	email                 string
+	eventCount            int
+	multiCalendar         bool
+	secretFile            string
+	showDeclined          bool
+	textInterval          int
+	withLocation          bool
+}
+
+func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
+	localConfig, _ := ymlConfig.Get("wtf.mods.gcal")
+
+	settings := Settings{
+		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+
+		conflictIcon:          localConfig.UString("conflictIcon", "🚨"),
+		currentIcon:           localConfig.UString("currentIcon", "🔸"),
+		displayResponseStatus: localConfig.UBool("displayResponseStatus", true),
+		email:                 localConfig.UString("email", ""),
+		eventCount:            localConfig.UInt("eventCount", 10),
+		multiCalendar:         localConfig.UBool("multiCalendar", false),
+		secretFile:            localConfig.UString("secretFile", ""),
+		showDeclined:          localConfig.UBool("showDeclined", false),
+		textInterval:          localConfig.UInt("textInterval", 30),
+		withLocation:          localConfig.UBool("withLocation", true),
+	}
+
+	settings.colors.day = localConfig.UString("colors.day", "forestgreen")
+	settings.colors.description = localConfig.UString("colors.description", "white")
+	settings.colors.past = localConfig.UString("colors.past", "gray")
+	settings.colors.title = localConfig.UString("colors.title", "white")
+
+	return &settings
+}

--- a/modules/gcal/settings.go
+++ b/modules/gcal/settings.go
@@ -5,6 +5,8 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
+const configKey = "gcal"
+
 type colors struct {
 	day         string
 	description string
@@ -30,11 +32,11 @@ type Settings struct {
 	withLocation          bool
 }
 
-func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
-	localConfig, _ := ymlConfig.Get("wtf.mods.gcal")
+func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
+	localConfig, _ := ymlConfig.Get("wtf.mods." + configKey)
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
 
 		conflictIcon:          localConfig.UString("conflictIcon", "🚨"),
 		currentIcon:           localConfig.UString("currentIcon", "🔸"),

--- a/modules/gcal/widget.go
+++ b/modules/gcal/widget.go
@@ -20,7 +20,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, "Calendar", "gcal", true),
+		TextWidget: wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, true),
 
 		app:      app,
 		ch:       make(chan struct{}),

--- a/modules/gcal/widget.go
+++ b/modules/gcal/widget.go
@@ -20,7 +20,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, true),
+		TextWidget: wtf.NewTextWidget(app, settings.common, true),
 
 		app:      app,
 		ch:       make(chan struct{}),

--- a/modules/gerrit/display.go
+++ b/modules/gerrit/display.go
@@ -21,10 +21,10 @@ func (widget *Widget) display() {
 	str = str + widget.displayStats(project)
 	str = str + "\n"
 	str = str + " [red]Open Incoming Reviews[white]\n"
-	str = str + widget.displayMyIncomingReviews(project, wtf.Config.UString("wtf.mods.gerrit.username"))
+	str = str + widget.displayMyIncomingReviews(project, widget.settings.username)
 	str = str + "\n"
 	str = str + " [red]My Outgoing Reviews[white]\n"
-	str = str + widget.displayMyOutgoingReviews(project, wtf.Config.UString("wtf.mods.gerrit.username"))
+	str = str + widget.displayMyOutgoingReviews(project, widget.settings.username)
 
 	widget.View.SetText(str)
 }

--- a/modules/gerrit/gerrit_repo.go
+++ b/modules/gerrit/gerrit_repo.go
@@ -2,7 +2,6 @@ package gerrit
 
 import (
 	glb "github.com/andygrunwald/go-gerrit"
-	"github.com/wtfutil/wtf/wtf"
 )
 
 type GerritProject struct {
@@ -25,8 +24,7 @@ func NewGerritProject(path string, gerrit *glb.Client) *GerritProject {
 }
 
 // Refresh reloads the gerrit data via the Gerrit API
-func (project *GerritProject) Refresh() {
-	username := wtf.Config.UString("wtf.mods.gerrit.username")
+func (project *GerritProject) Refresh(username string) {
 	project.Changes, _ = project.loadChanges()
 
 	project.ReviewCount = project.countReviews(project.Changes)

--- a/modules/gerrit/settings.go
+++ b/modules/gerrit/settings.go
@@ -1,0 +1,45 @@
+package gerrit
+
+import (
+	"os"
+
+	"github.com/olebedev/config"
+	"github.com/wtfutil/wtf/cfg"
+)
+
+type colors struct {
+	rows struct {
+		even string
+		odd  string
+	}
+}
+
+type Settings struct {
+	colors
+	common *cfg.Common
+
+	domain                  string
+	password                string
+	projects                []interface{}
+	username                string
+	verifyServerCertificate bool
+}
+
+func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
+	localConfig, _ := ymlConfig.Get("wtf.mods.gerrit")
+
+	settings := Settings{
+		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+
+		domain:                  localConfig.UString("domain", ""),
+		password:                localConfig.UString("password", os.Getenv("WTF_GERRIT_PASSWORD")),
+		projects:                localConfig.UList("projects"),
+		username:                localConfig.UString("username", ""),
+		verifyServerCertificate: localConfig.UBool("verifyServerCertificate", true),
+	}
+
+	settings.colors.rows.even = localConfig.UString("colors.rows.even", "white")
+	settings.colors.rows.odd = localConfig.UString("colors.rows.odd", "blue")
+
+	return &settings
+}

--- a/modules/gerrit/settings.go
+++ b/modules/gerrit/settings.go
@@ -14,6 +14,8 @@ type colors struct {
 	}
 }
 
+const configKey = "gerrit"
+
 type Settings struct {
 	colors
 	common *cfg.Common
@@ -25,11 +27,11 @@ type Settings struct {
 	verifyServerCertificate bool
 }
 
-func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
-	localConfig, _ := ymlConfig.Get("wtf.mods.gerrit")
+func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
+	localConfig, _ := ymlConfig.Get("wtf.mods." + configKey)
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
 
 		domain:                  localConfig.UString("domain", ""),
 		password:                localConfig.UString("password", os.Getenv("WTF_GERRIT_PASSWORD")),

--- a/modules/gerrit/widget.go
+++ b/modules/gerrit/widget.go
@@ -49,7 +49,7 @@ var (
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
 		HelpfulWidget: wtf.NewHelpfulWidget(app, pages, HelpText),
-		TextWidget:    wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, true),
+		TextWidget:    wtf.NewTextWidget(app, settings.common, true),
 
 		Idx:      0,
 		settings: settings,

--- a/modules/gerrit/widget.go
+++ b/modules/gerrit/widget.go
@@ -4,7 +4,6 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net/http"
-	// "os"
 	"regexp"
 
 	glb "github.com/andygrunwald/go-gerrit"

--- a/modules/gerrit/widget.go
+++ b/modules/gerrit/widget.go
@@ -49,7 +49,7 @@ var (
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
 		HelpfulWidget: wtf.NewHelpfulWidget(app, pages, HelpText),
-		TextWidget:    wtf.NewTextWidget(app, "Gerrit", "gerrit", true),
+		TextWidget:    wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, true),
 
 		Idx:      0,
 		settings: settings,

--- a/modules/gerrit/widget.go
+++ b/modules/gerrit/widget.go
@@ -4,7 +4,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net/http"
-	"os"
+	// "os"
 	"regexp"
 
 	glb "github.com/andygrunwald/go-gerrit"
@@ -40,18 +40,20 @@ type Widget struct {
 	GerritProjects []*GerritProject
 	Idx            int
 	selected       int
+	settings       *Settings
 }
 
 var (
 	GerritURLPattern = regexp.MustCompile(`^(http|https)://(.*)$`)
 )
 
-func NewWidget(app *tview.Application, pages *tview.Pages) *Widget {
+func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
 		HelpfulWidget: wtf.NewHelpfulWidget(app, pages, HelpText),
 		TextWidget:    wtf.NewTextWidget(app, "Gerrit", "gerrit", true),
 
-		Idx: 0,
+		Idx:      0,
+		settings: settings,
 	}
 
 	widget.HelpfulWidget.SetView(widget.View)
@@ -65,31 +67,27 @@ func NewWidget(app *tview.Application, pages *tview.Pages) *Widget {
 /* -------------------- Exported Functions -------------------- */
 
 func (widget *Widget) Refresh() {
-	baseURL := wtf.Config.UString("wtf.mods.gerrit.domain")
-	username := wtf.Config.UString("wtf.mods.gerrit.username")
-
-	password := wtf.Config.UString(
-		"wtf.mods.gerrit.password",
-		os.Getenv("WTF_GERRIT_PASSWORD"),
-	)
-
-	verifyServerCertificate := wtf.Config.UBool("wtf.mods.gerrit.verifyServerCertificate", true)
-
-	httpClient := &http.Client{Transport: &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: !verifyServerCertificate,
+	httpClient := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: !widget.settings.verifyServerCertificate,
+			},
+			Proxy: http.ProxyFromEnvironment,
 		},
-		Proxy: http.ProxyFromEnvironment,
-	},
 	}
 
-	gerritUrl := baseURL
-	submatches := GerritURLPattern.FindAllStringSubmatch(baseURL, -1)
+	gerritUrl := widget.settings.domain
+	submatches := GerritURLPattern.FindAllStringSubmatch(widget.settings.domain, -1)
 
 	if len(submatches) > 0 && len(submatches[0]) > 2 {
 		submatch := submatches[0]
 		gerritUrl = fmt.Sprintf(
-			"%s://%s:%s@%s", submatch[1], username, password, submatch[2])
+			"%s://%s:%s@%s",
+			submatch[1],
+			widget.settings.username,
+			widget.settings.password,
+			submatch[2],
+		)
 	}
 	gerrit, err := glb.NewClient(gerritUrl, httpClient)
 	if err != nil {
@@ -99,10 +97,10 @@ func (widget *Widget) Refresh() {
 		return
 	}
 	widget.gerrit = gerrit
-	widget.GerritProjects = widget.buildProjectCollection(wtf.Config.UList("wtf.mods.gerrit.projects"))
+	widget.GerritProjects = widget.buildProjectCollection(widget.settings.projects)
 
 	for _, project := range widget.GerritProjects {
-		project.Refresh()
+		project.Refresh(widget.settings.username)
 	}
 
 	widget.display()
@@ -159,7 +157,7 @@ func (widget *Widget) openReview() {
 		} else {
 			change = project.OutgoingReviews[sel-len(project.IncomingReviews)]
 		}
-		wtf.OpenFile(fmt.Sprintf("%s/%s/%d", wtf.Config.UString("wtf.mods.gerrit.domain"), "#/c", change.Number))
+		wtf.OpenFile(fmt.Sprintf("%s/%s/%d", widget.settings.domain, "#/c", change.Number))
 	}
 }
 

--- a/modules/git/git_repo.go
+++ b/modules/git/git_repo.go
@@ -16,12 +16,12 @@ type GitRepo struct {
 	Path         string
 }
 
-func NewGitRepo(repoPath string) *GitRepo {
+func NewGitRepo(repoPath string, commitCount int, commitFormat, dateFormat string) *GitRepo {
 	repo := GitRepo{Path: repoPath}
 
 	repo.Branch = repo.branch()
 	repo.ChangedFiles = repo.changedFiles()
-	repo.Commits = repo.commits()
+	repo.Commits = repo.commits(commitCount, commitFormat, dateFormat)
 	repo.Repository = strings.TrimSpace(repo.repository())
 
 	return &repo
@@ -49,13 +49,9 @@ func (repo *GitRepo) changedFiles() []string {
 	return data
 }
 
-func (repo *GitRepo) commits() []string {
-	numStr := fmt.Sprintf("-n %d", wtf.Config.UInt("wtf.mods.git.commitCount", 10))
-
-	dateFormat := wtf.Config.UString("wtf.mods.git.dateFormat", "%b %d, %Y")
+func (repo *GitRepo) commits(commitCount int, commitFormat, dateFormat string) []string {
 	dateStr := fmt.Sprintf("--date=format:\"%s\"", dateFormat)
-
-	commitFormat := wtf.Config.UString("wtf.mods.git.commitFormat", "[forestgreen]%h [white]%s [grey]%an on %cd[white]")
+	numStr := fmt.Sprintf("-n %d", commitCount)
 	commitStr := fmt.Sprintf("--pretty=format:\"%s\"", commitFormat)
 
 	arg := []string{repo.gitDir(), repo.workTree(), "log", dateStr, numStr, commitStr}

--- a/modules/git/settings.go
+++ b/modules/git/settings.go
@@ -1,0 +1,30 @@
+package git
+
+import (
+	"github.com/olebedev/config"
+	"github.com/wtfutil/wtf/cfg"
+)
+
+type Settings struct {
+	common *cfg.Common
+
+	commitCount  int
+	commitFormat string
+	dateFormat   string
+	repositories []interface{}
+}
+
+func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
+	localConfig, _ := ymlConfig.Get("wtf.mods.git")
+
+	settings := Settings{
+		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+
+		commitCount:  localConfig.UInt("commitCount", 10),
+		commitFormat: localConfig.UString("commitFormat", "[forestgreen]%h [white]%s [grey]%an on %cd[white]"),
+		dateFormat:   localConfig.UString("dateFormat", "%b %d, %Y"),
+		repositories: localConfig.UList("repositories"),
+	}
+
+	return &settings
+}

--- a/modules/git/settings.go
+++ b/modules/git/settings.go
@@ -5,6 +5,8 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
+const configKey = "git"
+
 type Settings struct {
 	common *cfg.Common
 
@@ -14,11 +16,11 @@ type Settings struct {
 	repositories []interface{}
 }
 
-func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
-	localConfig, _ := ymlConfig.Get("wtf.mods.git")
+func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
+	localConfig, _ := ymlConfig.Get("wtf.mods." + configKey)
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
 
 		commitCount:  localConfig.UInt("commitCount", 10),
 		commitFormat: localConfig.UString("commitFormat", "[forestgreen]%h [white]%s [grey]%an on %cd[white]"),

--- a/modules/git/widget.go
+++ b/modules/git/widget.go
@@ -42,8 +42,8 @@ type Widget struct {
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
 		HelpfulWidget:     wtf.NewHelpfulWidget(app, pages, HelpText),
-		MultiSourceWidget: wtf.NewMultiSourceWidget("git", "repository", "repositories"),
-		TextWidget:        wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, true),
+		MultiSourceWidget: wtf.NewMultiSourceWidget(settings.common.ConfigKey, "repository", "repositories"),
+		TextWidget:        wtf.NewTextWidget(app, settings.common, true),
 
 		app:      app,
 		pages:    pages,

--- a/modules/git/widget.go
+++ b/modules/git/widget.go
@@ -43,7 +43,7 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 	widget := Widget{
 		HelpfulWidget:     wtf.NewHelpfulWidget(app, pages, HelpText),
 		MultiSourceWidget: wtf.NewMultiSourceWidget("git", "repository", "repositories"),
-		TextWidget:        wtf.NewTextWidget(app, "Git", "git", true),
+		TextWidget:        wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, true),
 
 		app:      app,
 		pages:    pages,

--- a/modules/github/display.go
+++ b/modules/github/display.go
@@ -21,16 +21,16 @@ func (widget *Widget) display() {
 	str = str + widget.displayStats(repo)
 	str = str + "\n"
 	str = str + " [red]Open Review Requests[white]\n"
-	str = str + widget.displayMyReviewRequests(repo, wtf.Config.UString("wtf.mods.github.username"))
+	str = str + widget.displayMyReviewRequests(repo, widget.settings.username)
 	str = str + "\n"
 	str = str + " [red]My Pull Requests[white]\n"
-	str = str + widget.displayMyPullRequests(repo, wtf.Config.UString("wtf.mods.github.username"))
+	str = str + widget.displayMyPullRequests(repo, widget.settings.username)
 
 	widget.View.SetText(str)
 }
 
 func (widget *Widget) displayMyPullRequests(repo *GithubRepo, username string) string {
-	prs := repo.myPullRequests(username)
+	prs := repo.myPullRequests(username, widget.settings.enableStatus)
 
 	if len(prs) == 0 {
 		return " [grey]none[white]\n"
@@ -38,7 +38,7 @@ func (widget *Widget) displayMyPullRequests(repo *GithubRepo, username string) s
 
 	str := ""
 	for _, pr := range prs {
-		str = str + fmt.Sprintf(" %s[green]%4d[white] %s\n", mergeString(pr), *pr.Number, *pr.Title)
+		str = str + fmt.Sprintf(" %s[green]%4d[white] %s\n", widget.mergeString(pr), *pr.Number, *pr.Title)
 	}
 
 	return str
@@ -74,10 +74,6 @@ func (widget *Widget) title(repo *GithubRepo) string {
 	return fmt.Sprintf("[green]%s - %s[white]", repo.Owner, repo.Name)
 }
 
-func showStatus() bool {
-	return wtf.Config.UBool("wtf.mods.github.enableStatus", false)
-}
-
 var mergeIcons = map[string]string{
 	"dirty":    "[red]![white] ",
 	"clean":    "[green]✔[white] ",
@@ -85,8 +81,8 @@ var mergeIcons = map[string]string{
 	"blocked":  "[red]✖[white] ",
 }
 
-func mergeString(pr *github.PullRequest) string {
-	if !showStatus() {
+func (widget *Widget) mergeString(pr *github.PullRequest) string {
+	if !widget.settings.enableStatus {
 		return ""
 	}
 	if str, ok := mergeIcons[pr.GetMergeableState()]; ok {

--- a/modules/github/settings.go
+++ b/modules/github/settings.go
@@ -7,6 +7,8 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
+const configKey = "github"
+
 type Settings struct {
 	common *cfg.Common
 
@@ -18,11 +20,11 @@ type Settings struct {
 	username     string
 }
 
-func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
-	localConfig, _ := ymlConfig.Get("wtf.mods.github")
+func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
+	localConfig, _ := ymlConfig.Get("wtf.mods." + configKey)
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
 
 		apiKey:       localConfig.UString("apiKey", os.Getenv("WTF_GITHUB_TOKEN")),
 		baseURL:      localConfig.UString("baseURL", os.Getenv("WTF_GITHUB_BASE_URL")),

--- a/modules/github/settings.go
+++ b/modules/github/settings.go
@@ -1,0 +1,36 @@
+package github
+
+import (
+	"os"
+
+	"github.com/olebedev/config"
+	"github.com/wtfutil/wtf/cfg"
+)
+
+type Settings struct {
+	common *cfg.Common
+
+	apiKey       string
+	baseURL      string
+	enableStatus bool
+	repositories map[string]interface{}
+	uploadURL    string
+	username     string
+}
+
+func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
+	localConfig, _ := ymlConfig.Get("wtf.mods.github")
+
+	settings := Settings{
+		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+
+		apiKey:       localConfig.UString("apiKey", os.Getenv("WTF_GITHUB_TOKEN")),
+		baseURL:      localConfig.UString("baseURL", os.Getenv("WTF_GITHUB_BASE_URL")),
+		enableStatus: localConfig.UBool("enableStatus", false),
+		repositories: localConfig.UMap("repositories"),
+		uploadURL:    localConfig.UString("uploadURL", os.Getenv("WTF_GITHUB_UPLOAD_URL")),
+		username:     localConfig.UString("username"),
+	}
+
+	return &settings
+}

--- a/modules/github/widget.go
+++ b/modules/github/widget.go
@@ -32,7 +32,7 @@ type Widget struct {
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
 		HelpfulWidget: wtf.NewHelpfulWidget(app, pages, HelpText),
-		TextWidget:    wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, true),
+		TextWidget:    wtf.NewTextWidget(app, settings.common, true),
 
 		Idx:      0,
 		settings: settings,

--- a/modules/github/widget.go
+++ b/modules/github/widget.go
@@ -26,17 +26,19 @@ type Widget struct {
 
 	GithubRepos []*GithubRepo
 	Idx         int
+	settings    *Settings
 }
 
-func NewWidget(app *tview.Application, pages *tview.Pages) *Widget {
+func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
 		HelpfulWidget: wtf.NewHelpfulWidget(app, pages, HelpText),
 		TextWidget:    wtf.NewTextWidget(app, "GitHub", "github", true),
 
-		Idx: 0,
+		Idx:      0,
+		settings: settings,
 	}
 
-	widget.GithubRepos = widget.buildRepoCollection(wtf.Config.UMap("wtf.mods.github.repositories"))
+	widget.GithubRepos = widget.buildRepoCollection(widget.settings.repositories)
 
 	widget.HelpfulWidget.SetView(widget.View)
 	widget.View.SetInputCapture(widget.keyboardIntercept)
@@ -78,7 +80,14 @@ func (widget *Widget) buildRepoCollection(repoData map[string]interface{}) []*Gi
 	githubRepos := []*GithubRepo{}
 
 	for name, owner := range repoData {
-		repo := NewGithubRepo(name, owner.(string))
+		repo := NewGithubRepo(
+			name,
+			owner.(string),
+			widget.settings.apiKey,
+			widget.settings.baseURL,
+			widget.settings.uploadURL,
+		)
+
 		githubRepos = append(githubRepos, repo)
 	}
 

--- a/modules/github/widget.go
+++ b/modules/github/widget.go
@@ -32,7 +32,7 @@ type Widget struct {
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
 		HelpfulWidget: wtf.NewHelpfulWidget(app, pages, HelpText),
-		TextWidget:    wtf.NewTextWidget(app, "GitHub", "github", true),
+		TextWidget:    wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, true),
 
 		Idx:      0,
 		settings: settings,

--- a/modules/gitlab/display.go
+++ b/modules/gitlab/display.go
@@ -21,10 +21,10 @@ func (widget *Widget) display() {
 	str = str + widget.displayStats(project)
 	str = str + "\n"
 	str = str + " [red]Open Approval Requests[white]\n"
-	str = str + widget.displayMyApprovalRequests(project, wtf.Config.UString("wtf.mods.gitlab.username"))
+	str = str + widget.displayMyApprovalRequests(project, widget.settings.username)
 	str = str + "\n"
 	str = str + " [red]My Merge Requests[white]\n"
-	str = str + widget.displayMyMergeRequests(project, wtf.Config.UString("wtf.mods.gitlab.username"))
+	str = str + widget.displayMyMergeRequests(project, widget.settings.username)
 
 	widget.View.SetText(str)
 }

--- a/modules/gitlab/settings.go
+++ b/modules/gitlab/settings.go
@@ -7,6 +7,8 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
+const configKey = "gitlab"
+
 type Settings struct {
 	common *cfg.Common
 
@@ -16,11 +18,11 @@ type Settings struct {
 	username string
 }
 
-func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
-	localConfig, _ := ymlConfig.Get("wtf.mods.gitlab")
+func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
+	localConfig, _ := ymlConfig.Get("wtf.mods." + configKey)
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
 
 		apiKey:   localConfig.UString("apiKey", os.Getenv("WTF_GITLAB_TOKEN")),
 		domain:   localConfig.UString("domain"),

--- a/modules/gitlab/settings.go
+++ b/modules/gitlab/settings.go
@@ -1,0 +1,32 @@
+package gitlab
+
+import (
+	"os"
+
+	"github.com/olebedev/config"
+	"github.com/wtfutil/wtf/cfg"
+)
+
+type Settings struct {
+	common *cfg.Common
+
+	apiKey   string
+	domain   string
+	projects map[string]interface{}
+	username string
+}
+
+func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
+	localConfig, _ := ymlConfig.Get("wtf.mods.gitlab")
+
+	settings := Settings{
+		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+
+		apiKey:   localConfig.UString("apiKey", os.Getenv("WTF_GITLAB_TOKEN")),
+		domain:   localConfig.UString("domain"),
+		projects: localConfig.UMap("projects"),
+		username: localConfig.UString("username"),
+	}
+
+	return &settings
+}

--- a/modules/gitlab/widget.go
+++ b/modules/gitlab/widget.go
@@ -39,7 +39,7 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 
 	widget := Widget{
 		HelpfulWidget: wtf.NewHelpfulWidget(app, pages, HelpText),
-		TextWidget:    wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, true),
+		TextWidget:    wtf.NewTextWidget(app, settings.common, true),
 
 		Idx:      0,
 		gitlab:   gitlab,

--- a/modules/gitlab/widget.go
+++ b/modules/gitlab/widget.go
@@ -39,7 +39,7 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 
 	widget := Widget{
 		HelpfulWidget: wtf.NewHelpfulWidget(app, pages, HelpText),
-		TextWidget:    wtf.NewTextWidget(app, "Gitlab", "gitlab", true),
+		TextWidget:    wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, true),
 
 		Idx:      0,
 		gitlab:   gitlab,

--- a/modules/gitter/client.go
+++ b/modules/gitter/client.go
@@ -5,18 +5,16 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/wtfutil/wtf/logger"
-	"github.com/wtfutil/wtf/wtf"
 	"io"
 	"io/ioutil"
 	"net/http"
-	"os"
 	"strconv"
 )
 
-func GetMessages(roomId string, numberOfMessages int) ([]Message, error) {
+func GetMessages(roomId string, numberOfMessages int, apiToken string) ([]Message, error) {
 	var messages []Message
 
-	resp, err := apiRequest("rooms/" + roomId + "/chatMessages?limit=" + strconv.Itoa(numberOfMessages))
+	resp, err := apiRequest("rooms/"+roomId+"/chatMessages?limit="+strconv.Itoa(numberOfMessages), apiToken)
 	if err != nil {
 		return nil, err
 	}
@@ -26,10 +24,10 @@ func GetMessages(roomId string, numberOfMessages int) ([]Message, error) {
 	return messages, nil
 }
 
-func GetRoom(roomUri string) (*Room, error) {
+func GetRoom(roomUri, apiToken string) (*Room, error) {
 	var rooms Rooms
 
-	resp, err := apiRequest("rooms?q=" + roomUri)
+	resp, err := apiRequest("rooms?q="+roomUri, apiToken)
 	if err != nil {
 		return nil, err
 	}
@@ -52,9 +50,9 @@ var (
 	apiBaseURL = "https://api.gitter.im/v1/"
 )
 
-func apiRequest(path string) (*http.Response, error) {
+func apiRequest(path, apiToken string) (*http.Response, error) {
 	req, err := http.NewRequest("GET", apiBaseURL+path, nil)
-	bearer := fmt.Sprintf("Bearer %s", apiToken())
+	bearer := fmt.Sprintf("Bearer %s", apiToken)
 	req.Header.Add("Authorization", bearer)
 
 	httpClient := &http.Client{}
@@ -85,11 +83,4 @@ func parseJson(obj interface{}, text io.Reader) {
 			panic(err)
 		}
 	}
-}
-
-func apiToken() string {
-	return wtf.Config.UString(
-		"wtf.mods.gitter.apiToken",
-		os.Getenv("WTF_GITTER_API_TOKEN"),
-	)
 }

--- a/modules/gitter/settings.go
+++ b/modules/gitter/settings.go
@@ -1,0 +1,30 @@
+package gitter
+
+import (
+	"os"
+
+	"github.com/olebedev/config"
+	"github.com/wtfutil/wtf/cfg"
+)
+
+type Settings struct {
+	common *cfg.Common
+
+	apiToken         string
+	numberOfMessages int
+	roomURI          string
+}
+
+func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
+	localConfig, _ := ymlConfig.Get("wtf.mods.gitter")
+
+	settings := Settings{
+		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+
+		apiToken:         localConfig.UString("apiToken", os.Getenv("WTF_GITTER_API_TOKEN")),
+		numberOfMessages: localConfig.UInt("numberOfMessages", 10),
+		roomURI:          localConfig.UString("roomUri", "wtfutil/Lobby"),
+	}
+
+	return &settings
+}

--- a/modules/gitter/settings.go
+++ b/modules/gitter/settings.go
@@ -7,6 +7,8 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
+const configKey = "gitter"
+
 type Settings struct {
 	common *cfg.Common
 
@@ -15,11 +17,11 @@ type Settings struct {
 	roomURI          string
 }
 
-func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
-	localConfig, _ := ymlConfig.Get("wtf.mods.gitter")
+func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
+	localConfig, _ := ymlConfig.Get("wtf.mods." + configKey)
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
 
 		apiToken:         localConfig.UString("apiToken", os.Getenv("WTF_GITTER_API_TOKEN")),
 		numberOfMessages: localConfig.UInt("numberOfMessages", 10),

--- a/modules/gitter/widget.go
+++ b/modules/gitter/widget.go
@@ -26,12 +26,15 @@ type Widget struct {
 
 	messages []Message
 	selected int
+	settings *Settings
 }
 
-func NewWidget(app *tview.Application, pages *tview.Pages) *Widget {
+func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
 		HelpfulWidget: wtf.NewHelpfulWidget(app, pages, HelpText),
 		TextWidget:    wtf.NewTextWidget(app, "Gitter", "gitter", true),
+
+		settings: settings,
 	}
 
 	widget.HelpfulWidget.SetView(widget.View)
@@ -51,7 +54,7 @@ func (widget *Widget) Refresh() {
 		return
 	}
 
-	room, err := GetRoom(wtf.Config.UString("wtf.mods.gitter.roomUri", "wtfutil/Lobby"))
+	room, err := GetRoom(widget.settings.roomURI, widget.settings.apiToken)
 	if err != nil {
 		widget.View.SetWrap(true)
 		widget.View.SetTitle(widget.Name())
@@ -63,7 +66,7 @@ func (widget *Widget) Refresh() {
 		return
 	}
 
-	messages, err := GetMessages(room.ID, wtf.Config.UInt("wtf.mods.gitter.numberOfMessages", 10))
+	messages, err := GetMessages(room.ID, widget.settings.numberOfMessages, widget.settings.apiToken)
 
 	if err != nil {
 		widget.View.SetWrap(true)
@@ -86,7 +89,7 @@ func (widget *Widget) display() {
 
 	widget.View.SetWrap(true)
 	widget.View.Clear()
-	widget.View.SetTitle(widget.ContextualTitle(fmt.Sprintf("%s - %s", widget.Name(), wtf.Config.UString("wtf.mods.gitter.roomUri", "wtfutil/Lobby"))))
+	widget.View.SetTitle(widget.ContextualTitle(fmt.Sprintf("%s - %s", widget.Name(), widget.settings.roomURI)))
 	widget.View.SetText(widget.contentFrom(widget.messages))
 	widget.View.Highlight(strconv.Itoa(widget.selected)).ScrollToHighlight()
 }

--- a/modules/gitter/widget.go
+++ b/modules/gitter/widget.go
@@ -32,7 +32,7 @@ type Widget struct {
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
 		HelpfulWidget: wtf.NewHelpfulWidget(app, pages, HelpText),
-		TextWidget:    wtf.NewTextWidget(app, "Gitter", "gitter", true),
+		TextWidget:    wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, true),
 
 		settings: settings,
 	}

--- a/modules/gitter/widget.go
+++ b/modules/gitter/widget.go
@@ -32,7 +32,7 @@ type Widget struct {
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
 		HelpfulWidget: wtf.NewHelpfulWidget(app, pages, HelpText),
-		TextWidget:    wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, true),
+		TextWidget:    wtf.NewTextWidget(app, settings.common, true),
 
 		settings: settings,
 	}

--- a/modules/gspreadsheets/client.go
+++ b/modules/gspreadsheets/client.go
@@ -26,10 +26,10 @@ import (
 
 /* -------------------- Exported Functions -------------------- */
 
-func Fetch() ([]*sheets.ValueRange, error) {
+func (widget *Widget) Fetch() ([]*sheets.ValueRange, error) {
 	ctx := context.Background()
 
-	secretPath, _ := wtf.ExpandHomeDir(wtf.Config.UString("wtf.mods.gspreadsheets.secretFile"))
+	secretPath, _ := wtf.ExpandHomeDir(widget.settings.secretFile)
 
 	b, err := ioutil.ReadFile(secretPath)
 	if err != nil {
@@ -51,14 +51,13 @@ func Fetch() ([]*sheets.ValueRange, error) {
 		return nil, err
 	}
 
-	cells := wtf.ToStrs(wtf.Config.UList("wtf.mods.gspreadsheets.cells.addresses"))
-	documentId := wtf.Config.UString("wtf.mods.gspreadsheets.sheetId")
+	cells := wtf.ToStrs(widget.settings.cellAddresses)
 	addresses := strings.Join(cells[:], ";")
 
 	responses := make([]*sheets.ValueRange, len(cells))
 
 	for i := 0; i < len(cells); i++ {
-		resp, err := srv.Spreadsheets.Values.Get(documentId, cells[i]).Do()
+		resp, err := srv.Spreadsheets.Values.Get(widget.settings.sheetID, cells[i]).Do()
 		if err != nil {
 			log.Fatalf("Error fetching cells %s", addresses)
 			return nil, err

--- a/modules/gspreadsheets/settings.go
+++ b/modules/gspreadsheets/settings.go
@@ -5,6 +5,8 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
+const configKey = "gspreadsheets"
+
 type colors struct {
 	values string
 }
@@ -19,11 +21,11 @@ type Settings struct {
 	sheetID       string
 }
 
-func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
-	localConfig, _ := ymlConfig.Get("wtf.mods.gspreadsheets")
+func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
+	localConfig, _ := ymlConfig.Get("wtf.mods." + configKey)
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
 
 		cellNames:  localConfig.UList("cells.names"),
 		secretFile: localConfig.UString("secretFile"),

--- a/modules/gspreadsheets/settings.go
+++ b/modules/gspreadsheets/settings.go
@@ -1,0 +1,36 @@
+package gspreadsheets
+
+import (
+	"github.com/olebedev/config"
+	"github.com/wtfutil/wtf/cfg"
+)
+
+type colors struct {
+	values string
+}
+
+type Settings struct {
+	colors
+	common *cfg.Common
+
+	cellAddresses []interface{}
+	cellNames     []interface{}
+	secretFile    string
+	sheetID       string
+}
+
+func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
+	localConfig, _ := ymlConfig.Get("wtf.mods.gspreadsheets")
+
+	settings := Settings{
+		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+
+		cellNames:  localConfig.UList("cells.names"),
+		secretFile: localConfig.UString("secretFile"),
+		sheetID:    localConfig.UString("sheetId"),
+	}
+
+	settings.colors.values = localConfig.UString("colors.values", "green")
+
+	return &settings
+}

--- a/modules/gspreadsheets/widget.go
+++ b/modules/gspreadsheets/widget.go
@@ -10,11 +10,15 @@ import (
 
 type Widget struct {
 	wtf.TextWidget
+
+	settings *Settings
 }
 
-func NewWidget(app *tview.Application) *Widget {
+func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
 		TextWidget: wtf.NewTextWidget(app, "Google Spreadsheets", "gspreadsheets", false),
+
+		settings: settings,
 	}
 
 	return &widget
@@ -23,7 +27,7 @@ func NewWidget(app *tview.Application) *Widget {
 /* -------------------- Exported Functions -------------------- */
 
 func (widget *Widget) Refresh() {
-	cells, _ := Fetch()
+	cells, _ := widget.Fetch()
 
 	widget.View.SetText(widget.contentFrom(cells))
 }
@@ -35,12 +39,11 @@ func (widget *Widget) contentFrom(valueRanges []*sheets.ValueRange) string {
 		return "error 1"
 	}
 
-	valuesColor := wtf.Config.UString("wtf.mods.gspreadsheets.colors.values", "green")
 	res := ""
 
-	cells := wtf.ToStrs(wtf.Config.UList("wtf.mods.gspreadsheets.cells.names"))
+	cells := wtf.ToStrs(widget.settings.cellNames)
 	for i := 0; i < len(valueRanges); i++ {
-		res = res + fmt.Sprintf("%s\t[%s]%s\n", cells[i], valuesColor, valueRanges[i].Values[0][0])
+		res = res + fmt.Sprintf("%s\t[%s]%s\n", cells[i], widget.settings.colors.values, valueRanges[i].Values[0][0])
 	}
 
 	return res

--- a/modules/gspreadsheets/widget.go
+++ b/modules/gspreadsheets/widget.go
@@ -16,7 +16,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, false),
+		TextWidget: wtf.NewTextWidget(app, settings.common, false),
 
 		settings: settings,
 	}

--- a/modules/gspreadsheets/widget.go
+++ b/modules/gspreadsheets/widget.go
@@ -16,7 +16,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, "Google Spreadsheets", "gspreadsheets", false),
+		TextWidget: wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, false),
 
 		settings: settings,
 	}

--- a/modules/hackernews/settings.go
+++ b/modules/hackernews/settings.go
@@ -1,0 +1,26 @@
+package hackernews
+
+import (
+	"github.com/olebedev/config"
+	"github.com/wtfutil/wtf/cfg"
+)
+
+type Settings struct {
+	common *cfg.Common
+
+	numberOfStories int
+	storyType       string
+}
+
+func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
+	localConfig, _ := ymlConfig.Get("wtf.mods.hackernews")
+
+	settings := Settings{
+		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+
+		numberOfStories: localConfig.UInt("numberOfStories", 10),
+		storyType:       localConfig.UString("storyType", "top"),
+	}
+
+	return &settings
+}

--- a/modules/hackernews/settings.go
+++ b/modules/hackernews/settings.go
@@ -5,6 +5,8 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
+const configKey = "hackernews"
+
 type Settings struct {
 	common *cfg.Common
 
@@ -12,11 +14,11 @@ type Settings struct {
 	storyType       string
 }
 
-func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
-	localConfig, _ := ymlConfig.Get("wtf.mods.hackernews")
+func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
+	localConfig, _ := ymlConfig.Get("wtf.mods." + configKey)
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
 
 		numberOfStories: localConfig.UInt("numberOfStories", 10),
 		storyType:       localConfig.UString("storyType", "top"),

--- a/modules/hackernews/widget.go
+++ b/modules/hackernews/widget.go
@@ -32,12 +32,15 @@ type Widget struct {
 
 	stories  []Story
 	selected int
+	settings *Settings
 }
 
-func NewWidget(app *tview.Application, pages *tview.Pages) *Widget {
+func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
 		HelpfulWidget: wtf.NewHelpfulWidget(app, pages, HelpText),
 		TextWidget:    wtf.NewTextWidget(app, "Hacker News", "hackernews", true),
+
+		settings: settings,
 	}
 
 	widget.HelpfulWidget.SetView(widget.View)
@@ -57,7 +60,7 @@ func (widget *Widget) Refresh() {
 		return
 	}
 
-	storyIds, err := GetStories(wtf.Config.UString("wtf.mods.hackernews.storyType", "top"))
+	storyIds, err := GetStories(widget.settings.storyType)
 	if storyIds == nil {
 		return
 	}
@@ -68,8 +71,7 @@ func (widget *Widget) Refresh() {
 		widget.View.SetText(err.Error())
 	} else {
 		var stories []Story
-		numberOfStoriesToDisplay := wtf.Config.UInt("wtf.mods.hackernews.numberOfStories", 10)
-		for idx := 0; idx < numberOfStoriesToDisplay; idx++ {
+		for idx := 0; idx < widget.settings.numberOfStories; idx++ {
 			story, e := GetStory(storyIds[idx])
 			if e != nil {
 				panic(e)
@@ -94,7 +96,7 @@ func (widget *Widget) display() {
 	widget.View.SetWrap(false)
 
 	widget.View.Clear()
-	widget.View.SetTitle(widget.ContextualTitle(fmt.Sprintf("%s - %sstories", widget.Name(), wtf.Config.UString("wtf.mods.hackernews.storyType", "top"))))
+	widget.View.SetTitle(widget.ContextualTitle(fmt.Sprintf("%s - %sstories", widget.Name(), widget.settings.storyType)))
 	widget.View.SetText(widget.contentFrom(widget.stories))
 	widget.View.Highlight(strconv.Itoa(widget.selected)).ScrollToHighlight()
 }

--- a/modules/hackernews/widget.go
+++ b/modules/hackernews/widget.go
@@ -38,7 +38,7 @@ type Widget struct {
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
 		HelpfulWidget: wtf.NewHelpfulWidget(app, pages, HelpText),
-		TextWidget:    wtf.NewTextWidget(app, "Hacker News", "hackernews", true),
+		TextWidget:    wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, true),
 
 		settings: settings,
 	}

--- a/modules/hackernews/widget.go
+++ b/modules/hackernews/widget.go
@@ -38,7 +38,7 @@ type Widget struct {
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
 		HelpfulWidget: wtf.NewHelpfulWidget(app, pages, HelpText),
-		TextWidget:    wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, true),
+		TextWidget:    wtf.NewTextWidget(app, settings.common, true),
 
 		settings: settings,
 	}

--- a/modules/ipaddresses/ipapi/settings.go
+++ b/modules/ipaddresses/ipapi/settings.go
@@ -1,0 +1,29 @@
+package ipapi
+
+import (
+	"github.com/olebedev/config"
+	"github.com/wtfutil/wtf/cfg"
+)
+
+type colors struct {
+	name  string
+	value string
+}
+
+type Settings struct {
+	colors
+	common *cfg.Common
+}
+
+func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
+	localConfig, _ := ymlConfig.Get("wtf.mods.ipapi")
+
+	settings := Settings{
+		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+	}
+
+	settings.colors.name = localConfig.UString("colors.name", "red")
+	settings.colors.value = localConfig.UString("colors.value", "white")
+
+	return &settings
+}

--- a/modules/ipaddresses/ipapi/settings.go
+++ b/modules/ipaddresses/ipapi/settings.go
@@ -5,6 +5,8 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
+const configKey = "ipapi"
+
 type colors struct {
 	name  string
 	value string
@@ -15,11 +17,11 @@ type Settings struct {
 	common *cfg.Common
 }
 
-func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
-	localConfig, _ := ymlConfig.Get("wtf.mods.ipapi")
+func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
+	localConfig, _ := ymlConfig.Get("wtf.mods." + configKey)
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
 	}
 
 	settings.colors.name = localConfig.UString("colors.name", "red")

--- a/modules/ipaddresses/ipapi/widget.go
+++ b/modules/ipaddresses/ipapi/widget.go
@@ -15,10 +15,9 @@ import (
 // Widget widget struct
 type Widget struct {
 	wtf.TextWidget
-	result string
-	colors struct {
-		name, value string
-	}
+
+	result   string
+	settings *Settings
 }
 
 type ipinfo struct {
@@ -37,14 +36,14 @@ type ipinfo struct {
 }
 
 // NewWidget constructor
-func NewWidget(app *tview.Application) *Widget {
+func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
 		TextWidget: wtf.NewTextWidget(app, "IPInfo", "ipapi", false),
+
+		settings: settings,
 	}
 
 	widget.View.SetWrap(false)
-
-	widget.config()
 
 	return &widget
 }
@@ -80,13 +79,6 @@ func (widget *Widget) ipinfo() {
 	widget.setResult(&info)
 }
 
-// read module configs
-func (widget *Widget) config() {
-	nameColor, valueColor := wtf.Config.UString("wtf.mods.ipinfo.colors.name", "red"), wtf.Config.UString("wtf.mods.ipinfo.colors.value", "white")
-	widget.colors.name = nameColor
-	widget.colors.value = valueColor
-}
-
 func (widget *Widget) setResult(info *ipinfo) {
 	resultTemplate, _ := template.New("ipinfo_result").Parse(
 		formatableText("IP Address", "Ip") +
@@ -104,8 +96,8 @@ func (widget *Widget) setResult(info *ipinfo) {
 	resultBuffer := new(bytes.Buffer)
 
 	resultTemplate.Execute(resultBuffer, map[string]string{
-		"nameColor":    widget.colors.name,
-		"valueColor":   widget.colors.value,
+		"nameColor":    widget.settings.colors.name,
+		"valueColor":   widget.settings.colors.value,
 		"Ip":           info.Query,
 		"ISP":          info.ISP,
 		"AS":           info.AS,

--- a/modules/ipaddresses/ipapi/widget.go
+++ b/modules/ipaddresses/ipapi/widget.go
@@ -38,7 +38,7 @@ type ipinfo struct {
 // NewWidget constructor
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, "IPInfo", "ipapi", false),
+		TextWidget: wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, false),
 
 		settings: settings,
 	}

--- a/modules/ipaddresses/ipapi/widget.go
+++ b/modules/ipaddresses/ipapi/widget.go
@@ -38,7 +38,7 @@ type ipinfo struct {
 // NewWidget constructor
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, false),
+		TextWidget: wtf.NewTextWidget(app, settings.common, false),
 
 		settings: settings,
 	}

--- a/modules/ipaddresses/ipinfo/settings.go
+++ b/modules/ipaddresses/ipinfo/settings.go
@@ -5,6 +5,8 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
+const configKey = "ipinfo"
+
 type colors struct {
 	name  string
 	value string
@@ -15,11 +17,11 @@ type Settings struct {
 	common *cfg.Common
 }
 
-func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
-	localConfig, _ := ymlConfig.Get("wtf.mods.ipinfo")
+func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
+	localConfig, _ := ymlConfig.Get("wtf.mods." + configKey)
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
 	}
 
 	settings.colors.name = localConfig.UString("colors.name", "red")

--- a/modules/ipaddresses/ipinfo/settings.go
+++ b/modules/ipaddresses/ipinfo/settings.go
@@ -1,0 +1,29 @@
+package ipinfo
+
+import (
+	"github.com/olebedev/config"
+	"github.com/wtfutil/wtf/cfg"
+)
+
+type colors struct {
+	name  string
+	value string
+}
+
+type Settings struct {
+	colors
+	common *cfg.Common
+}
+
+func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
+	localConfig, _ := ymlConfig.Get("wtf.mods.ipinfo")
+
+	settings := Settings{
+		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+	}
+
+	settings.colors.name = localConfig.UString("colors.name", "red")
+	settings.colors.value = localConfig.UString("colors.value", "white")
+
+	return &settings
+}

--- a/modules/ipaddresses/ipinfo/widget.go
+++ b/modules/ipaddresses/ipinfo/widget.go
@@ -31,7 +31,7 @@ type ipinfo struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, false),
+		TextWidget: wtf.NewTextWidget(app, settings.common, false),
 
 		settings: settings,
 	}

--- a/modules/ipaddresses/ipinfo/widget.go
+++ b/modules/ipaddresses/ipinfo/widget.go
@@ -31,7 +31,7 @@ type ipinfo struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, "IPInfo", "ipinfo", false),
+		TextWidget: wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, false),
 
 		settings: settings,
 	}

--- a/modules/ipaddresses/ipinfo/widget.go
+++ b/modules/ipaddresses/ipinfo/widget.go
@@ -13,10 +13,9 @@ import (
 
 type Widget struct {
 	wtf.TextWidget
-	result string
-	colors struct {
-		name, value string
-	}
+
+	result   string
+	settings *Settings
 }
 
 type ipinfo struct {
@@ -30,14 +29,14 @@ type ipinfo struct {
 	Organization string `json:"org"`
 }
 
-func NewWidget(app *tview.Application) *Widget {
+func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
 		TextWidget: wtf.NewTextWidget(app, "IPInfo", "ipinfo", false),
+
+		settings: settings,
 	}
 
 	widget.View.SetWrap(false)
-
-	widget.config()
 
 	return &widget
 }
@@ -75,12 +74,6 @@ func (widget *Widget) ipinfo() {
 	widget.setResult(&info)
 }
 
-// read module configs
-func (widget *Widget) config() {
-	widget.colors.name = wtf.Config.UString("wtf.mods.ipinfo.colors.name", "white")
-	widget.colors.value = wtf.Config.UString("wtf.mods.ipinfo.colors.value", "white")
-}
-
 func (widget *Widget) setResult(info *ipinfo) {
 	resultTemplate, _ := template.New("ipinfo_result").Parse(
 		formatableText("IP", "Ip") +
@@ -95,8 +88,8 @@ func (widget *Widget) setResult(info *ipinfo) {
 	resultBuffer := new(bytes.Buffer)
 
 	resultTemplate.Execute(resultBuffer, map[string]string{
-		"nameColor":    widget.colors.name,
-		"valueColor":   widget.colors.value,
+		"nameColor":    widget.settings.colors.name,
+		"valueColor":   widget.settings.colors.value,
 		"Ip":           info.Ip,
 		"Hostname":     info.Hostname,
 		"City":         info.City,

--- a/modules/jenkins/client.go
+++ b/modules/jenkins/client.go
@@ -9,11 +9,9 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
-
-	"github.com/wtfutil/wtf/wtf"
 )
 
-func Create(jenkinsURL string, username string, apiKey string) (*View, error) {
+func (widget *Widget) Create(jenkinsURL string, username string, apiKey string) (*View, error) {
 	const apiSuffix = "api/json?pretty=true"
 	parsedSuffix, err := url.Parse(apiSuffix)
 	if err != nil {
@@ -29,10 +27,9 @@ func Create(jenkinsURL string, username string, apiKey string) (*View, error) {
 	req, _ := http.NewRequest("GET", jenkinsAPIURL.String(), nil)
 	req.SetBasicAuth(username, apiKey)
 
-	verifyServerCertificate := wtf.Config.UBool("wtf.mods.jenkins.verifyServerCertificate", true)
 	httpClient := &http.Client{Transport: &http.Transport{
 		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: !verifyServerCertificate,
+			InsecureSkipVerify: !widget.settings.verifyServerCertificate,
 		},
 		Proxy: http.ProxyFromEnvironment,
 	},

--- a/modules/jenkins/settings.go
+++ b/modules/jenkins/settings.go
@@ -1,0 +1,34 @@
+package jenkins
+
+import (
+	"os"
+
+	"github.com/olebedev/config"
+	"github.com/wtfutil/wtf/cfg"
+)
+
+type Settings struct {
+	common *cfg.Common
+
+	apiKey                  string
+	successBallColor        string
+	url                     string
+	user                    string
+	verifyServerCertificate bool
+}
+
+func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
+	localConfig, _ := ymlConfig.Get("wtf.mods.jenkins")
+
+	settings := Settings{
+		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+
+		apiKey:                  localConfig.UString("apiKey", os.Getenv("WTF_JENKINS_API_KEY")),
+		successBallColor:        localConfig.UString("successBallColor", "blue"),
+		url:                     localConfig.UString("url"),
+		user:                    localConfig.UString("user"),
+		verifyServerCertificate: localConfig.UBool("verifyServerCertificate", true),
+	}
+
+	return &settings
+}

--- a/modules/jenkins/settings.go
+++ b/modules/jenkins/settings.go
@@ -7,6 +7,8 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
+const configKey = "jenkins"
+
 type Settings struct {
 	common *cfg.Common
 
@@ -17,11 +19,11 @@ type Settings struct {
 	verifyServerCertificate bool
 }
 
-func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
-	localConfig, _ := ymlConfig.Get("wtf.mods.jenkins")
+func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
+	localConfig, _ := ymlConfig.Get("wtf.mods." + configKey)
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
 
 		apiKey:                  localConfig.UString("apiKey", os.Getenv("WTF_JENKINS_API_KEY")),
 		successBallColor:        localConfig.UString("successBallColor", "blue"),

--- a/modules/jenkins/widget.go
+++ b/modules/jenkins/widget.go
@@ -35,7 +35,7 @@ type Widget struct {
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
 		HelpfulWidget: wtf.NewHelpfulWidget(app, pages, HelpText),
-		TextWidget:    wtf.NewTextWidget(app, "Jenkins", "jenkins", true),
+		TextWidget:    wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, true),
 
 		settings: settings,
 	}

--- a/modules/jenkins/widget.go
+++ b/modules/jenkins/widget.go
@@ -36,7 +36,7 @@ type Widget struct {
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
 		HelpfulWidget: wtf.NewHelpfulWidget(app, pages, HelpText),
-		TextWidget:    wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, true),
+		TextWidget:    wtf.NewTextWidget(app, settings.common, true),
 
 		settings: settings,
 	}

--- a/modules/jira/settings.go
+++ b/modules/jira/settings.go
@@ -1,0 +1,74 @@
+package jira
+
+import (
+	"os"
+
+	"github.com/olebedev/config"
+	"github.com/wtfutil/wtf/cfg"
+)
+
+type colors struct {
+	rows struct {
+		even string
+		odd  string
+	}
+}
+
+type Settings struct {
+	colors
+	common *cfg.Common
+
+	apiKey                  string
+	domain                  string
+	email                   string
+	jql                     string
+	projects                []string
+	username                string
+	verifyServerCertificate bool
+}
+
+func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
+	localConfig, _ := ymlConfig.Get("wtf.mods.jira")
+
+	settings := Settings{
+		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+
+		apiKey:                  localConfig.UString("apiKey", os.Getenv("WTF_JIRA_API_KEY")),
+		domain:                  localConfig.UString("domain"),
+		email:                   localConfig.UString("email"),
+		jql:                     localConfig.UString("jql"),
+		username:                localConfig.UString("username"),
+		verifyServerCertificate: localConfig.UBool("verifyServerCertificate", true),
+	}
+
+	settings.colors.rows.even = localConfig.UString("colors.even", "lightblue")
+	settings.colors.rows.odd = localConfig.UString("colors.odd", "white")
+
+	settings.projects = settings.arrayifyProjects(localConfig)
+
+	return &settings
+}
+
+/* -------------------- Unexported functions -------------------- */
+
+// arrayifyProjects figures out if we're dealing with a single project or an array of projects
+func (settings *Settings) arrayifyProjects(localConfig *config.Config) []string {
+	projects := []string{}
+
+	// Single project
+	project, err := localConfig.String("project")
+	if err == nil {
+		projects = append(projects, project)
+		return projects
+	}
+
+	// Array of projects
+	projectList := localConfig.UList("project")
+	for _, projectName := range projectList {
+		if project, ok := projectName.(string); ok {
+			projects = append(projects, project)
+		}
+	}
+
+	return projects
+}

--- a/modules/jira/settings.go
+++ b/modules/jira/settings.go
@@ -7,6 +7,8 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
+const configKey = "jira"
+
 type colors struct {
 	rows struct {
 		even string
@@ -27,11 +29,11 @@ type Settings struct {
 	verifyServerCertificate bool
 }
 
-func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
-	localConfig, _ := ymlConfig.Get("wtf.mods.jira")
+func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
+	localConfig, _ := ymlConfig.Get("wtf.mods." + configKey)
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
 
 		apiKey:                  localConfig.UString("apiKey", os.Getenv("WTF_JIRA_API_KEY")),
 		domain:                  localConfig.UString("domain"),

--- a/modules/jira/widget.go
+++ b/modules/jira/widget.go
@@ -34,7 +34,7 @@ type Widget struct {
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
 		HelpfulWidget: wtf.NewHelpfulWidget(app, pages, HelpText),
-		TextWidget:    wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, true),
+		TextWidget:    wtf.NewTextWidget(app, settings.common, true),
 
 		settings: settings,
 	}

--- a/modules/jira/widget.go
+++ b/modules/jira/widget.go
@@ -34,7 +34,7 @@ type Widget struct {
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
 		HelpfulWidget: wtf.NewHelpfulWidget(app, pages, HelpText),
-		TextWidget:    wtf.NewTextWidget(app, "Jira", "jira", true),
+		TextWidget:    wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, true),
 
 		settings: settings,
 	}

--- a/modules/mercurial/hg_repo.go
+++ b/modules/mercurial/hg_repo.go
@@ -19,13 +19,13 @@ type MercurialRepo struct {
 	Path         string
 }
 
-func NewMercurialRepo(repoPath string) *MercurialRepo {
+func NewMercurialRepo(repoPath string, commitCount int, commitFormat string) *MercurialRepo {
 	repo := MercurialRepo{Path: repoPath}
 
 	repo.Branch = strings.TrimSpace(repo.branch())
 	repo.Bookmark = strings.TrimSpace(repo.bookmark())
 	repo.ChangedFiles = repo.changedFiles()
-	repo.Commits = repo.commits()
+	repo.Commits = repo.commits(commitCount, commitFormat)
 	repo.Repository = strings.TrimSpace(repo.Path)
 
 	return &repo
@@ -61,10 +61,8 @@ func (repo *MercurialRepo) changedFiles() []string {
 	return data
 }
 
-func (repo *MercurialRepo) commits() []string {
-	numStr := fmt.Sprintf("-l %d", wtf.Config.UInt("wtf.mods.mercurial.commitCount", 10))
-
-	commitFormat := wtf.Config.UString("wtf.mods.mercurial.commitFormat", "[forestgreen]{rev}:{phase} [white]{desc|firstline|strip} [grey]{author|person} {date|age}[white]")
+func (repo *MercurialRepo) commits(commitCount int, commitFormat string) []string {
+	numStr := fmt.Sprintf("-l %d", commitCount)
 	commitStr := fmt.Sprintf("--template=\"%s\n\"", commitFormat)
 
 	arg := []string{"log", repo.repoPath(), numStr, commitStr}

--- a/modules/mercurial/settings.go
+++ b/modules/mercurial/settings.go
@@ -5,6 +5,8 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
+const configKey = "mercurial"
+
 type Settings struct {
 	common *cfg.Common
 
@@ -13,11 +15,11 @@ type Settings struct {
 	repositories []interface{}
 }
 
-func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
-	localConfig, _ := ymlConfig.Get("wtf.mods.mercurial")
+func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
+	localConfig, _ := ymlConfig.Get("wtf.mods." + configKey)
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
 
 		commitCount:  localConfig.UInt("commitCount", 10),
 		commitFormat: localConfig.UString("commitFormat", "[forestgreen]{rev}:{phase} [white]{desc|firstline|strip} [grey]{author|person} {date|age}[white]"),

--- a/modules/mercurial/settings.go
+++ b/modules/mercurial/settings.go
@@ -1,0 +1,28 @@
+package mercurial
+
+import (
+	"github.com/olebedev/config"
+	"github.com/wtfutil/wtf/cfg"
+)
+
+type Settings struct {
+	common *cfg.Common
+
+	commitCount  int
+	commitFormat string
+	repositories []interface{}
+}
+
+func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
+	localConfig, _ := ymlConfig.Get("wtf.mods.mercurial")
+
+	settings := Settings{
+		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+
+		commitCount:  localConfig.UInt("commitCount", 10),
+		commitFormat: localConfig.UString("commitFormat", "[forestgreen]{rev}:{phase} [white]{desc|firstline|strip} [grey]{author|person} {date|age}[white]"),
+		repositories: localConfig.UList("repositories"),
+	}
+
+	return &settings
+}

--- a/modules/mercurial/widget.go
+++ b/modules/mercurial/widget.go
@@ -28,19 +28,21 @@ type Widget struct {
 	wtf.MultiSourceWidget
 	wtf.TextWidget
 
-	app   *tview.Application
-	Data  []*MercurialRepo
-	pages *tview.Pages
+	app      *tview.Application
+	Data     []*MercurialRepo
+	pages    *tview.Pages
+	settings *Settings
 }
 
-func NewWidget(app *tview.Application, pages *tview.Pages) *Widget {
+func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
 		HelpfulWidget:     wtf.NewHelpfulWidget(app, pages, HelpText),
 		MultiSourceWidget: wtf.NewMultiSourceWidget("mercurial", "repository", "repositories"),
 		TextWidget:        wtf.NewTextWidget(app, "Mercurial", "mercurial", true),
 
-		app:   app,
-		pages: pages,
+		app:      app,
+		pages:    pages,
+		settings: settings,
 	}
 
 	widget.LoadSources()
@@ -79,7 +81,7 @@ func (widget *Widget) Pull() {
 }
 
 func (widget *Widget) Refresh() {
-	repoPaths := wtf.ToStrs(wtf.Config.UList("wtf.mods.mercurial.repositories"))
+	repoPaths := wtf.ToStrs(widget.settings.repositories)
 
 	widget.Data = widget.mercurialRepos(repoPaths)
 	widget.display()
@@ -156,7 +158,7 @@ func (widget *Widget) mercurialRepos(repoPaths []string) []*MercurialRepo {
 	repos := []*MercurialRepo{}
 
 	for _, repoPath := range repoPaths {
-		repo := NewMercurialRepo(repoPath)
+		repo := NewMercurialRepo(repoPath, widget.settings.commitCount, widget.settings.commitFormat)
 		repos = append(repos, repo)
 	}
 

--- a/modules/mercurial/widget.go
+++ b/modules/mercurial/widget.go
@@ -38,7 +38,7 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 	widget := Widget{
 		HelpfulWidget:     wtf.NewHelpfulWidget(app, pages, HelpText),
 		MultiSourceWidget: wtf.NewMultiSourceWidget(settings.common.ConfigKey, "repository", "repositories"),
-		TextWidget:        wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, true),
+		TextWidget:        wtf.NewTextWidget(app, settings.common, true),
 
 		app:      app,
 		pages:    pages,

--- a/modules/mercurial/widget.go
+++ b/modules/mercurial/widget.go
@@ -37,8 +37,8 @@ type Widget struct {
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
 		HelpfulWidget:     wtf.NewHelpfulWidget(app, pages, HelpText),
-		MultiSourceWidget: wtf.NewMultiSourceWidget("mercurial", "repository", "repositories"),
-		TextWidget:        wtf.NewTextWidget(app, "Mercurial", "mercurial", true),
+		MultiSourceWidget: wtf.NewMultiSourceWidget(settings.common.ConfigKey, "repository", "repositories"),
+		TextWidget:        wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, true),
 
 		app:      app,
 		pages:    pages,

--- a/modules/nbascore/settings.go
+++ b/modules/nbascore/settings.go
@@ -5,13 +5,15 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
+const configKey = "nbascore"
+
 type Settings struct {
 	common *cfg.Common
 }
 
-func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
+func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
 	}
 
 	return &settings

--- a/modules/nbascore/settings.go
+++ b/modules/nbascore/settings.go
@@ -1,0 +1,18 @@
+package nbascore
+
+import (
+	"github.com/olebedev/config"
+	"github.com/wtfutil/wtf/cfg"
+)
+
+type Settings struct {
+	common *cfg.Common
+}
+
+func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
+	settings := Settings{
+		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+	}
+
+	return &settings
+}

--- a/modules/nbascore/widget.go
+++ b/modules/nbascore/widget.go
@@ -22,22 +22,23 @@ const HelpText = `
 type Widget struct {
 	wtf.HelpfulWidget
 	wtf.TextWidget
-	app      *tview.Application
-	pages    *tview.Pages
+
 	language string
 	result   string
+	settings *Settings
 }
 
 var offset = 0
 
-func NewWidget(app *tview.Application, pages *tview.Pages) *Widget {
+func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
 		HelpfulWidget: wtf.NewHelpfulWidget(app, pages, HelpText),
 		TextWidget:    wtf.NewTextWidget(app, "NBA Score", "nbascore", true),
+
+		settings: settings,
 	}
 
 	widget.HelpfulWidget.SetView(widget.View)
-	widget.TextWidget.RefreshInt = 15
 	widget.View.SetInputCapture(widget.keyboardIntercept)
 	widget.View.SetScrollable(true)
 

--- a/modules/nbascore/widget.go
+++ b/modules/nbascore/widget.go
@@ -33,7 +33,7 @@ var offset = 0
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
 		HelpfulWidget: wtf.NewHelpfulWidget(app, pages, HelpText),
-		TextWidget:    wtf.NewTextWidget(app, "NBA Score", "nbascore", true),
+		TextWidget:    wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, true),
 
 		settings: settings,
 	}

--- a/modules/nbascore/widget.go
+++ b/modules/nbascore/widget.go
@@ -33,7 +33,7 @@ var offset = 0
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
 		HelpfulWidget: wtf.NewHelpfulWidget(app, pages, HelpText),
-		TextWidget:    wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, true),
+		TextWidget:    wtf.NewTextWidget(app, settings.common, true),
 
 		settings: settings,
 	}

--- a/modules/newrelic/settings.go
+++ b/modules/newrelic/settings.go
@@ -7,6 +7,8 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
+const configKey = "newrelic"
+
 type Settings struct {
 	common *cfg.Common
 
@@ -15,11 +17,11 @@ type Settings struct {
 	deployCount   int
 }
 
-func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
-	localConfig, _ := ymlConfig.Get("wtf.mods.newrelic")
+func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
+	localConfig, _ := ymlConfig.Get("wtf.mods." + configKey)
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
 
 		apiKey:        localConfig.UString("apiKey", os.Getenv("WTF_NEW_RELIC_API_KEY")),
 		applicationID: localConfig.UInt("applicationID"),

--- a/modules/newrelic/settings.go
+++ b/modules/newrelic/settings.go
@@ -1,0 +1,30 @@
+package newrelic
+
+import (
+	"os"
+
+	"github.com/olebedev/config"
+	"github.com/wtfutil/wtf/cfg"
+)
+
+type Settings struct {
+	common *cfg.Common
+
+	apiKey        string
+	applicationID int
+	deployCount   int
+}
+
+func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
+	localConfig, _ := ymlConfig.Get("wtf.mods.newrelic")
+
+	settings := Settings{
+		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+
+		apiKey:        localConfig.UString("apiKey", os.Getenv("WTF_NEW_RELIC_API_KEY")),
+		applicationID: localConfig.UInt("applicationID"),
+		deployCount:   localConfig.UInt("deployCount", 5),
+	}
+
+	return &settings
+}

--- a/modules/newrelic/widget.go
+++ b/modules/newrelic/widget.go
@@ -17,7 +17,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, "New Relic", "newrelic", false),
+		TextWidget: wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, false),
 
 		settings: settings,
 	}

--- a/modules/newrelic/widget.go
+++ b/modules/newrelic/widget.go
@@ -2,7 +2,6 @@ package newrelic
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/rivo/tview"
 	"github.com/wtfutil/wtf/wtf"
@@ -11,14 +10,19 @@ import (
 
 type Widget struct {
 	wtf.TextWidget
-	client *Client
+
+	client   *Client
+	settings *Settings
 }
 
-func NewWidget(app *tview.Application) *Widget {
+func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
 		TextWidget: wtf.NewTextWidget(app, "New Relic", "newrelic", false),
-		client:     NewClient(apiKey(), wtf.Config.UInt("wtf.mods.newrelic.applicationId")),
+
+		settings: settings,
 	}
+
+	widget.client = NewClient(widget.settings.apiKey, widget.settings.applicationID)
 
 	return &widget
 }
@@ -81,18 +85,11 @@ func (widget *Widget) contentFrom(deploys []nr.ApplicationDeployment) string {
 
 			revisions = append(revisions, deploy.Revision)
 
-			if len(revisions) == wtf.Config.UInt("wtf.mods.newrelic.deployCount", 5) {
+			if len(revisions) == widget.settings.deployCount {
 				break
 			}
 		}
 	}
 
 	return str
-}
-
-func apiKey() string {
-	return wtf.Config.UString(
-		"wtf.mods.newrelic.apiKey",
-		os.Getenv("WTF_NEW_RELIC_API_KEY"),
-	)
 }

--- a/modules/newrelic/widget.go
+++ b/modules/newrelic/widget.go
@@ -17,7 +17,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, false),
+		TextWidget: wtf.NewTextWidget(app, settings.common, false),
 
 		settings: settings,
 	}

--- a/modules/opsgenie/client.go
+++ b/modules/opsgenie/client.go
@@ -4,9 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"os"
-
-	"github.com/wtfutil/wtf/wtf"
 )
 
 type OnCallResponse struct {
@@ -29,11 +26,12 @@ type Parent struct {
 
 /* -------------------- Exported Functions -------------------- */
 
-func Fetch(scheduleIdentifierType string, schedules []string) ([]*OnCallResponse, error) {
+func (widget *Widget) Fetch(scheduleIdentifierType string, schedules []string) ([]*OnCallResponse, error) {
 	agregatedResponses := []*OnCallResponse{}
+
 	for _, sched := range schedules {
 		scheduleUrl := fmt.Sprintf("https://api.opsgenie.com/v2/schedules/%s/on-calls?scheduleIdentifierType=%s&flat=true", sched, scheduleIdentifierType)
-		response, err := opsGenieRequest(scheduleUrl, apiKey())
+		response, err := opsGenieRequest(scheduleUrl, widget.settings.apiKey)
 		agregatedResponses = append(agregatedResponses, response)
 		if err != nil {
 			return nil, err
@@ -43,13 +41,6 @@ func Fetch(scheduleIdentifierType string, schedules []string) ([]*OnCallResponse
 }
 
 /* -------------------- Unexported Functions -------------------- */
-
-func apiKey() string {
-	return wtf.Config.UString(
-		"wtf.mods.opsgenie.apiKey",
-		os.Getenv("WTF_OPS_GENIE_API_KEY"),
-	)
-}
 
 func opsGenieRequest(url string, apiKey string) (*OnCallResponse, error) {
 	req, err := http.NewRequest("GET", url, nil)

--- a/modules/opsgenie/settings.go
+++ b/modules/opsgenie/settings.go
@@ -1,0 +1,55 @@
+package opsgenie
+
+import (
+	"os"
+
+	"github.com/olebedev/config"
+	"github.com/wtfutil/wtf/cfg"
+)
+
+type Settings struct {
+	common *cfg.Common
+
+	apiKey                 string
+	displayEmpty           bool
+	schedule               []string
+	scheduleIdentifierType string
+}
+
+func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
+	localConfig, _ := ymlConfig.Get("wtf.mods.opsgenie")
+
+	settings := Settings{
+		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+
+		apiKey:                 localConfig.UString("apiKey", os.Getenv("WTF_OPS_GENIE_API_KEY")),
+		displayEmpty:           localConfig.UBool("displayEmpty", true),
+		scheduleIdentifierType: localConfig.UString("scheduleIdentifierType", "id"),
+	}
+
+	settings.schedule = settings.arrayifySchedules(localConfig)
+
+	return &settings
+}
+
+// arrayifySchedules figures out if we're dealing with a single project or an array of projects
+func (settings *Settings) arrayifySchedules(localConfig *config.Config) []string {
+	schedules := []string{}
+
+	// Single schedule
+	schedule, err := localConfig.String("schedule")
+	if err == nil {
+		schedules = append(schedules, schedule)
+		return schedules
+	}
+
+	// Array of schedules
+	scheduleList := localConfig.UList("schedule")
+	for _, scheduleName := range scheduleList {
+		if schedule, ok := scheduleName.(string); ok {
+			schedules = append(schedules, schedule)
+		}
+	}
+
+	return schedules
+}

--- a/modules/opsgenie/settings.go
+++ b/modules/opsgenie/settings.go
@@ -7,6 +7,8 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
+const configKey = "opsgenie"
+
 type Settings struct {
 	common *cfg.Common
 
@@ -16,11 +18,11 @@ type Settings struct {
 	scheduleIdentifierType string
 }
 
-func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
-	localConfig, _ := ymlConfig.Get("wtf.mods.opsgenie")
+func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
+	localConfig, _ := ymlConfig.Get("wtf.mods." + configKey)
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
 
 		apiKey:                 localConfig.UString("apiKey", os.Getenv("WTF_OPS_GENIE_API_KEY")),
 		displayEmpty:           localConfig.UBool("displayEmpty", true),

--- a/modules/opsgenie/widget.go
+++ b/modules/opsgenie/widget.go
@@ -10,11 +10,15 @@ import (
 
 type Widget struct {
 	wtf.TextWidget
+
+	settings *Settings
 }
 
-func NewWidget(app *tview.Application) *Widget {
+func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
 		TextWidget: wtf.NewTextWidget(app, "OpsGenie", "opsgenie", false),
+
+		settings: settings,
 	}
 
 	return &widget
@@ -23,10 +27,11 @@ func NewWidget(app *tview.Application) *Widget {
 /* -------------------- Exported Functions -------------------- */
 
 func (widget *Widget) Refresh() {
-	data, err := Fetch(
-		wtf.Config.UString("wtf.mods.opsgenie.scheduleIdentifierType"),
-		getSchedules(),
+	data, err := widget.Fetch(
+		widget.settings.scheduleIdentifierType,
+		widget.settings.schedule,
 	)
+
 	widget.View.SetTitle(widget.ContextualTitle(widget.Name()))
 
 	var content string
@@ -43,31 +48,11 @@ func (widget *Widget) Refresh() {
 
 /* -------------------- Unexported Functions -------------------- */
 
-func getSchedules() []string {
-	// see if schedule is set to a single string
-	configPath := "wtf.mods.opsgenie.schedule"
-	singleSchedule, err := wtf.Config.String(configPath)
-	if err == nil {
-		return []string{singleSchedule}
-	}
-	// else, assume list
-	scheduleList := wtf.Config.UList(configPath)
-	var ret []string
-	for _, schedule := range scheduleList {
-		if str, ok := schedule.(string); ok {
-			ret = append(ret, str)
-		}
-	}
-	return ret
-}
-
 func (widget *Widget) contentFrom(onCallResponses []*OnCallResponse) string {
 	str := ""
 
-	displayEmpty := wtf.Config.UBool("wtf.mods.opsgenie.displayEmpty", true)
-
 	for _, data := range onCallResponses {
-		if (len(data.OnCallData.Recipients) == 0) && (displayEmpty == false) {
+		if (len(data.OnCallData.Recipients) == 0) && (widget.settings.displayEmpty == false) {
 			continue
 		}
 

--- a/modules/opsgenie/widget.go
+++ b/modules/opsgenie/widget.go
@@ -16,7 +16,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, false),
+		TextWidget: wtf.NewTextWidget(app, settings.common, false),
 
 		settings: settings,
 	}

--- a/modules/opsgenie/widget.go
+++ b/modules/opsgenie/widget.go
@@ -16,7 +16,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, "OpsGenie", "opsgenie", false),
+		TextWidget: wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, false),
 
 		settings: settings,
 	}

--- a/modules/pagerduty/client.go
+++ b/modules/pagerduty/client.go
@@ -1,16 +1,14 @@
 package pagerduty
 
 import (
-	"os"
 	"time"
 
 	"github.com/PagerDuty/go-pagerduty"
-	"github.com/wtfutil/wtf/wtf"
 )
 
 // GetOnCalls returns a list of people currently on call
-func GetOnCalls() ([]pagerduty.OnCall, error) {
-	client := pagerduty.NewClient(apiKey())
+func GetOnCalls(apiKey string) ([]pagerduty.OnCall, error) {
+	client := pagerduty.NewClient(apiKey)
 
 	var results []pagerduty.OnCall
 
@@ -38,8 +36,8 @@ func GetOnCalls() ([]pagerduty.OnCall, error) {
 }
 
 // GetIncidents returns a list of people currently on call
-func GetIncidents() ([]pagerduty.Incident, error) {
-	client := pagerduty.NewClient(apiKey())
+func GetIncidents(apiKey string) ([]pagerduty.Incident, error) {
+	client := pagerduty.NewClient(apiKey)
 
 	var results []pagerduty.Incident
 
@@ -63,11 +61,4 @@ func GetIncidents() ([]pagerduty.Incident, error) {
 	}
 
 	return results, nil
-}
-
-func apiKey() string {
-	return wtf.Config.UString(
-		"wtf.mods.pagerduty.apiKey",
-		os.Getenv("WTF_PAGERDUTY_API_KEY"),
-	)
 }

--- a/modules/pagerduty/settings.go
+++ b/modules/pagerduty/settings.go
@@ -7,6 +7,8 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
+const configKey = "pagerduty"
+
 type Settings struct {
 	common *cfg.Common
 
@@ -16,11 +18,11 @@ type Settings struct {
 	showSchedules    bool
 }
 
-func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
-	localConfig, _ := ymlConfig.Get("wtf.mods.pagerduty")
+func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
+	localConfig, _ := ymlConfig.Get("wtf.mods." + configKey)
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
 
 		apiKey:           localConfig.UString("apiKey", os.Getenv("WTF_PAGERDUTY_API_KEY")),
 		escalationFilter: localConfig.UList("escalationFilter"),

--- a/modules/pagerduty/settings.go
+++ b/modules/pagerduty/settings.go
@@ -1,0 +1,32 @@
+package pagerduty
+
+import (
+	"os"
+
+	"github.com/olebedev/config"
+	"github.com/wtfutil/wtf/cfg"
+)
+
+type Settings struct {
+	common *cfg.Common
+
+	apiKey           string
+	escalationFilter []interface{}
+	showIncidents    bool
+	showSchedules    bool
+}
+
+func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
+	localConfig, _ := ymlConfig.Get("wtf.mods.pagerduty")
+
+	settings := Settings{
+		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+
+		apiKey:           localConfig.UString("apiKey", os.Getenv("WTF_PAGERDUTY_API_KEY")),
+		escalationFilter: localConfig.UList("escalationFilter"),
+		showIncidents:    localConfig.UBool("showIncidents", true),
+		showSchedules:    localConfig.UBool("showSchedules", true),
+	}
+
+	return &settings
+}

--- a/modules/pagerduty/widget.go
+++ b/modules/pagerduty/widget.go
@@ -17,7 +17,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, "PagerDuty", "pagerduty", false),
+		TextWidget: wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, false),
 
 		settings: settings,
 	}

--- a/modules/pagerduty/widget.go
+++ b/modules/pagerduty/widget.go
@@ -11,11 +11,15 @@ import (
 
 type Widget struct {
 	wtf.TextWidget
+
+	settings *Settings
 }
 
-func NewWidget(app *tview.Application) *Widget {
+func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
 		TextWidget: wtf.NewTextWidget(app, "PagerDuty", "pagerduty", false),
+
+		settings: settings,
 	}
 
 	return &widget
@@ -30,12 +34,12 @@ func (widget *Widget) Refresh() {
 	var err1 error
 	var err2 error
 
-	if wtf.Config.UBool("wtf.mods.pagerduty.showSchedules", true) {
-		onCalls, err1 = GetOnCalls()
+	if widget.settings.showSchedules {
+		onCalls, err1 = GetOnCalls(widget.settings.apiKey)
 	}
 
-	if wtf.Config.UBool("wtf.mods.pagerduty.showIncidents") {
-		incidents, err2 = GetIncidents()
+	if widget.settings.showIncidents {
+		incidents, err2 = GetIncidents(widget.settings.apiKey)
 	}
 
 	widget.View.SetTitle(widget.ContextualTitle(fmt.Sprintf("%s", widget.Name())))
@@ -75,15 +79,14 @@ func (widget *Widget) contentFrom(onCalls []pagerduty.OnCall, incidents []pagerd
 
 	tree := make(map[string][]pagerduty.OnCall)
 
-	filtering := wtf.Config.UList("wtf.mods.pagerduty.escalationFilter")
 	filter := make(map[string]bool)
-	for _, item := range filtering {
+	for _, item := range widget.settings.escalationFilter {
 		filter[item.(string)] = true
 	}
 
 	for _, onCall := range onCalls {
 		key := onCall.EscalationPolicy.Summary
-		if len(filtering) == 0 || filter[key] {
+		if len(widget.settings.escalationFilter) == 0 || filter[key] {
 			tree[key] = append(tree[key], onCall)
 		}
 	}

--- a/modules/pagerduty/widget.go
+++ b/modules/pagerduty/widget.go
@@ -17,7 +17,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, false),
+		TextWidget: wtf.NewTextWidget(app, settings.common, false),
 
 		settings: settings,
 	}

--- a/modules/power/settings.go
+++ b/modules/power/settings.go
@@ -1,0 +1,20 @@
+package power
+
+import (
+	"github.com/olebedev/config"
+	"github.com/wtfutil/wtf/cfg"
+)
+
+type Settings struct {
+	common *cfg.Common
+
+	filePath string
+}
+
+func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
+	settings := Settings{
+		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+	}
+
+	return &settings
+}

--- a/modules/power/settings.go
+++ b/modules/power/settings.go
@@ -5,15 +5,17 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
+const configKey = "power"
+
 type Settings struct {
 	common *cfg.Common
 
 	filePath string
 }
 
-func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
+func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
 	}
 
 	return &settings

--- a/modules/power/widget.go
+++ b/modules/power/widget.go
@@ -16,7 +16,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, "Power", "power", false),
+		TextWidget: wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, false),
 
 		Battery:  NewBattery(),
 		settings: settings,

--- a/modules/power/widget.go
+++ b/modules/power/widget.go
@@ -10,13 +10,16 @@ import (
 type Widget struct {
 	wtf.TextWidget
 
-	Battery *Battery
+	Battery  *Battery
+	settings *Settings
 }
 
-func NewWidget(app *tview.Application) *Widget {
+func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
 		TextWidget: wtf.NewTextWidget(app, "Power", "power", false),
-		Battery:    NewBattery(),
+
+		Battery:  NewBattery(),
+		settings: settings,
 	}
 
 	widget.View.SetWrap(true)

--- a/modules/power/widget.go
+++ b/modules/power/widget.go
@@ -16,7 +16,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, false),
+		TextWidget: wtf.NewTextWidget(app, settings.common, false),
 
 		Battery:  NewBattery(),
 		settings: settings,

--- a/modules/resourceusage/settings.go
+++ b/modules/resourceusage/settings.go
@@ -1,0 +1,18 @@
+package resourceusage
+
+import (
+	"github.com/olebedev/config"
+	"github.com/wtfutil/wtf/cfg"
+)
+
+type Settings struct {
+	common *cfg.Common
+}
+
+func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
+	settings := Settings{
+		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+	}
+
+	return &settings
+}

--- a/modules/resourceusage/settings.go
+++ b/modules/resourceusage/settings.go
@@ -5,13 +5,15 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
+const configKey = "resourceusage"
+
 type Settings struct {
 	common *cfg.Common
 }
 
-func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
+func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
 	}
 
 	return &settings

--- a/modules/resourceusage/widget.go
+++ b/modules/resourceusage/widget.go
@@ -17,12 +17,16 @@ var ok = true
 // Widget define wtf widget to register widget later
 type Widget struct {
 	wtf.BarGraph
+
+	settings *Settings
 }
 
 // NewWidget Make new instance of widget
-func NewWidget(app *tview.Application) *Widget {
+func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
 		BarGraph: wtf.NewBarGraph(app, "Resource Usage", "resourceusage", false),
+
+		settings: settings,
 	}
 
 	widget.View.SetWrap(false)

--- a/modules/resourceusage/widget.go
+++ b/modules/resourceusage/widget.go
@@ -24,7 +24,7 @@ type Widget struct {
 // NewWidget Make new instance of widget
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		BarGraph: wtf.NewBarGraph(app, "Resource Usage", "resourceusage", false),
+		BarGraph: wtf.NewBarGraph(app, settings.common.Name, settings.common.ConfigKey, false),
 
 		settings: settings,
 	}

--- a/modules/rollbar/client.go
+++ b/modules/rollbar/client.go
@@ -12,10 +12,9 @@ import (
 	"github.com/wtfutil/wtf/wtf"
 )
 
-func CurrentActiveItems() (*ActiveItems, error) {
+func CurrentActiveItems(accessToken string) (*ActiveItems, error) {
 	items := &ActiveItems{}
 
-	accessToken := wtf.Config.UString("wtf.mods.rollbar.accessToken", "")
 	rollbarAPIURL.Host = "api.rollbar.com"
 	rollbarAPIURL.Path = "/api/1/items"
 	resp, err := rollbarItemRequest(accessToken)

--- a/modules/rollbar/client.go
+++ b/modules/rollbar/client.go
@@ -8,16 +8,14 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
-
-	"github.com/wtfutil/wtf/wtf"
 )
 
-func CurrentActiveItems(accessToken string) (*ActiveItems, error) {
+func CurrentActiveItems(accessToken, assignedToName string, activeOnly bool) (*ActiveItems, error) {
 	items := &ActiveItems{}
 
 	rollbarAPIURL.Host = "api.rollbar.com"
 	rollbarAPIURL.Path = "/api/1/items"
-	resp, err := rollbarItemRequest(accessToken)
+	resp, err := rollbarItemRequest(accessToken, assignedToName, activeOnly)
 	if err != nil {
 		return items, err
 	}
@@ -33,13 +31,11 @@ var (
 	rollbarAPIURL = &url.URL{Scheme: "https"}
 )
 
-func rollbarItemRequest(accessToken string) (*http.Response, error) {
+func rollbarItemRequest(accessToken, assignedToName string, activeOnly bool) (*http.Response, error) {
 	params := url.Values{}
 	params.Add("access_token", accessToken)
-	userName := wtf.Config.UString("wtf.mods.rollbar.assignedToName", "")
-	params.Add("assigned_user", userName)
-	active := wtf.Config.UBool("wtf.mods.rollbar.activeOnly", false)
-	if active {
+	params.Add("assigned_user", assignedToName)
+	if activeOnly {
 		params.Add("status", "active")
 	}
 

--- a/modules/rollbar/settings.go
+++ b/modules/rollbar/settings.go
@@ -5,6 +5,8 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
+const configKey = "rollbar"
+
 type Settings struct {
 	common *cfg.Common
 
@@ -16,11 +18,11 @@ type Settings struct {
 	projectOwner   string
 }
 
-func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
-	localConfig, _ := ymlConfig.Get("wtf.mods.rollbar")
+func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
+	localConfig, _ := ymlConfig.Get("wtf.mods." + configKey)
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
 
 		accessToken:    localConfig.UString("accessToken"),
 		activeOnly:     localConfig.UBool("activeOnly", false),

--- a/modules/rollbar/settings.go
+++ b/modules/rollbar/settings.go
@@ -1,0 +1,34 @@
+package rollbar
+
+import (
+	"github.com/olebedev/config"
+	"github.com/wtfutil/wtf/cfg"
+)
+
+type Settings struct {
+	common *cfg.Common
+
+	accessToken    string
+	activeOnly     bool
+	assignedToName string
+	count          int
+	projectName    string
+	projectOwner   string
+}
+
+func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
+	localConfig, _ := ymlConfig.Get("wtf.mods.rollbar")
+
+	settings := Settings{
+		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+
+		accessToken:    localConfig.UString("accessToken"),
+		activeOnly:     localConfig.UBool("activeOnly"),
+		assignedToName: localConfig.UString("assignedToName"),
+		count:          localConfig.UInt("count", 10),
+		projectName:    localConfig.UString("projectName", "Items"),
+		projectOwner:   localConfig.UString("projectOwner"),
+	}
+
+	return &settings
+}

--- a/modules/rollbar/settings.go
+++ b/modules/rollbar/settings.go
@@ -23,7 +23,7 @@ func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
 		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
 
 		accessToken:    localConfig.UString("accessToken"),
-		activeOnly:     localConfig.UBool("activeOnly"),
+		activeOnly:     localConfig.UBool("activeOnly", false),
 		assignedToName: localConfig.UString("assignedToName"),
 		count:          localConfig.UInt("count", 10),
 		projectName:    localConfig.UString("projectName", "Items"),

--- a/modules/rollbar/widget.go
+++ b/modules/rollbar/widget.go
@@ -35,7 +35,7 @@ type Widget struct {
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
 		HelpfulWidget: wtf.NewHelpfulWidget(app, pages, HelpText),
-		TextWidget:    wtf.NewTextWidget(app, "Rollbar", "rollbar", true),
+		TextWidget:    wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, true),
 
 		settings: settings,
 	}

--- a/modules/rollbar/widget.go
+++ b/modules/rollbar/widget.go
@@ -55,7 +55,11 @@ func (widget *Widget) Refresh() {
 		return
 	}
 
-	items, err := CurrentActiveItems(widget.settings.accessToken)
+	items, err := CurrentActiveItems(
+		widget.settings.accessToken,
+		widget.settings.assignedToName,
+		widget.settings.activeOnly,
+	)
 
 	if err != nil {
 		widget.View.SetWrap(true)

--- a/modules/rollbar/widget.go
+++ b/modules/rollbar/widget.go
@@ -35,7 +35,7 @@ type Widget struct {
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
 		HelpfulWidget: wtf.NewHelpfulWidget(app, pages, HelpText),
-		TextWidget:    wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, true),
+		TextWidget:    wtf.NewTextWidget(app, settings.common, true),
 
 		settings: settings,
 	}

--- a/modules/security/settings.go
+++ b/modules/security/settings.go
@@ -1,0 +1,18 @@
+package security
+
+import (
+	"github.com/olebedev/config"
+	"github.com/wtfutil/wtf/cfg"
+)
+
+type Settings struct {
+	common *cfg.Common
+}
+
+func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
+	settings := Settings{
+		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+	}
+
+	return &settings
+}

--- a/modules/security/settings.go
+++ b/modules/security/settings.go
@@ -5,13 +5,15 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
+const configKey = "security"
+
 type Settings struct {
 	common *cfg.Common
 }
 
-func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
+func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
 	}
 
 	return &settings

--- a/modules/security/widget.go
+++ b/modules/security/widget.go
@@ -10,11 +10,15 @@ import (
 
 type Widget struct {
 	wtf.TextWidget
+
+	settings *Settings
 }
 
-func NewWidget(app *tview.Application) *Widget {
+func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
 		TextWidget: wtf.NewTextWidget(app, "Security", "security", false),
+
+		settings: settings,
 	}
 
 	return &widget
@@ -48,12 +52,10 @@ func (widget *Widget) contentFrom(data *SecurityData) string {
 	str = str + "\n"
 
 	str = str + " [red]Users[white]\n"
-	str = str + fmt.Sprintf("  %s", strings.Join(data.LoggedInUsers, "\n "))
-	str = str + "\n"
+	str = str + fmt.Sprintf("  %s", strings.Join(data.LoggedInUsers, "\n  "))
+	str = str + "\n\n"
 
 	str = str + " [red]DNS[white]\n"
-	//str = str + fmt.Sprintf(" %8s: [%s]%-3s[white]   %-16s\n", "Enabled", widget.labelColor(data.FirewallEnabled), data.FirewallEnabled, data.DnsAt(0))
-	//str = str + fmt.Sprintf(" %8s: [%s]%-3s[white]   %-16s\n", "Stealth", widget.labelColor(data.FirewallStealth), data.FirewallStealth, data.DnsAt(1))
 	str = str + fmt.Sprintf("  %12s\n", data.DnsAt(0))
 	str = str + fmt.Sprintf("  %12s\n", data.DnsAt(1))
 	str = str + "\n"

--- a/modules/security/widget.go
+++ b/modules/security/widget.go
@@ -16,7 +16,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, "Security", "security", false),
+		TextWidget: wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, false),
 
 		settings: settings,
 	}

--- a/modules/security/widget.go
+++ b/modules/security/widget.go
@@ -16,7 +16,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, false),
+		TextWidget: wtf.NewTextWidget(app, settings.common, false),
 
 		settings: settings,
 	}

--- a/modules/spotify/settings.go
+++ b/modules/spotify/settings.go
@@ -1,0 +1,18 @@
+package spotify
+
+import (
+	"github.com/olebedev/config"
+	"github.com/wtfutil/wtf/cfg"
+)
+
+type Settings struct {
+	common *cfg.Common
+}
+
+func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
+	settings := Settings{
+		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+	}
+
+	return &settings
+}

--- a/modules/spotify/settings.go
+++ b/modules/spotify/settings.go
@@ -5,13 +5,15 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
+const configKey = "spotify"
+
 type Settings struct {
 	common *cfg.Common
 }
 
-func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
+func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
 	}
 
 	return &settings

--- a/modules/spotify/widget.go
+++ b/modules/spotify/widget.go
@@ -20,17 +20,21 @@ const HelpText = `
 type Widget struct {
 	wtf.HelpfulWidget
 	wtf.TextWidget
-	spotigopher.SpotifyClient
+
+	settings *Settings
 	spotigopher.Info
+	spotigopher.SpotifyClient
 }
 
-func NewWidget(app *tview.Application, pages *tview.Pages) *Widget {
+func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	spotifyClient := spotigopher.NewClient()
 	widget := Widget{
 		HelpfulWidget: wtf.NewHelpfulWidget(app, pages, HelpText),
 		TextWidget:    wtf.NewTextWidget(app, "Spotify", "spotify", true),
-		SpotifyClient: spotifyClient,
+
 		Info:          spotigopher.Info{},
+		SpotifyClient: spotifyClient,
+		settings:      settings,
 	}
 	widget.HelpfulWidget.SetView(widget.View)
 	widget.TextWidget.RefreshInt = 5

--- a/modules/spotify/widget.go
+++ b/modules/spotify/widget.go
@@ -30,7 +30,7 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 	spotifyClient := spotigopher.NewClient()
 	widget := Widget{
 		HelpfulWidget: wtf.NewHelpfulWidget(app, pages, HelpText),
-		TextWidget:    wtf.NewTextWidget(app, "Spotify", "spotify", true),
+		TextWidget:    wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, true),
 
 		Info:          spotigopher.Info{},
 		SpotifyClient: spotifyClient,

--- a/modules/spotify/widget.go
+++ b/modules/spotify/widget.go
@@ -30,14 +30,16 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 	spotifyClient := spotigopher.NewClient()
 	widget := Widget{
 		HelpfulWidget: wtf.NewHelpfulWidget(app, pages, HelpText),
-		TextWidget:    wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, true),
+		TextWidget:    wtf.NewTextWidget(app, settings.common, true),
 
 		Info:          spotigopher.Info{},
 		SpotifyClient: spotifyClient,
 		settings:      settings,
 	}
+
+	widget.settings.common.RefreshInterval = 5
+
 	widget.HelpfulWidget.SetView(widget.View)
-	widget.TextWidget.RefreshInt = 5
 	widget.View.SetInputCapture(widget.captureInput)
 	widget.View.SetWrap(true)
 	widget.View.SetWordWrap(true)

--- a/modules/spotifyweb/settings.go
+++ b/modules/spotifyweb/settings.go
@@ -1,0 +1,30 @@
+package spotifyweb
+
+import (
+	"os"
+
+	"github.com/olebedev/config"
+	"github.com/wtfutil/wtf/cfg"
+)
+
+type Settings struct {
+	common *cfg.Common
+
+	callbackPort string
+	clientID     string
+	secretKey    string
+}
+
+func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
+	localConfig, _ := ymlConfig.Get("wtf.mods.spotifyweb")
+
+	settings := Settings{
+		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+
+		callbackPort: localConfig.UString("callbackPort", "8080"),
+		clientID:     localConfig.UString("clientID", os.Getenv("SPOTIFY_ID")),
+		secretKey:    localConfig.UString("secretKey", os.Getenv("SPOTIFY_SECRET")),
+	}
+
+	return &settings
+}

--- a/modules/spotifyweb/settings.go
+++ b/modules/spotifyweb/settings.go
@@ -7,6 +7,8 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
+const configKey = "spotifyweb"
+
 type Settings struct {
 	common *cfg.Common
 
@@ -15,11 +17,11 @@ type Settings struct {
 	secretKey    string
 }
 
-func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
-	localConfig, _ := ymlConfig.Get("wtf.mods.spotifyweb")
+func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
+	localConfig, _ := ymlConfig.Get("wtf.mods." + configKey)
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
 
 		callbackPort: localConfig.UString("callbackPort", "8080"),
 		clientID:     localConfig.UString("clientID", os.Getenv("SPOTIFY_ID")),

--- a/modules/spotifyweb/widget.go
+++ b/modules/spotifyweb/widget.go
@@ -93,7 +93,7 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 
 	widget := Widget{
 		HelpfulWidget: wtf.NewHelpfulWidget(app, pages, HelpText),
-		TextWidget:    wtf.NewTextWidget(app, "SpotifyWeb", "spotifyweb", true),
+		TextWidget:    wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, true),
 
 		Info:        Info{},
 		client:      client,

--- a/modules/spotifyweb/widget.go
+++ b/modules/spotifyweb/widget.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"os"
 	"time"
 
 	"github.com/gdamore/tcell"
@@ -47,10 +46,12 @@ type Info struct {
 type Widget struct {
 	wtf.HelpfulWidget
 	wtf.TextWidget
+
 	Info
-	clientChan  chan *spotify.Client
 	client      *spotify.Client
+	clientChan  chan *spotify.Client
 	playerState *spotify.PlayerState
+	settings    *Settings
 }
 
 var (
@@ -79,27 +80,12 @@ func authHandler(w http.ResponseWriter, r *http.Request) {
 	tempClientChan <- &client
 }
 
-func clientID() string {
-	return wtf.Config.UString(
-		"wtf.mods.spotifyweb.clientID",
-		os.Getenv("SPOTIFY_ID"),
-	)
-}
-
-func secretKey() string {
-	return wtf.Config.UString(
-		"wtf.mods.spotifyweb.secretKey",
-		os.Getenv("SPOTIFY_SECRET"),
-	)
-}
-
 // NewWidget creates a new widget for WTF
-func NewWidget(app *tview.Application, pages *tview.Pages) *Widget {
-	callbackPort = wtf.Config.UString("wtf.mods.spotifyweb.callbackPort", "8080")
-	redirectURI = "http://localhost:" + callbackPort + "/callback"
+func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
+	redirectURI = "http://localhost:" + settings.callbackPort + "/callback"
 
 	auth = spotify.NewAuthenticator(redirectURI, spotify.ScopeUserReadCurrentlyPlaying, spotify.ScopeUserReadPlaybackState, spotify.ScopeUserModifyPlaybackState)
-	auth.SetAuthInfo(clientID(), secretKey())
+	auth.SetAuthInfo(settings.clientID, settings.secretKey)
 	authURL = auth.AuthURL(state)
 
 	var client *spotify.Client
@@ -108,10 +94,12 @@ func NewWidget(app *tview.Application, pages *tview.Pages) *Widget {
 	widget := Widget{
 		HelpfulWidget: wtf.NewHelpfulWidget(app, pages, HelpText),
 		TextWidget:    wtf.NewTextWidget(app, "SpotifyWeb", "spotifyweb", true),
-		Info:          Info{},
-		clientChan:    tempClientChan,
-		client:        client,
-		playerState:   playerState,
+
+		Info:        Info{},
+		client:      client,
+		clientChan:  tempClientChan,
+		playerState: playerState,
+		settings:    settings,
 	}
 
 	http.HandleFunc("/callback", authHandler)

--- a/modules/spotifyweb/widget.go
+++ b/modules/spotifyweb/widget.go
@@ -93,7 +93,7 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 
 	widget := Widget{
 		HelpfulWidget: wtf.NewHelpfulWidget(app, pages, HelpText),
-		TextWidget:    wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, true),
+		TextWidget:    wtf.NewTextWidget(app, settings.common, true),
 
 		Info:        Info{},
 		client:      client,
@@ -135,8 +135,9 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 	// If inconvenient, I'll remove this option and save the URL in a file or some other method.
 	wtf.OpenFile(`"` + authURL + `"`)
 
+	widget.settings.common.RefreshInterval = 5
+
 	widget.HelpfulWidget.SetView(widget.View)
-	widget.TextWidget.RefreshInt = 5
 	widget.View.SetInputCapture(widget.captureInput)
 	widget.View.SetWrap(true)
 	widget.View.SetWordWrap(true)

--- a/modules/status/settings.go
+++ b/modules/status/settings.go
@@ -1,0 +1,18 @@
+package status
+
+import (
+	"github.com/olebedev/config"
+	"github.com/wtfutil/wtf/cfg"
+)
+
+type Settings struct {
+	common *cfg.Common
+}
+
+func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
+	settings := Settings{
+		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+	}
+
+	return &settings
+}

--- a/modules/status/settings.go
+++ b/modules/status/settings.go
@@ -5,13 +5,15 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
+const configKey = "status"
+
 type Settings struct {
 	common *cfg.Common
 }
 
-func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
+func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
 	}
 
 	return &settings

--- a/modules/status/widget.go
+++ b/modules/status/widget.go
@@ -14,7 +14,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, false),
+		TextWidget: wtf.NewTextWidget(app, settings.common, false),
 
 		CurrentIcon: 0,
 		settings:    settings,

--- a/modules/status/widget.go
+++ b/modules/status/widget.go
@@ -14,7 +14,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, "Status", "status", false),
+		TextWidget: wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, false),
 
 		CurrentIcon: 0,
 		settings:    settings,

--- a/modules/status/widget.go
+++ b/modules/status/widget.go
@@ -9,12 +9,15 @@ type Widget struct {
 	wtf.TextWidget
 
 	CurrentIcon int
+	settings    *Settings
 }
 
-func NewWidget(app *tview.Application) *Widget {
+func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget:  wtf.NewTextWidget(app, "Status", "status", false),
+		TextWidget: wtf.NewTextWidget(app, "Status", "status", false),
+
 		CurrentIcon: 0,
+		settings:    settings,
 	}
 
 	return &widget

--- a/modules/system/settings.go
+++ b/modules/system/settings.go
@@ -5,13 +5,15 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
+const configKey = "system"
+
 type Settings struct {
 	common *cfg.Common
 }
 
-func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
+func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
 	}
 
 	return &settings

--- a/modules/system/settings.go
+++ b/modules/system/settings.go
@@ -1,0 +1,18 @@
+package system
+
+import (
+	"github.com/olebedev/config"
+	"github.com/wtfutil/wtf/cfg"
+)
+
+type Settings struct {
+	common *cfg.Common
+}
+
+func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
+	settings := Settings{
+		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+	}
+
+	return &settings
+}

--- a/modules/system/widget.go
+++ b/modules/system/widget.go
@@ -11,17 +11,19 @@ import (
 type Widget struct {
 	wtf.TextWidget
 
-	systemInfo *SystemInfo
 	Date       string
 	Version    string
+	settings   *Settings
+	systemInfo *SystemInfo
 }
 
-func NewWidget(app *tview.Application, date, version string) *Widget {
+func NewWidget(app *tview.Application, date, version string, settings *Settings) *Widget {
 	widget := Widget{
 		TextWidget: wtf.NewTextWidget(app, "System", "system", false),
 
-		Date:    date,
-		Version: version,
+		Date:     date,
+		settings: settings,
+		Version:  version,
 	}
 
 	widget.systemInfo = NewSystemInfo()

--- a/modules/system/widget.go
+++ b/modules/system/widget.go
@@ -19,7 +19,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, date, version string, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, "System", "system", false),
+		TextWidget: wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, false),
 
 		Date:     date,
 		settings: settings,

--- a/modules/system/widget.go
+++ b/modules/system/widget.go
@@ -19,7 +19,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, date, version string, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, false),
+		TextWidget: wtf.NewTextWidget(app, settings.common, false),
 
 		Date:     date,
 		settings: settings,

--- a/modules/textfile/settings.go
+++ b/modules/textfile/settings.go
@@ -1,0 +1,28 @@
+package textfile
+
+import (
+	"github.com/olebedev/config"
+	"github.com/wtfutil/wtf/cfg"
+)
+
+type Settings struct {
+	common *cfg.Common
+
+	filePaths   []interface{}
+	format      bool
+	formatStyle string
+}
+
+func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
+	localConfig, _ := ymlConfig.Get("wtf.mods.textfile")
+
+	settings := Settings{
+		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+
+		filePaths:   localConfig.UList("filePaths"),
+		format:      localConfig.UBool("format", false),
+		formatStyle: localConfig.UString("formatStyle", "vim"),
+	}
+
+	return &settings
+}

--- a/modules/textfile/settings.go
+++ b/modules/textfile/settings.go
@@ -5,6 +5,8 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
+const configKey = "textfile"
+
 type Settings struct {
 	common *cfg.Common
 
@@ -13,11 +15,11 @@ type Settings struct {
 	formatStyle string
 }
 
-func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
-	localConfig, _ := ymlConfig.Get("wtf.mods.textfile")
+func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
+	localConfig, _ := ymlConfig.Get("wtf.mods." + configKey)
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
 
 		filePaths:   localConfig.UList("filePaths"),
 		format:      localConfig.UBool("format", false),

--- a/modules/textfile/widget.go
+++ b/modules/textfile/widget.go
@@ -42,19 +42,17 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 	widget := Widget{
 		HelpfulWidget:     wtf.NewHelpfulWidget(app, pages, HelpText),
 		MultiSourceWidget: wtf.NewMultiSourceWidget(settings.common.ConfigKey, "filePath", "filePaths"),
-		TextWidget:        wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, true),
+		TextWidget:        wtf.NewTextWidget(app, settings.common, true),
 
 		settings: settings,
 	}
 
 	// Don't use a timer for this widget, watch for filesystem changes instead
-	widget.RefreshInt = 0
-
-	widget.LoadSources()
-	widget.SetDisplayFunction(widget.display)
+	widget.settings.common.RefreshInterval = 0
 
 	widget.HelpfulWidget.SetView(widget.View)
-
+	widget.LoadSources()
+	widget.SetDisplayFunction(widget.display)
 	widget.View.SetWrap(true)
 	widget.View.SetWordWrap(true)
 	widget.View.SetInputCapture(widget.keyboardIntercept)

--- a/modules/textfile/widget.go
+++ b/modules/textfile/widget.go
@@ -41,8 +41,8 @@ type Widget struct {
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
 		HelpfulWidget:     wtf.NewHelpfulWidget(app, pages, HelpText),
-		MultiSourceWidget: wtf.NewMultiSourceWidget("textfile", "filePath", "filePaths"),
-		TextWidget:        wtf.NewTextWidget(app, "TextFile", "textfile", true),
+		MultiSourceWidget: wtf.NewMultiSourceWidget(settings.common.ConfigKey, "filePath", "filePaths"),
+		TextWidget:        wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, true),
 
 		settings: settings,
 	}

--- a/modules/textfile/widget.go
+++ b/modules/textfile/widget.go
@@ -34,13 +34,17 @@ type Widget struct {
 	wtf.HelpfulWidget
 	wtf.MultiSourceWidget
 	wtf.TextWidget
+
+	settings *Settings
 }
 
-func NewWidget(app *tview.Application, pages *tview.Pages) *Widget {
+func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
 		HelpfulWidget:     wtf.NewHelpfulWidget(app, pages, HelpText),
 		MultiSourceWidget: wtf.NewMultiSourceWidget("textfile", "filePath", "filePaths"),
 		TextWidget:        wtf.NewTextWidget(app, "TextFile", "textfile", true),
+
+		settings: settings,
 	}
 
 	// Don't use a timer for this widget, watch for filesystem changes instead
@@ -76,16 +80,14 @@ func (widget *Widget) display() {
 
 	text := wtf.SigilStr(len(widget.Sources), widget.Idx, widget.View) + "\n"
 
-	if wtf.Config.UBool("wtf.mods.textfile.format", false) {
+	if widget.settings.format {
 		text = text + widget.formattedText()
 	} else {
 		text = text + widget.plainText()
 	}
 
-	//widget.View.Lock()
 	widget.View.SetTitle(title) // <- Writes to TextView's title
 	widget.View.SetText(text)   // <- Writes to TextView's text
-	//widget.View.Unlock()
 }
 
 func (widget *Widget) fileName() string {
@@ -105,7 +107,7 @@ func (widget *Widget) formattedText() string {
 		lexer = lexers.Fallback
 	}
 
-	style := styles.Get(wtf.Config.UString("wtf.mods.textfile.formatStyle", "vim"))
+	style := styles.Get(widget.settings.formatStyle)
 	if style == nil {
 		style = styles.Fallback
 	}

--- a/modules/todo/display.go
+++ b/modules/todo/display.go
@@ -13,7 +13,10 @@ const checkWidth = 4
 
 func (widget *Widget) display() {
 	str := ""
-	newList := checklist.NewChecklist()
+	newList := checklist.NewChecklist(
+		widget.settings.common.Sigils.CheckedIcon,
+		widget.settings.common.Sigils.UncheckedIcon,
+	)
 
 	offset := 0
 
@@ -33,19 +36,19 @@ func (widget *Widget) display() {
 
 	widget.View.Clear()
 	widget.View.SetText(str)
-	widget.View.Highlight(strconv.Itoa(widget.list.Selected)).ScrollToHighlight()
+	widget.View.Highlight(strconv.Itoa(widget.list.Selected())).ScrollToHighlight()
 }
 
 func (widget *Widget) formattedItemLine(idx int, item *checklist.ChecklistItem, selectedItem *checklist.ChecklistItem, maxLen int) string {
-	foreColor, backColor := "white", wtf.Config.UString("wtf.colors.background", "black")
+	foreColor, backColor := widget.settings.common.Colors.Text, widget.settings.common.Colors.Background
 
 	if item.Checked {
-		foreColor = wtf.Config.UString("wtf.colors.checked", "white")
+		foreColor = widget.settings.common.Colors.Checked
 	}
 
 	if widget.View.HasFocus() && (item == selectedItem) {
-		foreColor = wtf.Config.UString("wtf.colors.highlight.fore", "black")
-		backColor = wtf.Config.UString("wtf.colors.highlight.back", "orange")
+		foreColor = widget.settings.common.Colors.HighlightFore
+		backColor = widget.settings.common.Colors.HighlightBack
 	}
 
 	str := fmt.Sprintf(

--- a/modules/todo/settings.go
+++ b/modules/todo/settings.go
@@ -1,0 +1,23 @@
+package todo
+
+import (
+	"github.com/olebedev/config"
+	"github.com/wtfutil/wtf/cfg"
+)
+
+type Settings struct {
+	Common *cfg.Common
+
+	FilePath string
+}
+
+func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
+	localConfig, _ := ymlConfig.Get("wtf.mods.todo")
+
+	settings := Settings{
+		Common:   cfg.NewCommonSettingsFromYAML(ymlConfig),
+		FilePath: localConfig.UString("filename"),
+	}
+
+	return &settings
+}

--- a/modules/todo/settings.go
+++ b/modules/todo/settings.go
@@ -5,17 +5,19 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
+const configKey = "todo"
+
 type Settings struct {
 	common *cfg.Common
 
 	filePath string
 }
 
-func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
-	localConfig, _ := ymlConfig.Get("wtf.mods.todo")
+func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
+	localConfig, _ := ymlConfig.Get("wtf.mods." + configKey)
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
 
 		filePath: localConfig.UString("filename"),
 	}

--- a/modules/todo/settings.go
+++ b/modules/todo/settings.go
@@ -6,17 +6,17 @@ import (
 )
 
 type Settings struct {
-	Common *cfg.Common
+	common *cfg.Common
 
-	FilePath string
+	filePath string
 }
 
 func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
 	localConfig, _ := ymlConfig.Get("wtf.mods.todo")
 
 	settings := Settings{
-		Common:   cfg.NewCommonSettingsFromYAML(ymlConfig),
-		FilePath: localConfig.UString("filename"),
+		common:   cfg.NewCommonSettingsFromYAML(ymlConfig),
+		filePath: localConfig.UString("filename"),
 	}
 
 	return &settings

--- a/modules/todo/settings.go
+++ b/modules/todo/settings.go
@@ -15,7 +15,8 @@ func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
 	localConfig, _ := ymlConfig.Get("wtf.mods.todo")
 
 	settings := Settings{
-		common:   cfg.NewCommonSettingsFromYAML(ymlConfig),
+		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+
 		filePath: localConfig.UString("filename"),
 	}
 

--- a/modules/todo/widget.go
+++ b/modules/todo/widget.go
@@ -40,18 +40,20 @@ type Widget struct {
 	wtf.TextWidget
 
 	app      *tview.Application
+	settings *Settings
 	filePath string
 	list     checklist.Checklist
 	pages    *tview.Pages
 }
 
-func NewWidget(app *tview.Application, pages *tview.Pages) *Widget {
+func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
 		HelpfulWidget: wtf.NewHelpfulWidget(app, pages, HelpText),
 		TextWidget:    wtf.NewTextWidget(app, "Todo", "todo", true),
 
 		app:      app,
-		filePath: wtf.Config.UString("wtf.mods.todo.filename"),
+		settings: settings,
+		filePath: settings.FilePath,
 		list:     checklist.NewChecklist(),
 		pages:    pages,
 	}
@@ -255,11 +257,8 @@ func (widget *Widget) modalFocus(form *tview.Form) {
 }
 
 func (widget *Widget) modalForm(lbl, text string) *tview.Form {
-	form := tview.NewForm().
-		SetFieldBackgroundColor(wtf.ColorFor(wtf.Config.UString("wtf.colors.background", "black")))
-
-	form.SetButtonsAlign(tview.AlignCenter).
-		SetButtonTextColor(wtf.ColorFor(wtf.Config.UString("wtf.colors.text", "white")))
+	form := tview.NewForm().SetFieldBackgroundColor(wtf.ColorFor(widget.settings.Common.Colors.Background))
+	form.SetButtonsAlign(tview.AlignCenter).SetButtonTextColor(wtf.ColorFor(widget.settings.Common.Colors.Text))
 
 	form.AddInputField(lbl, text, 60, nil, nil)
 

--- a/modules/todo/widget.go
+++ b/modules/todo/widget.go
@@ -49,7 +49,7 @@ type Widget struct {
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
 		HelpfulWidget: wtf.NewHelpfulWidget(app, pages, HelpText),
-		TextWidget:    wtf.NewTextWidget(app, "Todo", "todo", true),
+		TextWidget:    wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, true),
 
 		app:      app,
 		settings: settings,

--- a/modules/todo/widget.go
+++ b/modules/todo/widget.go
@@ -53,7 +53,7 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 
 		app:      app,
 		settings: settings,
-		filePath: settings.FilePath,
+		filePath: settings.filePath,
 		list:     checklist.NewChecklist(),
 		pages:    pages,
 	}
@@ -257,8 +257,8 @@ func (widget *Widget) modalFocus(form *tview.Form) {
 }
 
 func (widget *Widget) modalForm(lbl, text string) *tview.Form {
-	form := tview.NewForm().SetFieldBackgroundColor(wtf.ColorFor(widget.settings.Common.Colors.Background))
-	form.SetButtonsAlign(tview.AlignCenter).SetButtonTextColor(wtf.ColorFor(widget.settings.Common.Colors.Text))
+	form := tview.NewForm().SetFieldBackgroundColor(wtf.ColorFor(widget.settings.common.Colors.Background))
+	form.SetButtonsAlign(tview.AlignCenter).SetButtonTextColor(wtf.ColorFor(widget.settings.common.Colors.Text))
 
 	form.AddInputField(lbl, text, 60, nil, nil)
 

--- a/modules/todo/widget.go
+++ b/modules/todo/widget.go
@@ -193,7 +193,10 @@ func (widget *Widget) load() {
 	filePath := fmt.Sprintf("%s/%s", confDir, widget.filePath)
 
 	fileData, _ := wtf.ReadFileBytes(filePath)
+
 	yaml.Unmarshal(fileData, &widget.list)
+
+	widget.setItemChecks()
 }
 
 func (widget *Widget) newItem() {
@@ -224,6 +227,15 @@ func (widget *Widget) persist() {
 
 	if err != nil {
 		panic(err)
+	}
+}
+
+// setItemChecks rolls through the checklist and ensures that all checklist
+// items have the correct checked/unchecked icon per the user's preferences
+func (widget *Widget) setItemChecks() {
+	for _, item := range widget.list.Items {
+		item.CheckedIcon = widget.settings.common.CheckedIcon
+		item.UncheckedIcon = widget.settings.common.UncheckedIcon
 	}
 }
 

--- a/modules/todo/widget.go
+++ b/modules/todo/widget.go
@@ -49,7 +49,7 @@ type Widget struct {
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
 		HelpfulWidget: wtf.NewHelpfulWidget(app, pages, HelpText),
-		TextWidget:    wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, true),
+		TextWidget:    wtf.NewTextWidget(app, settings.common, true),
 
 		app:      app,
 		settings: settings,

--- a/modules/todo/widget.go
+++ b/modules/todo/widget.go
@@ -54,7 +54,7 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 		app:      app,
 		settings: settings,
 		filePath: settings.filePath,
-		list:     checklist.NewChecklist(),
+		list:     checklist.NewChecklist(settings.common.Sigils.CheckedIcon, settings.common.Sigils.UncheckedIcon),
 		pages:    pages,
 	}
 

--- a/modules/todoist/display.go
+++ b/modules/todoist/display.go
@@ -24,11 +24,11 @@ func (widget *Widget) display() {
 	maxLen := proj.LongestLine()
 
 	for index, item := range proj.tasks {
-		foreColor, backColor := "white", wtf.Config.UString("wtf.colors.background", "black")
+		foreColor, backColor := widget.settings.common.Colors.Text, widget.settings.common.Colors.Background
 
 		if index == proj.index {
-			foreColor = wtf.Config.UString("wtf.colors.highlight.fore", "black")
-			backColor = wtf.Config.UString("wtf.colors.highlight.back", "orange")
+			foreColor = widget.settings.common.Colors.HighlightFore
+			backColor = widget.settings.common.Colors.HighlightBack
 		}
 
 		row := fmt.Sprintf(

--- a/modules/todoist/display.go
+++ b/modules/todoist/display.go
@@ -46,6 +46,5 @@ func (widget *Widget) display() {
 		str = str + row + wtf.PadRow((checkWidth+len(item.Content)), (checkWidth+maxLen+1)) + "\n"
 	}
 
-	//widget.View.Clear()
 	widget.View.SetText(str)
 }

--- a/modules/todoist/settings.go
+++ b/modules/todoist/settings.go
@@ -1,0 +1,28 @@
+package todoist
+
+import (
+	"os"
+
+	"github.com/olebedev/config"
+	"github.com/wtfutil/wtf/cfg"
+)
+
+type Settings struct {
+	common *cfg.Common
+
+	apiKey   string
+	projects []interface{}
+}
+
+func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
+	localConfig, _ := ymlConfig.Get("wtf.mods.todoist")
+
+	settings := Settings{
+		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+
+		apiKey:   localConfig.UString("apiKey", os.Getenv("WTF_TODOIST_TOKEN")),
+		projects: localConfig.UList("projects"),
+	}
+
+	return &settings
+}

--- a/modules/todoist/settings.go
+++ b/modules/todoist/settings.go
@@ -7,6 +7,8 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
+const configKey = "todoist"
+
 type Settings struct {
 	common *cfg.Common
 
@@ -14,11 +16,11 @@ type Settings struct {
 	projects []interface{}
 }
 
-func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
-	localConfig, _ := ymlConfig.Get("wtf.mods.todoist")
+func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
+	localConfig, _ := ymlConfig.Get("wtf.mods." + configKey)
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
 
 		apiKey:   localConfig.UString("apiKey", os.Getenv("WTF_TODOIST_TOKEN")),
 		projects: localConfig.UList("projects"),

--- a/modules/todoist/widget.go
+++ b/modules/todoist/widget.go
@@ -37,7 +37,7 @@ type Widget struct {
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
 		HelpfulWidget: wtf.NewHelpfulWidget(app, pages, HelpText),
-		TextWidget:    wtf.NewTextWidget(app, "Todoist", "todoist", true),
+		TextWidget:    wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, true),
 
 		settings: settings,
 	}

--- a/modules/todoist/widget.go
+++ b/modules/todoist/widget.go
@@ -37,7 +37,7 @@ type Widget struct {
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
 		HelpfulWidget: wtf.NewHelpfulWidget(app, pages, HelpText),
-		TextWidget:    wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, true),
+		TextWidget:    wtf.NewTextWidget(app, settings.common, true),
 
 		settings: settings,
 	}

--- a/modules/travisci/settings.go
+++ b/modules/travisci/settings.go
@@ -7,18 +7,20 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
+const configKey = "travisci"
+
 type Settings struct {
-	Common *cfg.Common
+	common *cfg.Common
 
 	apiKey string
 	pro    bool
 }
 
-func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
-	localConfig, _ := ymlConfig.Get("wtf.mods.travisci")
+func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
+	localConfig, _ := ymlConfig.Get("wtf.mods." + configKey)
 
 	settings := Settings{
-		Common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
 
 		apiKey: localConfig.UString("apiKey", os.Getenv("WTF_TRAVIS_API_TOKEN")),
 		pro:    localConfig.UBool("pro", false),

--- a/modules/travisci/settings.go
+++ b/modules/travisci/settings.go
@@ -1,4 +1,4 @@
-package circleci
+package travisci
 
 import (
 	"os"
@@ -11,14 +11,17 @@ type Settings struct {
 	Common *cfg.Common
 
 	apiKey string
+	pro    bool
 }
 
 func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
-	localConfig, _ := ymlConfig.Get("wtf.mods.circleci")
+	localConfig, _ := ymlConfig.Get("wtf.mods.travisci")
 
 	settings := Settings{
 		Common: cfg.NewCommonSettingsFromYAML(ymlConfig),
-		apiKey: localConfig.UString("apiKey", os.Getenv("WTF_CIRCLE_API_KEY")),
+
+		apiKey: localConfig.UString("apiKey", os.Getenv("WTF_TRAVIS_API_TOKEN")),
+		pro:    localConfig.UBool("pro", false),
 	}
 
 	return &settings

--- a/modules/travisci/widget.go
+++ b/modules/travisci/widget.go
@@ -34,7 +34,7 @@ type Widget struct {
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
 		HelpfulWidget: wtf.NewHelpfulWidget(app, pages, HelpText),
-		TextWidget:    wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, true),
+		TextWidget:    wtf.NewTextWidget(app, settings.common, true),
 
 		settings: settings,
 	}

--- a/modules/travisci/widget.go
+++ b/modules/travisci/widget.go
@@ -28,12 +28,15 @@ type Widget struct {
 
 	builds   *Builds
 	selected int
+	settings *Settings
 }
 
-func NewWidget(app *tview.Application, pages *tview.Pages) *Widget {
+func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
 		HelpfulWidget: wtf.NewHelpfulWidget(app, pages, HelpText),
 		TextWidget:    wtf.NewTextWidget(app, "TravisCI", "travisci", true),
+
+		settings: settings,
 	}
 
 	widget.HelpfulWidget.SetView(widget.View)
@@ -51,7 +54,7 @@ func (widget *Widget) Refresh() {
 		return
 	}
 
-	builds, err := BuildsFor()
+	builds, err := BuildsFor(widget.settings.apiKey, widget.settings.pro)
 
 	if err != nil {
 		widget.View.SetWrap(true)

--- a/modules/travisci/widget.go
+++ b/modules/travisci/widget.go
@@ -34,7 +34,7 @@ type Widget struct {
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
 		HelpfulWidget: wtf.NewHelpfulWidget(app, pages, HelpText),
-		TextWidget:    wtf.NewTextWidget(app, "TravisCI", "travisci", true),
+		TextWidget:    wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, true),
 
 		settings: settings,
 	}

--- a/modules/travisci/widget.go
+++ b/modules/travisci/widget.go
@@ -150,7 +150,7 @@ func (widget *Widget) openBuild() {
 	sel := widget.selected
 	if sel >= 0 && widget.builds != nil && sel < len(widget.builds.Builds) {
 		build := &widget.builds.Builds[widget.selected]
-		travisHost := TRAVIS_HOSTS[wtf.Config.UBool("wtf.mods.travisci.pro", false)]
+		travisHost := TRAVIS_HOSTS[widget.settings.pro]
 		wtf.OpenFile(fmt.Sprintf("https://%s/%s/%s/%d", travisHost, build.Repository.Slug, "builds", build.ID))
 	}
 }

--- a/modules/trello/client.go
+++ b/modules/trello/client.go
@@ -4,11 +4,10 @@ import (
 	"fmt"
 
 	"github.com/adlio/trello"
-	"github.com/wtfutil/wtf/wtf"
 )
 
-func GetCards(client *trello.Client, lists map[string]string) (*SearchResult, error) {
-	boardID, err := getBoardID(client)
+func GetCards(client *trello.Client, username string, boardName string, lists map[string]string) (*SearchResult, error) {
+	boardID, err := getBoardID(client, username, boardName)
 	if err != nil {
 		return nil, err
 	}
@@ -43,8 +42,8 @@ func GetCards(client *trello.Client, lists map[string]string) (*SearchResult, er
 	return searchResult, nil
 }
 
-func getBoardID(client *trello.Client) (string, error) {
-	member, err := client.GetMember(wtf.Config.UString("wtf.mods.trello.username"), trello.Defaults())
+func getBoardID(client *trello.Client, username, boardName string) (string, error) {
+	member, err := client.GetMember(username, trello.Defaults())
 	if err != nil {
 		return "", err
 	}
@@ -55,12 +54,12 @@ func getBoardID(client *trello.Client) (string, error) {
 	}
 
 	for _, board := range boards {
-		if board.Name == wtf.Config.UString("wtf.mods.trello.board") {
+		if board.Name == boardName {
 			return board.ID, nil
 		}
 	}
 
-	return "", fmt.Errorf("could not find board with name %s", wtf.Config.UString("wtf.mods.trello.board"))
+	return "", fmt.Errorf("could not find board with name %s", boardName)
 }
 
 func getListIDs(client *trello.Client, boardID string, lists map[string]string) (map[string]string, error) {

--- a/modules/trello/settings.go
+++ b/modules/trello/settings.go
@@ -1,0 +1,56 @@
+package trello
+
+import (
+	"os"
+
+	"github.com/olebedev/config"
+	"github.com/wtfutil/wtf/cfg"
+)
+
+type Settings struct {
+	common *cfg.Common
+
+	accessToken string
+	apiKey      string
+	board       string
+	list        map[string]string
+	username    string
+}
+
+func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
+	localConfig, _ := ymlConfig.Get("wtf.mods.trello")
+
+	settings := Settings{
+		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+
+		accessToken: localConfig.UString("accessToken", os.Getenv("WTF_TRELLO_ACCESS_TOKEN")),
+		apiKey:      localConfig.UString("apiKey", os.Getenv("WTF_TRELLO_APP_KEY")),
+		board:       localConfig.UString("board"),
+		username:    localConfig.UString("username"),
+	}
+
+	settings.list = mapifyList(localConfig)
+
+	return &settings
+}
+
+func mapifyList(localConfig *config.Config) map[string]string {
+	lists := make(map[string]string)
+
+	// Single list
+	list, err := localConfig.String("list")
+	if err == nil {
+		lists[list] = ""
+		return lists
+	}
+
+	// Array of lists
+	listList := localConfig.UList("project")
+	for _, listName := range listList {
+		if list, ok := listName.(string); ok {
+			lists[list] = ""
+		}
+	}
+
+	return lists
+}

--- a/modules/trello/settings.go
+++ b/modules/trello/settings.go
@@ -7,6 +7,8 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
+const configKey = "trello"
+
 type Settings struct {
 	common *cfg.Common
 
@@ -17,11 +19,11 @@ type Settings struct {
 	username    string
 }
 
-func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
-	localConfig, _ := ymlConfig.Get("wtf.mods.trello")
+func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
+	localConfig, _ := ymlConfig.Get("wtf.mods." + configKey)
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
 
 		accessToken: localConfig.UString("accessToken", os.Getenv("WTF_TRELLO_ACCESS_TOKEN")),
 		apiKey:      localConfig.UString("apiKey", os.Getenv("WTF_TRELLO_APP_KEY")),

--- a/modules/trello/widget.go
+++ b/modules/trello/widget.go
@@ -16,7 +16,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, "Trello", "trello", false),
+		TextWidget: wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, false),
 
 		settings: settings,
 	}

--- a/modules/trello/widget.go
+++ b/modules/trello/widget.go
@@ -16,7 +16,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, false),
+		TextWidget: wtf.NewTextWidget(app, settings.common, false),
 
 		settings: settings,
 	}

--- a/modules/twitter/client.go
+++ b/modules/twitter/client.go
@@ -3,10 +3,7 @@ package twitter
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"strconv"
-
-	"github.com/wtfutil/wtf/wtf"
 )
 
 /* NOTE: Currently single application ONLY
@@ -22,14 +19,13 @@ type Client struct {
 }
 
 // NewClient creates and returns a new Twitter client
-func NewClient() *Client {
+func NewClient(settings *Settings) *Client {
 	client := Client{
-		apiBase:    "https://api.twitter.com/1.1/",
-		count:      wtf.Config.UInt("wtf.mods.twitter.count", 5),
-		screenName: "",
+		apiBase:     "https://api.twitter.com/1.1/",
+		count:       settings.count,
+		screenName:  "",
+		bearerToken: settings.bearerToken,
 	}
-
-	client.loadAPICredentials()
 
 	return &client
 }
@@ -64,11 +60,4 @@ func (client *Client) tweets() (tweets []Tweet, err error) {
 	err = json.Unmarshal(data, &tweets)
 
 	return
-}
-
-func (client *Client) loadAPICredentials() {
-	client.bearerToken = wtf.Config.UString(
-		"wtf.mods.twitter.bearerToken",
-		os.Getenv("WTF_TWITTER_BEARER_TOKEN"),
-	)
 }

--- a/modules/twitter/request.go
+++ b/modules/twitter/request.go
@@ -13,8 +13,7 @@ func Request(bearerToken string, apiURL string) ([]byte, error) {
 	}
 
 	// Expected authorization format for single-application twitter dev accounts
-	req.Header.Add("Authorization",
-		fmt.Sprintf("Bearer %s", bearerToken))
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", bearerToken))
 
 	client := &http.Client{}
 	resp, err := client.Do(req)

--- a/modules/twitter/settings.go
+++ b/modules/twitter/settings.go
@@ -1,0 +1,30 @@
+package twitter
+
+import (
+	"os"
+
+	"github.com/olebedev/config"
+	"github.com/wtfutil/wtf/cfg"
+)
+
+type Settings struct {
+	common *cfg.Common
+
+	bearerToken string
+	count       int
+	screenNames []interface{}
+}
+
+func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
+	localConfig, _ := ymlConfig.Get("wtf.mods.twitter")
+
+	settings := Settings{
+		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+
+		bearerToken: localConfig.UString("bearerToken", os.Getenv("WTF_TWITTER_BEARER_TOKEN")),
+		count:       localConfig.UInt("count", 5),
+		screenNames: localConfig.UList("screenName"),
+	}
+
+	return &settings
+}

--- a/modules/twitter/settings.go
+++ b/modules/twitter/settings.go
@@ -7,6 +7,8 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
+const configKey = "twitter"
+
 type Settings struct {
 	common *cfg.Common
 
@@ -15,11 +17,11 @@ type Settings struct {
 	screenNames []interface{}
 }
 
-func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
-	localConfig, _ := ymlConfig.Get("wtf.mods.twitter")
+func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
+	localConfig, _ := ymlConfig.Get("wtf.mods." + configKey)
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
 
 		bearerToken: localConfig.UString("bearerToken", os.Getenv("WTF_TWITTER_BEARER_TOKEN")),
 		count:       localConfig.UInt("count", 5),

--- a/modules/twitter/widget.go
+++ b/modules/twitter/widget.go
@@ -36,8 +36,8 @@ type Widget struct {
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
 		HelpfulWidget:     wtf.NewHelpfulWidget(app, pages, HelpText),
-		MultiSourceWidget: wtf.NewMultiSourceWidget("twitter", "screenName", "screenNames"),
-		TextWidget:        wtf.NewTextWidget(app, "Twitter", "twitter", true),
+		MultiSourceWidget: wtf.NewMultiSourceWidget(settings.common.ConfigKey, "screenName", "screenNames"),
+		TextWidget:        wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, true),
 
 		idx:      0,
 		settings: settings,

--- a/modules/twitter/widget.go
+++ b/modules/twitter/widget.go
@@ -27,18 +27,20 @@ type Widget struct {
 	wtf.MultiSourceWidget
 	wtf.TextWidget
 
-	client  *Client
-	idx     int
-	sources []string
+	client   *Client
+	idx      int
+	settings *Settings
+	sources  []string
 }
 
-func NewWidget(app *tview.Application, pages *tview.Pages) *Widget {
+func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
 		HelpfulWidget:     wtf.NewHelpfulWidget(app, pages, HelpText),
 		MultiSourceWidget: wtf.NewMultiSourceWidget("twitter", "screenName", "screenNames"),
 		TextWidget:        wtf.NewTextWidget(app, "Twitter", "twitter", true),
 
-		idx: 0,
+		idx:      0,
+		settings: settings,
 	}
 
 	widget.HelpfulWidget.SetView(widget.View)
@@ -46,7 +48,7 @@ func NewWidget(app *tview.Application, pages *tview.Pages) *Widget {
 	widget.LoadSources()
 	widget.SetDisplayFunction(widget.display)
 
-	widget.client = NewClient()
+	widget.client = NewClient(settings)
 
 	widget.View.SetBorderPadding(1, 1, 1, 1)
 	widget.View.SetWrap(true)
@@ -163,6 +165,4 @@ func (widget *Widget) keyboardIntercept(event *tcell.EventKey) *tcell.EventKey {
 	default:
 		return event
 	}
-
-	return event
 }

--- a/modules/twitter/widget.go
+++ b/modules/twitter/widget.go
@@ -37,7 +37,7 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 	widget := Widget{
 		HelpfulWidget:     wtf.NewHelpfulWidget(app, pages, HelpText),
 		MultiSourceWidget: wtf.NewMultiSourceWidget(settings.common.ConfigKey, "screenName", "screenNames"),
-		TextWidget:        wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, true),
+		TextWidget:        wtf.NewTextWidget(app, settings.common, true),
 
 		idx:      0,
 		settings: settings,

--- a/modules/unknown/settings.go
+++ b/modules/unknown/settings.go
@@ -5,13 +5,15 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
+const configKey = "unkown"
+
 type Settings struct {
 	common *cfg.Common
 }
 
-func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
+func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
 	}
 
 	return &settings

--- a/modules/unknown/settings.go
+++ b/modules/unknown/settings.go
@@ -1,0 +1,18 @@
+package unknown
+
+import (
+	"github.com/olebedev/config"
+	"github.com/wtfutil/wtf/cfg"
+)
+
+type Settings struct {
+	common *cfg.Common
+}
+
+func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
+	settings := Settings{
+		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+	}
+
+	return &settings
+}

--- a/modules/unknown/widget.go
+++ b/modules/unknown/widget.go
@@ -15,7 +15,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, name string, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, name, name, false),
+		TextWidget: wtf.NewTextWidget(app, settings.common, false),
 
 		settings: settings,
 	}

--- a/modules/unknown/widget.go
+++ b/modules/unknown/widget.go
@@ -9,11 +9,15 @@ import (
 
 type Widget struct {
 	wtf.TextWidget
+
+	settings *Settings
 }
 
-func NewWidget(app *tview.Application, name string) *Widget {
+func NewWidget(app *tview.Application, name string, settings *Settings) *Widget {
 	widget := Widget{
 		TextWidget: wtf.NewTextWidget(app, name, name, false),
+
+		settings: settings,
 	}
 
 	return &widget
@@ -22,7 +26,6 @@ func NewWidget(app *tview.Application, name string) *Widget {
 /* -------------------- Exported Functions -------------------- */
 
 func (widget *Widget) Refresh() {
-
 	widget.View.SetTitle(widget.ContextualTitle(fmt.Sprintf("%s", widget.Name())))
 	widget.View.Clear()
 

--- a/modules/victorops/client.go
+++ b/modules/victorops/client.go
@@ -4,34 +4,20 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"os"
 	"strings"
 
 	"github.com/wtfutil/wtf/logger"
-	"github.com/wtfutil/wtf/wtf"
 )
 
 // Fetch gets the current oncall users
-func Fetch() ([]OnCallTeam, error) {
+func Fetch(apiID, apiKey string) ([]OnCallTeam, error) {
 	scheduleURL := "https://api.victorops.com/api-public/v1/oncall/current"
-	response, err := victorOpsRequest(scheduleURL, apiID(), apiKey())
+	response, err := victorOpsRequest(scheduleURL, apiID, apiKey)
+
 	return response, err
 }
 
 /* ---------------- Unexported Functions ---------------- */
-func apiID() string {
-	return wtf.Config.UString(
-		"wtf.mods.victorops.apiID",
-		os.Getenv("WTF_VICTOROPS_API_ID"),
-	)
-}
-
-func apiKey() string {
-	return wtf.Config.UString(
-		"wtf.mods.victorops.apiKey",
-		os.Getenv("WTF_VICTOROPS_API_KEY"),
-	)
-}
 
 func victorOpsRequest(url string, apiID string, apiKey string) ([]OnCallTeam, error) {
 	req, err := http.NewRequest("GET", url, nil)

--- a/modules/victorops/settings.go
+++ b/modules/victorops/settings.go
@@ -7,6 +7,8 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
+const configKey = "victorops"
+
 type Settings struct {
 	common *cfg.Common
 
@@ -15,11 +17,11 @@ type Settings struct {
 	team   string
 }
 
-func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
-	localConfig, _ := ymlConfig.Get("wtf.mods.victorops")
+func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
+	localConfig, _ := ymlConfig.Get("wtf.mods." + configKey)
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
 
 		apiID:  localConfig.UString("apiID", os.Getenv("WTF_VICTOROPS_API_ID")),
 		apiKey: localConfig.UString("apiKey", os.Getenv("WTF_VICTOROPS_API_KEY")),

--- a/modules/victorops/settings.go
+++ b/modules/victorops/settings.go
@@ -1,0 +1,30 @@
+package victorops
+
+import (
+	"os"
+
+	"github.com/olebedev/config"
+	"github.com/wtfutil/wtf/cfg"
+)
+
+type Settings struct {
+	common *cfg.Common
+
+	apiID  string
+	apiKey string
+	team   string
+}
+
+func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
+	localConfig, _ := ymlConfig.Get("wtf.mods.victorops")
+
+	settings := Settings{
+		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+
+		apiID:  localConfig.UString("apiID", os.Getenv("WTF_VICTOROPS_API_ID")),
+		apiKey: localConfig.UString("apiKey", os.Getenv("WTF_VICTOROPS_API_KEY")),
+		team:   localConfig.UString("team"),
+	}
+
+	return &settings
+}

--- a/modules/victorops/widget.go
+++ b/modules/victorops/widget.go
@@ -27,7 +27,7 @@ type Widget struct {
 // NewWidget creates a new widget
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, true),
+		TextWidget: wtf.NewTextWidget(app, settings.common, true),
 	}
 
 	widget.View.SetScrollable(true)

--- a/modules/victorops/widget.go
+++ b/modules/victorops/widget.go
@@ -19,11 +19,13 @@ const HelpText = `
 // Widget contains text info
 type Widget struct {
 	wtf.TextWidget
-	teams []OnCallTeam
+
+	teams    []OnCallTeam
+	settings *Settings
 }
 
 // NewWidget creates a new widget
-func NewWidget(app *tview.Application) *Widget {
+func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
 		TextWidget: wtf.NewTextWidget(app, "VictorOps - OnCall", "victorops", true),
 	}
@@ -40,7 +42,7 @@ func (widget *Widget) Refresh() {
 		return
 	}
 
-	teams, err := Fetch()
+	teams, err := Fetch(widget.settings.apiID, widget.settings.apiKey)
 	widget.View.SetTitle(widget.ContextualTitle(widget.Name()))
 
 	if err != nil {
@@ -64,10 +66,10 @@ func (widget *Widget) display() {
 }
 
 func (widget *Widget) contentFrom(teams []OnCallTeam) string {
-	teamToDisplay := wtf.Config.UString("wtf.mods.victorops.team")
 	var str string
+
 	for _, team := range teams {
-		if len(teamToDisplay) > 0 && teamToDisplay != team.Slug {
+		if len(widget.settings.team) > 0 && widget.settings.team != team.Slug {
 			continue
 		}
 

--- a/modules/victorops/widget.go
+++ b/modules/victorops/widget.go
@@ -27,7 +27,7 @@ type Widget struct {
 // NewWidget creates a new widget
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, "VictorOps - OnCall", "victorops", true),
+		TextWidget: wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, true),
 	}
 
 	widget.View.SetScrollable(true)

--- a/modules/weatherservices/prettyweather/settings.go
+++ b/modules/weatherservices/prettyweather/settings.go
@@ -5,6 +5,8 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
+const configKey = "prettyweather"
+
 type Settings struct {
 	common *cfg.Common
 
@@ -14,11 +16,11 @@ type Settings struct {
 	language string
 }
 
-func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
-	localConfig, _ := ymlConfig.Get("wtf.mods.prettyweather")
+func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
+	localConfig, _ := ymlConfig.Get("wtf.mods." + configKey)
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
 
 		city:     localConfig.UString("city", "Barcelona"),
 		language: localConfig.UString("language", "en"),

--- a/modules/weatherservices/prettyweather/settings.go
+++ b/modules/weatherservices/prettyweather/settings.go
@@ -1,0 +1,30 @@
+package prettyweather
+
+import (
+	"github.com/olebedev/config"
+	"github.com/wtfutil/wtf/cfg"
+)
+
+type Settings struct {
+	common *cfg.Common
+
+	city     string
+	unit     string
+	view     string
+	language string
+}
+
+func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
+	localConfig, _ := ymlConfig.Get("wtf.mods.prettyweather")
+
+	settings := Settings{
+		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+
+		city:     localConfig.UString("city", "Barcelona"),
+		language: localConfig.UString("language", "en"),
+		unit:     localConfig.UString("unit", "m"),
+		view:     localConfig.UString("view", "0"),
+	}
+
+	return &settings
+}

--- a/modules/weatherservices/prettyweather/widget.go
+++ b/modules/weatherservices/prettyweather/widget.go
@@ -18,7 +18,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, false),
+		TextWidget: wtf.NewTextWidget(app, settings.common, false),
 
 		settings: settings,
 	}

--- a/modules/weatherservices/prettyweather/widget.go
+++ b/modules/weatherservices/prettyweather/widget.go
@@ -18,7 +18,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, "Pretty Weather", "prettyweather", false),
+		TextWidget: wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, false),
 
 		settings: settings,
 	}

--- a/modules/weatherservices/prettyweather/widget.go
+++ b/modules/weatherservices/prettyweather/widget.go
@@ -11,16 +11,16 @@ import (
 
 type Widget struct {
 	wtf.TextWidget
+
 	result   string
-	unit     string
-	city     string
-	view     string
-	language string
+	settings *Settings
 }
 
-func NewWidget(app *tview.Application) *Widget {
+func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
 		TextWidget: wtf.NewTextWidget(app, "Pretty Weather", "prettyweather", false),
+
+		settings: settings,
 	}
 
 	return &widget
@@ -35,17 +35,18 @@ func (widget *Widget) Refresh() {
 //this method reads the config and calls wttr.in for pretty weather
 func (widget *Widget) prettyWeather() {
 	client := &http.Client{}
-	widget.unit = wtf.Config.UString("wtf.mods.prettyweather.unit", "m")
-	widget.city = wtf.Config.UString("wtf.mods.prettyweather.city", "")
-	widget.view = wtf.Config.UString("wtf.mods.prettyweather.view", "0")
-	widget.language = wtf.Config.UString("wtf.mods.prettyweather.language", "en")
-	req, err := http.NewRequest("GET", "https://wttr.in/"+widget.city+"?"+widget.view+"?"+widget.unit, nil)
+
+	city := widget.settings.city
+	unit := widget.settings.unit
+	view := widget.settings.view
+
+	req, err := http.NewRequest("GET", "https://wttr.in/"+city+"?"+view+"?"+unit, nil)
 	if err != nil {
 		widget.result = err.Error()
 		return
 	}
 
-	req.Header.Set("Accept-Language", widget.language)
+	req.Header.Set("Accept-Language", widget.settings.language)
 	req.Header.Set("User-Agent", "curl")
 	response, err := client.Do(req)
 	if err != nil {
@@ -61,6 +62,5 @@ func (widget *Widget) prettyWeather() {
 		return
 	}
 
-	//widget.result = strings.TrimSpace(string(contents))
 	widget.result = strings.TrimSpace(wtf.ASCIItoTviewColors(string(contents)))
 }

--- a/modules/weatherservices/weather/display.go
+++ b/modules/weatherservices/weather/display.go
@@ -9,7 +9,6 @@ import (
 )
 
 func (widget *Widget) display() {
-
 	if widget.apiKeyValid() == false {
 		widget.View.SetText(" Environment variable WTF_OWM_API_KEY is not set")
 		return
@@ -54,19 +53,17 @@ func (widget *Widget) sunInfo(cityData *owm.CurrentWeatherData) string {
 }
 
 func (widget *Widget) temperatures(cityData *owm.CurrentWeatherData) string {
-	tempUnit := wtf.Config.UString("wtf.mods.weather.tempUnit", "C")
-
-	str := fmt.Sprintf("%8s: %4.1f° %s\n", "High", cityData.Main.TempMax, tempUnit)
+	str := fmt.Sprintf("%8s: %4.1f° %s\n", "High", cityData.Main.TempMax, widget.settings.tempUnit)
 
 	str = str + fmt.Sprintf(
 		"%8s: [%s]%4.1f° %s[white]\n",
 		"Current",
-		wtf.Config.UString("wtf.mods.weather.colors.current", "green"),
+		widget.settings.colors.current,
 		cityData.Main.Temp,
-		tempUnit,
+		widget.settings.tempUnit,
 	)
 
-	str = str + fmt.Sprintf("%8s: %4.1f° %s\n", "Low", cityData.Main.TempMin, tempUnit)
+	str = str + fmt.Sprintf("%8s: %4.1f° %s\n", "Low", cityData.Main.TempMin, widget.settings.tempUnit)
 
 	return str
 }

--- a/modules/weatherservices/weather/settings.go
+++ b/modules/weatherservices/weather/settings.go
@@ -7,6 +7,8 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
+const configKey = "weather"
+
 type colors struct {
 	current string
 }
@@ -21,11 +23,11 @@ type Settings struct {
 	tempUnit string
 }
 
-func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
-	localConfig, _ := ymlConfig.Get("wtf.mods.weather")
+func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
+	localConfig, _ := ymlConfig.Get("wtf.mods." + configKey)
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
 
 		apiKey:   localConfig.UString("apiKey", os.Getenv("WTF_OWM_API_KEY")),
 		cityIDs:  localConfig.UList("cityids"),

--- a/modules/weatherservices/weather/settings.go
+++ b/modules/weatherservices/weather/settings.go
@@ -1,0 +1,39 @@
+package weather
+
+import (
+	"os"
+
+	"github.com/olebedev/config"
+	"github.com/wtfutil/wtf/cfg"
+)
+
+type colors struct {
+	current string
+}
+
+type Settings struct {
+	colors
+	common *cfg.Common
+
+	apiKey   string
+	cityIDs  []interface{}
+	language string
+	tempUnit string
+}
+
+func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
+	localConfig, _ := ymlConfig.Get("wtf.mods.weather")
+
+	settings := Settings{
+		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+
+		apiKey:   localConfig.UString("apiKey", os.Getenv("WTF_OWM_API_KEY")),
+		cityIDs:  localConfig.UList("cityids"),
+		language: localConfig.UString("language", "EN"),
+		tempUnit: localConfig.UString("tempUnit", "C"),
+	}
+
+	settings.colors.current = localConfig.UString("colors.current", "green")
+
+	return &settings
+}

--- a/modules/weatherservices/weather/widget.go
+++ b/modules/weatherservices/weather/widget.go
@@ -33,7 +33,7 @@ type Widget struct {
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
 		HelpfulWidget: wtf.NewHelpfulWidget(app, pages, HelpText),
-		TextWidget:    wtf.NewTextWidget(app, "Weather", "weather", true),
+		TextWidget:    wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, true),
 
 		Idx:      0,
 		settings: settings,

--- a/modules/weatherservices/weather/widget.go
+++ b/modules/weatherservices/weather/widget.go
@@ -33,7 +33,7 @@ type Widget struct {
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
 		HelpfulWidget: wtf.NewHelpfulWidget(app, pages, HelpText),
-		TextWidget:    wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, true),
+		TextWidget:    wtf.NewTextWidget(app, settings.common, true),
 
 		Idx:      0,
 		settings: settings,

--- a/modules/zendesk/settings.go
+++ b/modules/zendesk/settings.go
@@ -7,6 +7,8 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
+const configKey = "zendesk"
+
 type Settings struct {
 	common *cfg.Common
 
@@ -16,11 +18,11 @@ type Settings struct {
 	username  string
 }
 
-func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
-	localConfig, _ := ymlConfig.Get("wtf.mods.zendesk")
+func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
+	localConfig, _ := ymlConfig.Get("wtf.mods." + configKey)
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
 
 		apiKey:    localConfig.UString("apiKey", os.Getenv("ZENDESK_API")),
 		status:    localConfig.UString("status"),

--- a/modules/zendesk/settings.go
+++ b/modules/zendesk/settings.go
@@ -1,0 +1,32 @@
+package zendesk
+
+import (
+	"os"
+
+	"github.com/olebedev/config"
+	"github.com/wtfutil/wtf/cfg"
+)
+
+type Settings struct {
+	common *cfg.Common
+
+	apiKey    string
+	status    string
+	subdomain string
+	username  string
+}
+
+func NewSettingsFromYAML(ymlConfig *config.Config) *Settings {
+	localConfig, _ := ymlConfig.Get("wtf.mods.zendesk")
+
+	settings := Settings{
+		common: cfg.NewCommonSettingsFromYAML(ymlConfig),
+
+		apiKey:    localConfig.UString("apiKey", os.Getenv("ZENDESK_API")),
+		status:    localConfig.UString("status"),
+		subdomain: localConfig.UString("subdomain", os.Getenv("ZENDESK_SUBDOMAIN")),
+		username:  localConfig.UString("username"),
+	}
+
+	return &settings
+}

--- a/modules/zendesk/tickets.go
+++ b/modules/zendesk/tickets.go
@@ -45,7 +45,7 @@ type Ticket struct {
 	Fields                interface{} `json:"fields"`
 }
 
-func listTickets(pag ...string) (*TicketArray, error) {
+func (widget *Widget) listTickets(pag ...string) (*TicketArray, error) {
 
 	TicketStruct := &TicketArray{}
 
@@ -55,7 +55,7 @@ func listTickets(pag ...string) (*TicketArray, error) {
 	} else {
 		path = pag[0]
 	}
-	resource, err := api(apiKey(), "GET", path, "")
+	resource, err := widget.api("GET", path, "")
 	if err != nil {
 		return nil, err
 	}
@@ -66,14 +66,14 @@ func listTickets(pag ...string) (*TicketArray, error) {
 
 }
 
-func newTickets(ticketStatus string) (*TicketArray, error) {
+func (widget *Widget) newTickets() (*TicketArray, error) {
 	newTicketArray := &TicketArray{}
-	tickets, err := listTickets()
+	tickets, err := widget.listTickets(widget.settings.apiKey)
 	if err != nil {
 		log.Fatal(err)
 	}
 	for _, Ticket := range tickets.Tickets {
-		if Ticket.Status == ticketStatus && Ticket.Status != "closed" && Ticket.Status != "solved" {
+		if Ticket.Status == widget.settings.status && Ticket.Status != "closed" && Ticket.Status != "solved" {
 			newTicketArray.Tickets = append(newTicketArray.Tickets, Ticket)
 		}
 	}

--- a/modules/zendesk/widget.go
+++ b/modules/zendesk/widget.go
@@ -63,13 +63,13 @@ func (widget *Widget) textContent(items []Ticket) string {
 }
 
 func (widget *Widget) format(ticket Ticket, idx int) string {
-	var str string
-	requesterName := widget.parseRequester(ticket)
-	textColor := wtf.Config.UString("wtf.colors.background", "green")
+	textColor := widget.settings.common.Colors.Background
 	if idx == widget.selected {
-		textColor = wtf.Config.UString("wtf.colors.background", "orange")
+		textColor = widget.settings.common.Colors.BorderFocused
 	}
-	str = fmt.Sprintf(" [%s:]%d - %s\n %s\n\n", textColor, ticket.Id, requesterName, ticket.Subject)
+
+	requesterName := widget.parseRequester(ticket)
+	str := fmt.Sprintf(" [%s:]%d - %s\n %s\n\n", textColor, ticket.Id, requesterName, ticket.Subject)
 	return str
 }
 

--- a/modules/zendesk/widget.go
+++ b/modules/zendesk/widget.go
@@ -19,7 +19,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, "Zendesk", "zendesk", true),
+		TextWidget: wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, true),
 
 		settings: settings,
 	}

--- a/modules/zendesk/widget.go
+++ b/modules/zendesk/widget.go
@@ -19,7 +19,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, settings.common.Name, settings.common.ConfigKey, true),
+		TextWidget: wtf.NewTextWidget(app, settings.common, true),
 
 		settings: settings,
 	}

--- a/modules/zendesk/widget.go
+++ b/modules/zendesk/widget.go
@@ -14,11 +14,14 @@ type Widget struct {
 
 	result   *TicketArray
 	selected int
+	settings *Settings
 }
 
-func NewWidget(app *tview.Application) *Widget {
+func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
 		TextWidget: wtf.NewTextWidget(app, "Zendesk", "zendesk", true),
+
+		settings: settings,
 	}
 
 	widget.View.SetInputCapture(widget.keyboardIntercept)
@@ -28,8 +31,7 @@ func NewWidget(app *tview.Application) *Widget {
 
 /* -------------------- Exported Functions -------------------- */
 func (widget *Widget) Refresh() {
-	ticketStatus := wtf.Config.UString("wtf.mods.zendesk.status")
-	ticketArray, err := newTickets(ticketStatus)
+	ticketArray, err := widget.newTickets()
 	ticketArray.Count = len(ticketArray.Tickets)
 	if err != nil {
 		log.Fatal(err)
@@ -102,7 +104,7 @@ func (widget *Widget) openTicket() {
 	sel := widget.selected
 	if sel >= 0 && widget.result != nil && sel < len(widget.result.Tickets) {
 		issue := &widget.result.Tickets[widget.selected]
-		ticketUrl := fmt.Sprintf("https://%s.zendesk.com/agent/tickets/%d", subdomain(), issue.Id)
+		ticketUrl := fmt.Sprintf("https://%s.zendesk.com/agent/tickets/%d", widget.settings.subdomain, issue.Id)
 		wtf.OpenFile(ticketUrl)
 	}
 }

--- a/wtf/text_widget.go
+++ b/wtf/text_widget.go
@@ -115,6 +115,10 @@ func (widget *TextWidget) SetFocusChar(char string) {
 	widget.focusChar = char
 }
 
+func (widget *TextWidget) String() string {
+	return widget.name
+}
+
 func (widget *TextWidget) TextView() *tview.TextView {
 	return widget.View
 }

--- a/wtf/text_widget.go
+++ b/wtf/text_widget.go
@@ -135,7 +135,7 @@ func (widget *TextWidget) addView(app *tview.Application, configKey string) {
 
 	view.SetBorder(true)
 	view.SetDynamicColors(true)
-	view.SetTitle(widget.ContextualTitle(widget.name))
+	view.SetTitle(widget.ContextualTitle(widget.CommonSettings.Title))
 	view.SetWrap(false)
 
 	view.SetChangedFunc(func() {

--- a/wtf/utils.go
+++ b/wtf/utils.go
@@ -5,9 +5,8 @@ import (
 	"io/ioutil"
 	"os/exec"
 	"regexp"
-	"strings"
-	//"sync"
 	"runtime"
+	"strings"
 
 	"github.com/rivo/tview"
 )

--- a/wtf/utils.go
+++ b/wtf/utils.go
@@ -165,6 +165,18 @@ func SigilStr(len, pos int, view *tview.TextView) string {
 	return sigils
 }
 
+/* -------------------- Map Conversion -------------------- */
+
+func MapToStrs(aMap map[string]interface{}) map[string]string {
+	results := make(map[string]string)
+
+	for key, val := range aMap {
+		results[key] = val.(string)
+	}
+
+	return results
+}
+
 /* -------------------- Slice Conversion -------------------- */
 
 func ToInts(slice []interface{}) []int {

--- a/wtf/utils.go
+++ b/wtf/utils.go
@@ -96,17 +96,17 @@ func NamesFromEmails(emails []string) []string {
 
 // OpenFile opens the file defined in `path` via the operating system
 func OpenFile(path string) {
-	if (strings.HasPrefix(path,"http://"))||(strings.HasPrefix(path,"https://")) {
+	if (strings.HasPrefix(path, "http://")) || (strings.HasPrefix(path, "https://")) {
 		switch runtime.GOOS {
-			case "linux":	
-				exec.Command("xdg-open", path).Start()
-			case "windows":
-				exec.Command("rundll32", "url.dll,FileProtocolHandler", path).Start()
-			case "darwin":
-				exec.Command("open", path).Start()
-			default:
+		case "linux":
+			exec.Command("xdg-open", path).Start()
+		case "windows":
+			exec.Command("rundll32", "url.dll,FileProtocolHandler", path).Start()
+		case "darwin":
+			exec.Command("open", path).Start()
+		default:
 		}
-	}else {
+	} else {
 		filePath, _ := ExpandHomeDir(path)
 		openFileUtil := Config.UString("wtf.openFileUtil", "open")
 		cmd := exec.Command(openFileUtil, filePath)

--- a/wtf/utils.go
+++ b/wtf/utils.go
@@ -136,10 +136,7 @@ func ReadFileBytes(filePath string) ([]byte, error) {
 }
 
 func RightAlignFormat(view *tview.TextView) string {
-	//mutex := &sync.Mutex{}
-	//mutex.Lock()
 	_, _, w, _ := view.GetInnerRect()
-	//mutex.Unlock()
 
 	return fmt.Sprintf("%%%ds", w-1)
 }

--- a/wtf/widget_validator.go
+++ b/wtf/widget_validator.go
@@ -1,0 +1,21 @@
+package wtf
+
+import (
+	"fmt"
+	"log"
+)
+
+// Check that all the loaded widgets are valid for display
+func ValidateWidgets(widgets []Wtfable) (bool, error) {
+	result := true
+	var err error
+
+	for _, widget := range widgets {
+		if widget.Enabled() && !widget.IsPositionable() {
+			errStr := fmt.Sprintf("Widget config has invalid values: %s", widget.Key())
+			log.Fatalln(errStr)
+		}
+	}
+
+	return result, err
+}

--- a/wtf/wtfable.go
+++ b/wtf/wtfable.go
@@ -9,15 +9,15 @@ type Wtfable interface {
 	Scheduler
 
 	BorderColor() string
-	Focusable() bool
 	FocusChar() string
+	Focusable() bool
 	Key() string
 	Name() string
 	SetFocusChar(string)
 	TextView() *tview.TextView
 
-	Top() int
-	Left() int
-	Width() int
 	Height() int
+	Left() int
+	Top() int
+	Width() int
 }

--- a/wtf_tests/colors_test.go
+++ b/wtf_tests/colors_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/wtfutil/wtf/wtf"
 )
 
-func TestASCIItoTviewColors(t *testing.T) {
+func Test_ASCIItoTviewColors(t *testing.T) {
 	Equal(t, "", ASCIItoTviewColors(""))
 	Equal(t, "cat", ASCIItoTviewColors("cat"))
 	Equal(t, "[38;5;226mcat/[-]", ASCIItoTviewColors("[38;5;226mcat/[0m"))


### PR DESCRIPTION
This PR fundamentally reworks the settings system by removing all knowledge of the YAML config and `github.com/olebedev/config` from the widgets.

Each widget now has its own `Settings` type in its package that is populated by whichever means (in the case of the app itself, a `NewSettingsFromYAML` function that takes the output of `config`) and is now passed to the widget for configuration.

Beyond separating concerns, this should

a) make it a bit easier to test modules
b) make it possible to change settings in a widget dynamically from within the app 
c) start to lay the groundwork for multi-instance widgets