### PR TITLE
Jenkins Green Balls Plugin Support - #358 

### DIFF
--- a/modules/jenkins/widget.go
+++ b/modules/jenkins/widget.go
@@ -120,7 +120,12 @@ func (widget *Widget) rowColor(idx int) string {
 func (widget *Widget) jobColor(job *Job) string {
 	switch job.Color {
 	case "blue":
-		return "blue"
+		// Override color if greenBalls boolean param provided in config
+		if wtf.Config.UString("wtf.mods.jenkins.greenBalls") == "true" {
+			return "green"
+		} else {
+			return "blue"
+		}
 	case "red":
 		return "red"
 	default:

--- a/modules/jenkins/widget.go
+++ b/modules/jenkins/widget.go
@@ -120,9 +120,10 @@ func (widget *Widget) rowColor(idx int) string {
 func (widget *Widget) jobColor(job *Job) string {
 	switch job.Color {
 	case "blue":
-		// Override color if greenBalls boolean param provided in config
-		if wtf.Config.UString("wtf.mods.jenkins.greenBalls") == "true" {
-			return "green"
+		// Override color if successBallColor boolean param provided in config
+		ballColor := wtf.Config.UString("wtf.mods.jenkins.successBallColor", "blue")
+		if ballColor != "blue" {
+			return ballColor
 		} else {
 			return "blue"
 		}


### PR DESCRIPTION
Support for #358 - Adds successBallColor config value which supports custom Jenkins job colour to indicate success instead of default blue.