### PR TITLE
Allow users to filter jenkins jobs by regex

### DIFF
--- a/modules/jenkins/widget.go
+++ b/modules/jenkins/widget.go
@@ -2,6 +2,7 @@ package jenkins
 
 import (
 	"fmt"
+	"regexp"
 	"github.com/gdamore/tcell"
 	"github.com/rivo/tview"
 	"github.com/wtfutil/wtf/wtf"

--- a/modules/jenkins/widget.go
+++ b/modules/jenkins/widget.go
@@ -95,15 +95,19 @@ func (widget *Widget) apiKey() string {
 func (widget *Widget) contentFrom(view *View) string {
 	var str string
 	for idx, job := range view.Jobs {
-		str = str + fmt.Sprintf(
-			`["%d"][""][%s] [%s]%-6s[white]`,
-			idx,
-			widget.rowColor(idx),
-			widget.jobColor(&job),
-			job.Name,
-		)
+		regex := wtf.Config.UString("wtf.mods.jenkins.jobNameRegex", ".*")
+		var validID = regexp.MustCompile(regex)
+		if validID.MatchString(job.Name) {
+			str = str + fmt.Sprintf(
+				`["%d"][""][%s] [%s]%-6s[white]`,
+				idx,
+				widget.rowColor(idx),
+				widget.jobColor(&job),
+				job.Name,
+			)
 
-		str = str + "\n"
+			str = str + "\n"
+		}
 	}
 
 	return str


### PR DESCRIPTION
Addresses issue #359. Allows users to filter the Jenkins jobs shown in the widget by providing a regular expression in the config file. The regex should be specified in the config like so:
```
jobNameRegex: ^[a-z]+.$
```
Another example:
```
jobNameRegex^[a-z]+\[[0-9]+\]$
```