### PR TITLE
20190422 signal redraw on channel

### DIFF
--- a/cfg/common_settings.go
+++ b/cfg/common_settings.go
@@ -55,9 +55,10 @@ type Common struct {
 	Sigils
 
 	Enabled         bool
-	FocusChar       int
 	RefreshInterval int
 	Title           string
+
+	focusChar int
 }
 
 func NewCommonSettingsFromYAML(name, configKey string, ymlConfig *config.Config) *Common {
@@ -93,9 +94,10 @@ func NewCommonSettingsFromYAML(name, configKey string, ymlConfig *config.Config)
 		},
 
 		Enabled:         ymlConfig.UBool(modulePath+".enabled", false),
-		FocusChar:       ymlConfig.UInt(modulePath+".focusChar", -1),
 		RefreshInterval: ymlConfig.UInt(modulePath+".refreshInterval", 300),
 		Title:           ymlConfig.UString(modulePath+".title", name),
+
+		focusChar: ymlConfig.UInt(modulePath+".focusChar", -1),
 	}
 
 	common.Colors.Rows.Even = ymlConfig.UString(modulePath+".colors.rows.even", ymlConfig.UString(colorsPath+".rows.even", "white"))
@@ -116,6 +118,15 @@ func (common *Common) DefaultFocussedRowColor() string {
 
 func (common *Common) DefaultRowColor() string {
 	return fmt.Sprintf("%s:%s", common.Colors.Foreground, common.Colors.Background)
+}
+
+func (common *Common) FocusChar() string {
+	focusChar := string('0' + common.focusChar)
+	if common.focusChar == -1 {
+		focusChar = ""
+	}
+
+	return focusChar
 }
 
 func (common *Common) RowColor(idx int) string {

--- a/logger/log.go
+++ b/logger/log.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/rivo/tview"
 	"github.com/wtfutil/wtf/wtf"
 )
 
@@ -20,9 +19,9 @@ type Widget struct {
 	settings *Settings
 }
 
-func NewWidget(app *tview.Application, settings *Settings) *Widget {
+func NewWidget(refreshChan chan<- string, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, settings.common, true),
+		TextWidget: wtf.NewTextWidget(refreshChan, settings.common, true),
 
 		filePath: logFilePath(),
 		settings: settings,

--- a/main.go
+++ b/main.go
@@ -176,6 +176,16 @@ func watchForConfigChanges(app *tview.Application, refreshChan chan<- string, co
 	}
 }
 
+func watchForRefreshUpdates(app *tview.Application, refreshChan <-chan string) {
+	for {
+		select {
+		case <-refreshChan:
+			app.Draw()
+		default:
+		}
+	}
+}
+
 func makeWidget(app *tview.Application, refreshChan chan<- string, pages *tview.Pages, widgetName string) wtf.Wtfable {
 	var widget wtf.Wtfable
 
@@ -362,7 +372,7 @@ func main() {
 
 	setTerm()
 
-	refreshChan := make(chan string)
+	refreshChan := make(chan string, 2)
 
 	app := tview.NewApplication()
 	pages := tview.NewPages()
@@ -382,14 +392,7 @@ func main() {
 	app.SetInputCapture(keyboardIntercept)
 
 	go watchForConfigChanges(app, refreshChan, flags.Config, display.Grid, pages)
-
-	go func() {
-		select {
-		case <-refreshChan:
-			app.Draw()
-		default:
-		}
-	}()
+	go watchForRefreshUpdates(app, refreshChan)
 
 	if err := app.SetRoot(pages, true).Run(); err != nil {
 		fmt.Printf("Error: %v\n", err)

--- a/main.go
+++ b/main.go
@@ -134,7 +134,7 @@ func setTerm() {
 	}
 }
 
-func watchForConfigChanges(app *tview.Application, configFilePath string, grid *tview.Grid, pages *tview.Pages) {
+func watchForConfigChanges(app *tview.Application, refreshChan chan<- string, configFilePath string, grid *tview.Grid, pages *tview.Pages) {
 	watch := watcher.New()
 	absPath, _ := wtf.ExpandHomeDir(configFilePath)
 
@@ -150,7 +150,7 @@ func watchForConfigChanges(app *tview.Application, configFilePath string, grid *
 
 				loadConfigFile(absPath)
 
-				widgets := makeWidgets(app, pages)
+				widgets := makeWidgets(app, refreshChan, pages)
 				wtf.ValidateWidgets(widgets)
 
 				initializeFocusTracker(app, widgets)
@@ -176,161 +176,161 @@ func watchForConfigChanges(app *tview.Application, configFilePath string, grid *
 	}
 }
 
-func makeWidget(app *tview.Application, pages *tview.Pages, widgetName string) wtf.Wtfable {
+func makeWidget(app *tview.Application, refreshChan chan<- string, pages *tview.Pages, widgetName string) wtf.Wtfable {
 	var widget wtf.Wtfable
 
 	// Always in alphabetical order
 	switch widgetName {
 	case "bamboohr":
 		settings := bamboohr.NewSettingsFromYAML("BambooHR", wtf.Config)
-		widget = bamboohr.NewWidget(app, settings)
+		widget = bamboohr.NewWidget(refreshChan, settings)
 	case "bargraph":
 		widget = bargraph.NewWidget(app)
 	case "bittrex":
 		settings := bittrex.NewSettingsFromYAML("Bittrex", wtf.Config)
-		widget = bittrex.NewWidget(app, settings)
+		widget = bittrex.NewWidget(refreshChan, settings)
 	case "blockfolio":
 		settings := blockfolio.NewSettingsFromYAML("Blockfolio", wtf.Config)
-		widget = blockfolio.NewWidget(app, settings)
+		widget = blockfolio.NewWidget(refreshChan, settings)
 	case "circleci":
 		settings := circleci.NewSettingsFromYAML("CircleCI", wtf.Config)
-		widget = circleci.NewWidget(app, settings)
+		widget = circleci.NewWidget(refreshChan, settings)
 	case "clocks":
 		settings := clocks.NewSettingsFromYAML("Clocks", wtf.Config)
-		widget = clocks.NewWidget(app, settings)
+		widget = clocks.NewWidget(refreshChan, settings)
 	case "cmdrunner":
 		settings := cmdrunner.NewSettingsFromYAML("CmdRunner", wtf.Config)
-		widget = cmdrunner.NewWidget(app, settings)
+		widget = cmdrunner.NewWidget(refreshChan, settings)
 	case "cryptolive":
 		settings := cryptolive.NewSettingsFromYAML("CryptoLive", wtf.Config)
-		widget = cryptolive.NewWidget(app, settings)
+		widget = cryptolive.NewWidget(refreshChan, settings)
 	case "datadog":
 		settings := datadog.NewSettingsFromYAML("DataDog", wtf.Config)
-		widget = datadog.NewWidget(app, settings)
+		widget = datadog.NewWidget(refreshChan, settings)
 	case "gcal":
 		settings := gcal.NewSettingsFromYAML("Calendar", wtf.Config)
-		widget = gcal.NewWidget(app, settings)
+		widget = gcal.NewWidget(app, refreshChan, settings)
 	case "gerrit":
 		settings := gerrit.NewSettingsFromYAML("Gerrit", wtf.Config)
-		widget = gerrit.NewWidget(app, pages, settings)
+		widget = gerrit.NewWidget(app, refreshChan, pages, settings)
 	case "git":
 		settings := git.NewSettingsFromYAML("Git", wtf.Config)
-		widget = git.NewWidget(app, pages, settings)
+		widget = git.NewWidget(app, refreshChan, pages, settings)
 	case "github":
 		settings := github.NewSettingsFromYAML("GitHub", wtf.Config)
-		widget = github.NewWidget(app, pages, settings)
+		widget = github.NewWidget(app, refreshChan, pages, settings)
 	case "gitlab":
 		settings := gitlab.NewSettingsFromYAML("GitLab", wtf.Config)
-		widget = gitlab.NewWidget(app, pages, settings)
+		widget = gitlab.NewWidget(app, refreshChan, pages, settings)
 	case "gitter":
 		settings := gitter.NewSettingsFromYAML("Gitter", wtf.Config)
-		widget = gitter.NewWidget(app, pages, settings)
+		widget = gitter.NewWidget(app, refreshChan, pages, settings)
 	case "gspreadsheets":
 		settings := gspreadsheets.NewSettingsFromYAML("Google Spreadsheets", wtf.Config)
-		widget = gspreadsheets.NewWidget(app, settings)
+		widget = gspreadsheets.NewWidget(refreshChan, settings)
 	case "hackernews":
 		settings := hackernews.NewSettingsFromYAML("HackerNews", wtf.Config)
-		widget = hackernews.NewWidget(app, pages, settings)
+		widget = hackernews.NewWidget(app, refreshChan, pages, settings)
 	case "ipapi":
 		settings := ipapi.NewSettingsFromYAML("IPAPI", wtf.Config)
-		widget = ipapi.NewWidget(app, settings)
+		widget = ipapi.NewWidget(refreshChan, settings)
 	case "ipinfo":
 		settings := ipinfo.NewSettingsFromYAML("IPInfo", wtf.Config)
-		widget = ipinfo.NewWidget(app, settings)
+		widget = ipinfo.NewWidget(refreshChan, settings)
 	case "jenkins":
 		settings := jenkins.NewSettingsFromYAML("Jenkins", wtf.Config)
-		widget = jenkins.NewWidget(app, pages, settings)
+		widget = jenkins.NewWidget(app, refreshChan, pages, settings)
 	case "jira":
 		settings := jira.NewSettingsFromYAML("Jira", wtf.Config)
-		widget = jira.NewWidget(app, pages, settings)
+		widget = jira.NewWidget(app, refreshChan, pages, settings)
 	case "logger":
 		settings := logger.NewSettingsFromYAML("Log", wtf.Config)
-		widget = logger.NewWidget(app, settings)
+		widget = logger.NewWidget(refreshChan, settings)
 	case "mercurial":
 		settings := mercurial.NewSettingsFromYAML("Mercurial", wtf.Config)
-		widget = mercurial.NewWidget(app, pages, settings)
+		widget = mercurial.NewWidget(app, refreshChan, pages, settings)
 	case "nbascore":
 		settings := nbascore.NewSettingsFromYAML("NBA Score", wtf.Config)
-		widget = nbascore.NewWidget(app, pages, settings)
+		widget = nbascore.NewWidget(app, refreshChan, pages, settings)
 	case "newrelic":
 		settings := newrelic.NewSettingsFromYAML("NewRelic", wtf.Config)
-		widget = newrelic.NewWidget(app, settings)
+		widget = newrelic.NewWidget(refreshChan, settings)
 	case "opsgenie":
 		settings := opsgenie.NewSettingsFromYAML("OpsGenie", wtf.Config)
-		widget = opsgenie.NewWidget(app, settings)
+		widget = opsgenie.NewWidget(refreshChan, settings)
 	case "pagerduty":
 		settings := pagerduty.NewSettingsFromYAML("PagerDuty", wtf.Config)
-		widget = pagerduty.NewWidget(app, settings)
+		widget = pagerduty.NewWidget(refreshChan, settings)
 	case "power":
 		settings := power.NewSettingsFromYAML("Power", wtf.Config)
-		widget = power.NewWidget(app, settings)
+		widget = power.NewWidget(refreshChan, settings)
 	case "prettyweather":
 		settings := prettyweather.NewSettingsFromYAML("Pretty Weather", wtf.Config)
-		widget = prettyweather.NewWidget(app, settings)
+		widget = prettyweather.NewWidget(refreshChan, settings)
 	case "resourceusage":
 		settings := resourceusage.NewSettingsFromYAML("Resource Usage", wtf.Config)
 		widget = resourceusage.NewWidget(app, settings)
 	case "rollbar":
 		settings := rollbar.NewSettingsFromYAML("Rollbar", wtf.Config)
-		widget = rollbar.NewWidget(app, pages, settings)
+		widget = rollbar.NewWidget(app, refreshChan, pages, settings)
 	case "security":
 		settings := security.NewSettingsFromYAML("Security", wtf.Config)
-		widget = security.NewWidget(app, settings)
+		widget = security.NewWidget(refreshChan, settings)
 	case "spotify":
 		settings := spotify.NewSettingsFromYAML("Spotify", wtf.Config)
-		widget = spotify.NewWidget(app, pages, settings)
+		widget = spotify.NewWidget(app, refreshChan, pages, settings)
 	case "spotifyweb":
 		settings := spotifyweb.NewSettingsFromYAML("Spotify Web", wtf.Config)
-		widget = spotifyweb.NewWidget(app, pages, settings)
+		widget = spotifyweb.NewWidget(app, refreshChan, pages, settings)
 	case "status":
 		settings := status.NewSettingsFromYAML("Status", wtf.Config)
-		widget = status.NewWidget(app, settings)
+		widget = status.NewWidget(refreshChan, settings)
 	case "system":
 		settings := system.NewSettingsFromYAML("System", wtf.Config)
-		widget = system.NewWidget(app, date, version, settings)
+		widget = system.NewWidget(refreshChan, date, version, settings)
 	case "textfile":
 		settings := textfile.NewSettingsFromYAML("Textfile", wtf.Config)
-		widget = textfile.NewWidget(app, pages, settings)
+		widget = textfile.NewWidget(app, refreshChan, pages, settings)
 	case "todo":
 		settings := todo.NewSettingsFromYAML("Todo", wtf.Config)
-		widget = todo.NewWidget(app, pages, settings)
+		widget = todo.NewWidget(app, refreshChan, pages, settings)
 	case "todoist":
 		settings := todoist.NewSettingsFromYAML("Todoist", wtf.Config)
-		widget = todoist.NewWidget(app, pages, settings)
+		widget = todoist.NewWidget(app, refreshChan, pages, settings)
 	case "travisci":
 		settings := travisci.NewSettingsFromYAML("TravisCI", wtf.Config)
-		widget = travisci.NewWidget(app, pages, settings)
+		widget = travisci.NewWidget(app, refreshChan, pages, settings)
 	case "trello":
 		settings := trello.NewSettingsFromYAML("Trello", wtf.Config)
-		widget = trello.NewWidget(app, settings)
+		widget = trello.NewWidget(refreshChan, settings)
 	case "twitter":
 		settings := twitter.NewSettingsFromYAML("Twitter", wtf.Config)
-		widget = twitter.NewWidget(app, pages, settings)
+		widget = twitter.NewWidget(app, refreshChan, pages, settings)
 	case "victorops":
 		settings := victorops.NewSettingsFromYAML("VictorOps - OnCall", wtf.Config)
-		widget = victorops.NewWidget(app, settings)
+		widget = victorops.NewWidget(refreshChan, settings)
 	case "weather":
 		settings := weather.NewSettingsFromYAML("Weather", wtf.Config)
-		widget = weather.NewWidget(app, pages, settings)
+		widget = weather.NewWidget(app, refreshChan, pages, settings)
 	case "zendesk":
 		settings := zendesk.NewSettingsFromYAML("Zendesk", wtf.Config)
-		widget = zendesk.NewWidget(app, settings)
+		widget = zendesk.NewWidget(refreshChan, settings)
 	default:
 		settings := unknown.NewSettingsFromYAML(widgetName, wtf.Config)
-		widget = unknown.NewWidget(app, widgetName, settings)
+		widget = unknown.NewWidget(refreshChan, widgetName, settings)
 	}
 
 	return widget
 }
 
-func makeWidgets(app *tview.Application, pages *tview.Pages) []wtf.Wtfable {
+func makeWidgets(app *tview.Application, refreshChan chan<- string, pages *tview.Pages) []wtf.Wtfable {
 	widgets := []wtf.Wtfable{}
 
 	mods, _ := Config.Map("wtf.mods")
 
 	for mod := range mods {
 		if enabled := Config.UBool("wtf.mods."+mod+".enabled", false); enabled {
-			widget := makeWidget(app, pages, mod)
+			widget := makeWidget(app, refreshChan, pages, mod)
 			widgets = append(widgets, widget)
 		}
 	}
@@ -362,10 +362,12 @@ func main() {
 
 	setTerm()
 
+	refreshChan := make(chan string)
+
 	app := tview.NewApplication()
 	pages := tview.NewPages()
 
-	widgets := makeWidgets(app, pages)
+	widgets := makeWidgets(app, refreshChan, pages)
 	wtf.ValidateWidgets(widgets)
 
 	initializeFocusTracker(app, widgets)
@@ -373,9 +375,21 @@ func main() {
 	display := wtf.NewDisplay(widgets)
 	pages.AddPage("grid", display.Grid, true, true)
 
+	for _, widget := range widgets {
+		go wtf.Schedule(widget)
+	}
+
 	app.SetInputCapture(keyboardIntercept)
 
-	go watchForConfigChanges(app, flags.Config, display.Grid, pages)
+	go watchForConfigChanges(app, refreshChan, flags.Config, display.Grid, pages)
+
+	go func() {
+		select {
+		case <-refreshChan:
+			app.Draw()
+		default:
+		}
+	}()
 
 	if err := app.SetRoot(pages, true).Run(); err != nil {
 		fmt.Printf("Error: %v\n", err)

--- a/modules/bamboohr/widget.go
+++ b/modules/bamboohr/widget.go
@@ -3,7 +3,6 @@ package bamboohr
 import (
 	"fmt"
 
-	"github.com/rivo/tview"
 	"github.com/wtfutil/wtf/wtf"
 )
 
@@ -15,9 +14,9 @@ type Widget struct {
 	settings *Settings
 }
 
-func NewWidget(app *tview.Application, settings *Settings) *Widget {
+func NewWidget(refreshChan chan<- string, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, settings.common, false),
+		TextWidget: wtf.NewTextWidget(refreshChan, settings.common, false),
 
 		settings: settings,
 	}

--- a/modules/circleci/widget.go
+++ b/modules/circleci/widget.go
@@ -3,7 +3,6 @@ package circleci
 import (
 	"fmt"
 
-	"github.com/rivo/tview"
 	"github.com/wtfutil/wtf/wtf"
 )
 
@@ -14,9 +13,9 @@ type Widget struct {
 	settings *Settings
 }
 
-func NewWidget(app *tview.Application, settings *Settings) *Widget {
+func NewWidget(refreshChan chan<- string, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, settings.common, false),
+		TextWidget: wtf.NewTextWidget(refreshChan, settings.common, false),
 		Client:     NewClient(settings.apiKey),
 
 		settings: settings,

--- a/modules/clocks/widget.go
+++ b/modules/clocks/widget.go
@@ -4,7 +4,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/rivo/tview"
 	"github.com/wtfutil/wtf/wtf"
 )
 
@@ -17,9 +16,9 @@ type Widget struct {
 	settings   *Settings
 }
 
-func NewWidget(app *tview.Application, settings *Settings) *Widget {
+func NewWidget(refreshChan chan<- string, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, settings.common, false),
+		TextWidget: wtf.NewTextWidget(refreshChan, settings.common, false),
 
 		settings:   settings,
 		dateFormat: settings.dateFormat,
@@ -34,7 +33,8 @@ func NewWidget(app *tview.Application, settings *Settings) *Widget {
 /* -------------------- Exported Functions -------------------- */
 
 func (widget *Widget) Refresh() {
-	widget.display(widget.clockColl.Sorted(widget.settings.sort), widget.dateFormat, widget.timeFormat)
+	sortedClocks := widget.clockColl.Sorted(widget.settings.sort)
+	widget.display(sortedClocks, widget.dateFormat, widget.timeFormat)
 }
 
 /* -------------------- Unexported Functions -------------------- */

--- a/modules/cmdrunner/widget.go
+++ b/modules/cmdrunner/widget.go
@@ -18,9 +18,9 @@ type Widget struct {
 	settings *Settings
 }
 
-func NewWidget(app *tview.Application, settings *Settings) *Widget {
+func NewWidget(refreshChan chan<- string, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, settings.common, false),
+		TextWidget: wtf.NewTextWidget(refreshChan, settings.common, false),
 
 		args:     settings.args,
 		cmd:      settings.cmd,

--- a/modules/cryptoexchanges/bittrex/widget.go
+++ b/modules/cryptoexchanges/bittrex/widget.go
@@ -7,7 +7,6 @@ import (
 
 	"net/http"
 
-	"github.com/rivo/tview"
 	"github.com/wtfutil/wtf/wtf"
 )
 
@@ -25,9 +24,9 @@ type Widget struct {
 }
 
 // NewWidget Make new instance of widget
-func NewWidget(app *tview.Application, settings *Settings) *Widget {
+func NewWidget(refreshChan chan<- string, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, settings.common, false),
+		TextWidget: wtf.NewTextWidget(refreshChan, settings.common, false),
 
 		settings:    settings,
 		summaryList: summaryList{},

--- a/modules/cryptoexchanges/blockfolio/widget.go
+++ b/modules/cryptoexchanges/blockfolio/widget.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/rivo/tview"
 	"github.com/wtfutil/wtf/wtf"
 )
 
@@ -18,9 +17,9 @@ type Widget struct {
 	settings     *Settings
 }
 
-func NewWidget(app *tview.Application, settings *Settings) *Widget {
+func NewWidget(refreshChan chan<- string, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, settings.common, false),
+		TextWidget: wtf.NewTextWidget(refreshChan, settings.common, false),
 
 		device_token: settings.deviceToken,
 		settings:     settings,

--- a/modules/cryptoexchanges/cryptolive/widget.go
+++ b/modules/cryptoexchanges/cryptolive/widget.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/rivo/tview"
 	"github.com/wtfutil/wtf/modules/cryptoexchanges/cryptolive/price"
 	"github.com/wtfutil/wtf/modules/cryptoexchanges/cryptolive/toplist"
 	"github.com/wtfutil/wtf/wtf"
@@ -20,9 +19,9 @@ type Widget struct {
 }
 
 // NewWidget Make new instance of widget
-func NewWidget(app *tview.Application, settings *Settings) *Widget {
+func NewWidget(refreshChan chan<- string, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, settings.common, false),
+		TextWidget: wtf.NewTextWidget(refreshChan, settings.common, false),
 
 		priceWidget:   price.NewWidget(settings.priceSettings),
 		toplistWidget: toplist.NewWidget(settings.toplistSettings),

--- a/modules/datadog/widget.go
+++ b/modules/datadog/widget.go
@@ -3,7 +3,6 @@ package datadog
 import (
 	"fmt"
 
-	"github.com/rivo/tview"
 	"github.com/wtfutil/wtf/wtf"
 	datadog "github.com/zorkian/go-datadog-api"
 )
@@ -14,9 +13,9 @@ type Widget struct {
 	settings *Settings
 }
 
-func NewWidget(app *tview.Application, settings *Settings) *Widget {
+func NewWidget(refreshChan chan<- string, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, settings.common, false),
+		TextWidget: wtf.NewTextWidget(refreshChan, settings.common, false),
 
 		settings: settings,
 	}

--- a/modules/gcal/widget.go
+++ b/modules/gcal/widget.go
@@ -18,9 +18,9 @@ type Widget struct {
 	settings  *Settings
 }
 
-func NewWidget(app *tview.Application, settings *Settings) *Widget {
+func NewWidget(app *tview.Application, refreshChan chan<- string, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, settings.common, true),
+		TextWidget: wtf.NewTextWidget(refreshChan, settings.common, true),
 
 		app:      app,
 		ch:       make(chan struct{}),

--- a/modules/gerrit/widget.go
+++ b/modules/gerrit/widget.go
@@ -46,10 +46,10 @@ var (
 	GerritURLPattern = regexp.MustCompile(`^(http|https)://(.*)$`)
 )
 
-func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
+func NewWidget(app *tview.Application, refreshChan chan<- string, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
 		HelpfulWidget: wtf.NewHelpfulWidget(app, pages, HelpText),
-		TextWidget:    wtf.NewTextWidget(app, settings.common, true),
+		TextWidget:    wtf.NewTextWidget(refreshChan, settings.common, true),
 
 		Idx:      0,
 		settings: settings,

--- a/modules/git/widget.go
+++ b/modules/git/widget.go
@@ -39,11 +39,11 @@ type Widget struct {
 	settings *Settings
 }
 
-func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
+func NewWidget(app *tview.Application, refreshChan chan<- string, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
 		HelpfulWidget:     wtf.NewHelpfulWidget(app, pages, HelpText),
 		MultiSourceWidget: wtf.NewMultiSourceWidget(settings.common.ConfigKey, "repository", "repositories"),
-		TextWidget:        wtf.NewTextWidget(app, settings.common, true),
+		TextWidget:        wtf.NewTextWidget(refreshChan, settings.common, true),
 
 		app:      app,
 		pages:    pages,

--- a/modules/github/widget.go
+++ b/modules/github/widget.go
@@ -29,10 +29,10 @@ type Widget struct {
 	settings    *Settings
 }
 
-func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
+func NewWidget(app *tview.Application, refreshChan chan<- string, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
 		HelpfulWidget: wtf.NewHelpfulWidget(app, pages, HelpText),
-		TextWidget:    wtf.NewTextWidget(app, settings.common, true),
+		TextWidget:    wtf.NewTextWidget(refreshChan, settings.common, true),
 
 		Idx:      0,
 		settings: settings,

--- a/modules/gitlab/widget.go
+++ b/modules/gitlab/widget.go
@@ -29,7 +29,7 @@ type Widget struct {
 	settings       *Settings
 }
 
-func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
+func NewWidget(app *tview.Application, refreshChan chan<- string, pages *tview.Pages, settings *Settings) *Widget {
 	baseURL := settings.domain
 	gitlab := glb.NewClient(nil, settings.apiKey)
 
@@ -39,7 +39,7 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 
 	widget := Widget{
 		HelpfulWidget: wtf.NewHelpfulWidget(app, pages, HelpText),
-		TextWidget:    wtf.NewTextWidget(app, settings.common, true),
+		TextWidget:    wtf.NewTextWidget(refreshChan, settings.common, true),
 
 		Idx:      0,
 		gitlab:   gitlab,

--- a/modules/gitter/widget.go
+++ b/modules/gitter/widget.go
@@ -29,10 +29,10 @@ type Widget struct {
 	settings *Settings
 }
 
-func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
+func NewWidget(app *tview.Application, refreshChan chan<- string, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
 		HelpfulWidget: wtf.NewHelpfulWidget(app, pages, HelpText),
-		TextWidget:    wtf.NewTextWidget(app, settings.common, true),
+		TextWidget:    wtf.NewTextWidget(refreshChan, settings.common, true),
 
 		settings: settings,
 	}

--- a/modules/gspreadsheets/widget.go
+++ b/modules/gspreadsheets/widget.go
@@ -3,7 +3,6 @@ package gspreadsheets
 import (
 	"fmt"
 
-	"github.com/rivo/tview"
 	"github.com/wtfutil/wtf/wtf"
 	sheets "google.golang.org/api/sheets/v4"
 )
@@ -14,9 +13,9 @@ type Widget struct {
 	settings *Settings
 }
 
-func NewWidget(app *tview.Application, settings *Settings) *Widget {
+func NewWidget(refreshChan chan<- string, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, settings.common, false),
+		TextWidget: wtf.NewTextWidget(refreshChan, settings.common, false),
 
 		settings: settings,
 	}

--- a/modules/hackernews/widget.go
+++ b/modules/hackernews/widget.go
@@ -35,10 +35,10 @@ type Widget struct {
 	settings *Settings
 }
 
-func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
+func NewWidget(app *tview.Application, refreshChan chan<- string, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
 		HelpfulWidget: wtf.NewHelpfulWidget(app, pages, HelpText),
-		TextWidget:    wtf.NewTextWidget(app, settings.common, true),
+		TextWidget:    wtf.NewTextWidget(refreshChan, settings.common, true),
 
 		settings: settings,
 	}

--- a/modules/ipaddresses/ipapi/widget.go
+++ b/modules/ipaddresses/ipapi/widget.go
@@ -8,7 +8,6 @@ import (
 	"strconv"
 	"text/template"
 
-	"github.com/rivo/tview"
 	"github.com/wtfutil/wtf/wtf"
 )
 
@@ -36,9 +35,9 @@ type ipinfo struct {
 }
 
 // NewWidget constructor
-func NewWidget(app *tview.Application, settings *Settings) *Widget {
+func NewWidget(refreshChan chan<- string, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, settings.common, false),
+		TextWidget: wtf.NewTextWidget(refreshChan, settings.common, false),
 
 		settings: settings,
 	}

--- a/modules/ipaddresses/ipinfo/widget.go
+++ b/modules/ipaddresses/ipinfo/widget.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"text/template"
 
-	"github.com/rivo/tview"
 	"github.com/wtfutil/wtf/wtf"
 )
 
@@ -29,9 +28,9 @@ type ipinfo struct {
 	Organization string `json:"org"`
 }
 
-func NewWidget(app *tview.Application, settings *Settings) *Widget {
+func NewWidget(refreshChan chan<- string, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, settings.common, false),
+		TextWidget: wtf.NewTextWidget(refreshChan, settings.common, false),
 
 		settings: settings,
 	}

--- a/modules/jenkins/widget.go
+++ b/modules/jenkins/widget.go
@@ -33,10 +33,10 @@ type Widget struct {
 	view     *View
 }
 
-func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
+func NewWidget(app *tview.Application, refreshChan chan<- string, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
 		HelpfulWidget: wtf.NewHelpfulWidget(app, pages, HelpText),
-		TextWidget:    wtf.NewTextWidget(app, settings.common, true),
+		TextWidget:    wtf.NewTextWidget(refreshChan, settings.common, true),
 
 		settings: settings,
 	}

--- a/modules/jira/widget.go
+++ b/modules/jira/widget.go
@@ -31,10 +31,10 @@ type Widget struct {
 	settings *Settings
 }
 
-func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
+func NewWidget(app *tview.Application, refreshChan chan<- string, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
 		HelpfulWidget: wtf.NewHelpfulWidget(app, pages, HelpText),
-		TextWidget:    wtf.NewTextWidget(app, settings.common, true),
+		TextWidget:    wtf.NewTextWidget(refreshChan, settings.common, true),
 
 		settings: settings,
 	}

--- a/modules/mercurial/widget.go
+++ b/modules/mercurial/widget.go
@@ -34,11 +34,11 @@ type Widget struct {
 	settings *Settings
 }
 
-func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
+func NewWidget(app *tview.Application, refreshChan chan<- string, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
 		HelpfulWidget:     wtf.NewHelpfulWidget(app, pages, HelpText),
 		MultiSourceWidget: wtf.NewMultiSourceWidget(settings.common.ConfigKey, "repository", "repositories"),
-		TextWidget:        wtf.NewTextWidget(app, settings.common, true),
+		TextWidget:        wtf.NewTextWidget(refreshChan, settings.common, true),
 
 		app:      app,
 		pages:    pages,

--- a/modules/nbascore/widget.go
+++ b/modules/nbascore/widget.go
@@ -30,10 +30,10 @@ type Widget struct {
 
 var offset = 0
 
-func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
+func NewWidget(app *tview.Application, refreshChan chan<- string, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
 		HelpfulWidget: wtf.NewHelpfulWidget(app, pages, HelpText),
-		TextWidget:    wtf.NewTextWidget(app, settings.common, true),
+		TextWidget:    wtf.NewTextWidget(refreshChan, settings.common, true),
 
 		settings: settings,
 	}

--- a/modules/newrelic/widget.go
+++ b/modules/newrelic/widget.go
@@ -3,7 +3,6 @@ package newrelic
 import (
 	"fmt"
 
-	"github.com/rivo/tview"
 	"github.com/wtfutil/wtf/wtf"
 	nr "github.com/yfronto/newrelic"
 )
@@ -15,9 +14,9 @@ type Widget struct {
 	settings *Settings
 }
 
-func NewWidget(app *tview.Application, settings *Settings) *Widget {
+func NewWidget(refreshChan chan<- string, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, settings.common, false),
+		TextWidget: wtf.NewTextWidget(refreshChan, settings.common, false),
 
 		settings: settings,
 	}

--- a/modules/opsgenie/widget.go
+++ b/modules/opsgenie/widget.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/rivo/tview"
 	"github.com/wtfutil/wtf/wtf"
 )
 
@@ -14,9 +13,9 @@ type Widget struct {
 	settings *Settings
 }
 
-func NewWidget(app *tview.Application, settings *Settings) *Widget {
+func NewWidget(refreshChan chan<- string, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, settings.common, false),
+		TextWidget: wtf.NewTextWidget(refreshChan, settings.common, false),
 
 		settings: settings,
 	}

--- a/modules/pagerduty/widget.go
+++ b/modules/pagerduty/widget.go
@@ -5,7 +5,6 @@ import (
 	"sort"
 
 	"github.com/PagerDuty/go-pagerduty"
-	"github.com/rivo/tview"
 	"github.com/wtfutil/wtf/wtf"
 )
 
@@ -15,9 +14,9 @@ type Widget struct {
 	settings *Settings
 }
 
-func NewWidget(app *tview.Application, settings *Settings) *Widget {
+func NewWidget(refreshChan chan<- string, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, settings.common, false),
+		TextWidget: wtf.NewTextWidget(refreshChan, settings.common, false),
 
 		settings: settings,
 	}

--- a/modules/power/widget.go
+++ b/modules/power/widget.go
@@ -3,7 +3,6 @@ package power
 import (
 	"fmt"
 
-	"github.com/rivo/tview"
 	"github.com/wtfutil/wtf/wtf"
 )
 
@@ -14,9 +13,9 @@ type Widget struct {
 	settings *Settings
 }
 
-func NewWidget(app *tview.Application, settings *Settings) *Widget {
+func NewWidget(refreshChan chan<- string, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, settings.common, false),
+		TextWidget: wtf.NewTextWidget(refreshChan, settings.common, false),
 
 		Battery:  NewBattery(),
 		settings: settings,

--- a/modules/rollbar/widget.go
+++ b/modules/rollbar/widget.go
@@ -32,10 +32,10 @@ type Widget struct {
 	settings *Settings
 }
 
-func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
+func NewWidget(app *tview.Application, refreshChan chan<- string, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
 		HelpfulWidget: wtf.NewHelpfulWidget(app, pages, HelpText),
-		TextWidget:    wtf.NewTextWidget(app, settings.common, true),
+		TextWidget:    wtf.NewTextWidget(refreshChan, settings.common, true),
 
 		settings: settings,
 	}

--- a/modules/security/widget.go
+++ b/modules/security/widget.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/rivo/tview"
 	"github.com/wtfutil/wtf/wtf"
 )
 
@@ -14,9 +13,9 @@ type Widget struct {
 	settings *Settings
 }
 
-func NewWidget(app *tview.Application, settings *Settings) *Widget {
+func NewWidget(refreshChan chan<- string, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, settings.common, false),
+		TextWidget: wtf.NewTextWidget(refreshChan, settings.common, false),
 
 		settings: settings,
 	}

--- a/modules/spotify/widget.go
+++ b/modules/spotify/widget.go
@@ -26,11 +26,11 @@ type Widget struct {
 	spotigopher.SpotifyClient
 }
 
-func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
+func NewWidget(app *tview.Application, refreshChan chan<- string, pages *tview.Pages, settings *Settings) *Widget {
 	spotifyClient := spotigopher.NewClient()
 	widget := Widget{
 		HelpfulWidget: wtf.NewHelpfulWidget(app, pages, HelpText),
-		TextWidget:    wtf.NewTextWidget(app, settings.common, true),
+		TextWidget:    wtf.NewTextWidget(refreshChan, settings.common, true),
 
 		Info:          spotigopher.Info{},
 		SpotifyClient: spotifyClient,

--- a/modules/spotifyweb/widget.go
+++ b/modules/spotifyweb/widget.go
@@ -81,7 +81,7 @@ func authHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 // NewWidget creates a new widget for WTF
-func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
+func NewWidget(app *tview.Application, refreshChan chan<- string, pages *tview.Pages, settings *Settings) *Widget {
 	redirectURI = "http://localhost:" + settings.callbackPort + "/callback"
 
 	auth = spotify.NewAuthenticator(redirectURI, spotify.ScopeUserReadCurrentlyPlaying, spotify.ScopeUserReadPlaybackState, spotify.ScopeUserModifyPlaybackState)
@@ -93,7 +93,7 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 
 	widget := Widget{
 		HelpfulWidget: wtf.NewHelpfulWidget(app, pages, HelpText),
-		TextWidget:    wtf.NewTextWidget(app, settings.common, true),
+		TextWidget:    wtf.NewTextWidget(refreshChan, settings.common, true),
 
 		Info:        Info{},
 		client:      client,

--- a/modules/status/widget.go
+++ b/modules/status/widget.go
@@ -1,7 +1,6 @@
 package status
 
 import (
-	"github.com/rivo/tview"
 	"github.com/wtfutil/wtf/wtf"
 )
 
@@ -12,9 +11,9 @@ type Widget struct {
 	settings    *Settings
 }
 
-func NewWidget(app *tview.Application, settings *Settings) *Widget {
+func NewWidget(refreshChan chan<- string, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, settings.common, false),
+		TextWidget: wtf.NewTextWidget(refreshChan, settings.common, false),
 
 		CurrentIcon: 0,
 		settings:    settings,

--- a/modules/system/widget.go
+++ b/modules/system/widget.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/rivo/tview"
 	"github.com/wtfutil/wtf/wtf"
 )
 
@@ -17,9 +16,9 @@ type Widget struct {
 	systemInfo *SystemInfo
 }
 
-func NewWidget(app *tview.Application, date, version string, settings *Settings) *Widget {
+func NewWidget(refreshChan chan<- string, date, version string, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, settings.common, false),
+		TextWidget: wtf.NewTextWidget(refreshChan, settings.common, false),
 
 		Date:     date,
 		settings: settings,

--- a/modules/textfile/widget.go
+++ b/modules/textfile/widget.go
@@ -38,11 +38,11 @@ type Widget struct {
 	settings *Settings
 }
 
-func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
+func NewWidget(app *tview.Application, refreshChan chan<- string, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
 		HelpfulWidget:     wtf.NewHelpfulWidget(app, pages, HelpText),
 		MultiSourceWidget: wtf.NewMultiSourceWidget(settings.common.ConfigKey, "filePath", "filePaths"),
-		TextWidget:        wtf.NewTextWidget(app, settings.common, true),
+		TextWidget:        wtf.NewTextWidget(refreshChan, settings.common, true),
 
 		settings: settings,
 	}

--- a/modules/todo/widget.go
+++ b/modules/todo/widget.go
@@ -46,10 +46,10 @@ type Widget struct {
 	pages    *tview.Pages
 }
 
-func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
+func NewWidget(app *tview.Application, refreshChan chan<- string, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
 		HelpfulWidget: wtf.NewHelpfulWidget(app, pages, HelpText),
-		TextWidget:    wtf.NewTextWidget(app, settings.common, true),
+		TextWidget:    wtf.NewTextWidget(refreshChan, settings.common, true),
 
 		app:      app,
 		settings: settings,

--- a/modules/todoist/widget.go
+++ b/modules/todoist/widget.go
@@ -34,10 +34,10 @@ type Widget struct {
 	settings *Settings
 }
 
-func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
+func NewWidget(app *tview.Application, refreshChan chan<- string, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
 		HelpfulWidget: wtf.NewHelpfulWidget(app, pages, HelpText),
-		TextWidget:    wtf.NewTextWidget(app, settings.common, true),
+		TextWidget:    wtf.NewTextWidget(refreshChan, settings.common, true),
 
 		settings: settings,
 	}

--- a/modules/travisci/widget.go
+++ b/modules/travisci/widget.go
@@ -31,10 +31,10 @@ type Widget struct {
 	settings *Settings
 }
 
-func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
+func NewWidget(app *tview.Application, refreshChan chan<- string, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
 		HelpfulWidget: wtf.NewHelpfulWidget(app, pages, HelpText),
-		TextWidget:    wtf.NewTextWidget(app, settings.common, true),
+		TextWidget:    wtf.NewTextWidget(refreshChan, settings.common, true),
 
 		settings: settings,
 	}

--- a/modules/trello/widget.go
+++ b/modules/trello/widget.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/adlio/trello"
-	"github.com/rivo/tview"
 	"github.com/wtfutil/wtf/wtf"
 )
 
@@ -14,9 +13,9 @@ type Widget struct {
 	settings *Settings
 }
 
-func NewWidget(app *tview.Application, settings *Settings) *Widget {
+func NewWidget(refreshChan chan<- string, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, settings.common, false),
+		TextWidget: wtf.NewTextWidget(refreshChan, settings.common, false),
 
 		settings: settings,
 	}

--- a/modules/twitter/widget.go
+++ b/modules/twitter/widget.go
@@ -33,11 +33,11 @@ type Widget struct {
 	sources  []string
 }
 
-func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
+func NewWidget(app *tview.Application, refreshChan chan<- string, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
 		HelpfulWidget:     wtf.NewHelpfulWidget(app, pages, HelpText),
 		MultiSourceWidget: wtf.NewMultiSourceWidget(settings.common.ConfigKey, "screenName", "screenNames"),
-		TextWidget:        wtf.NewTextWidget(app, settings.common, true),
+		TextWidget:        wtf.NewTextWidget(refreshChan, settings.common, true),
 
 		idx:      0,
 		settings: settings,

--- a/modules/unknown/widget.go
+++ b/modules/unknown/widget.go
@@ -3,7 +3,6 @@ package unknown
 import (
 	"fmt"
 
-	"github.com/rivo/tview"
 	"github.com/wtfutil/wtf/wtf"
 )
 
@@ -13,9 +12,9 @@ type Widget struct {
 	settings *Settings
 }
 
-func NewWidget(app *tview.Application, name string, settings *Settings) *Widget {
+func NewWidget(refreshChan chan<- string, name string, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, settings.common, false),
+		TextWidget: wtf.NewTextWidget(refreshChan, settings.common, false),
 
 		settings: settings,
 	}

--- a/modules/victorops/widget.go
+++ b/modules/victorops/widget.go
@@ -3,7 +3,6 @@ package victorops
 import (
 	"fmt"
 
-	"github.com/rivo/tview"
 	"github.com/wtfutil/wtf/wtf"
 )
 
@@ -25,9 +24,9 @@ type Widget struct {
 }
 
 // NewWidget creates a new widget
-func NewWidget(app *tview.Application, settings *Settings) *Widget {
+func NewWidget(refreshChan chan<- string, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, settings.common, true),
+		TextWidget: wtf.NewTextWidget(refreshChan, settings.common, true),
 	}
 
 	widget.View.SetScrollable(true)

--- a/modules/weatherservices/prettyweather/widget.go
+++ b/modules/weatherservices/prettyweather/widget.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/rivo/tview"
 	"github.com/wtfutil/wtf/wtf"
 )
 
@@ -16,9 +15,9 @@ type Widget struct {
 	settings *Settings
 }
 
-func NewWidget(app *tview.Application, settings *Settings) *Widget {
+func NewWidget(refreshChan chan<- string, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, settings.common, false),
+		TextWidget: wtf.NewTextWidget(refreshChan, settings.common, false),
 
 		settings: settings,
 	}

--- a/modules/weatherservices/weather/widget.go
+++ b/modules/weatherservices/weather/widget.go
@@ -30,10 +30,10 @@ type Widget struct {
 }
 
 // NewWidget creates and returns a new instance of the weather Widget.
-func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
+func NewWidget(app *tview.Application, refreshChan chan<- string, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
 		HelpfulWidget: wtf.NewHelpfulWidget(app, pages, HelpText),
-		TextWidget:    wtf.NewTextWidget(app, settings.common, true),
+		TextWidget:    wtf.NewTextWidget(refreshChan, settings.common, true),
 
 		Idx:      0,
 		settings: settings,

--- a/modules/zendesk/widget.go
+++ b/modules/zendesk/widget.go
@@ -5,7 +5,6 @@ import (
 	"log"
 
 	"github.com/gdamore/tcell"
-	"github.com/rivo/tview"
 	"github.com/wtfutil/wtf/wtf"
 )
 
@@ -17,9 +16,9 @@ type Widget struct {
 	settings *Settings
 }
 
-func NewWidget(app *tview.Application, settings *Settings) *Widget {
+func NewWidget(refreshChan chan<- string, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, settings.common, true),
+		TextWidget: wtf.NewTextWidget(refreshChan, settings.common, true),
 
 		settings: settings,
 	}

--- a/wtf/display.go
+++ b/wtf/display.go
@@ -49,7 +49,6 @@ func (display *Display) build(widgets []Wtfable) *tview.Grid {
 
 	for _, widget := range widgets {
 		display.add(widget)
-		go Schedule(widget)
 	}
 
 	return display.Grid

--- a/wtf/text_widget.go
+++ b/wtf/text_widget.go
@@ -24,7 +24,7 @@ type TextWidget struct {
 	Position
 }
 
-func NewTextWidget(app *tview.Application, commonSettings *cfg.Common, focusable bool) TextWidget {
+func NewTextWidget(refreshChan chan<- string, commonSettings *cfg.Common, focusable bool) TextWidget {
 	widget := TextWidget{
 		CommonSettings: commonSettings,
 
@@ -46,7 +46,7 @@ func NewTextWidget(app *tview.Application, commonSettings *cfg.Common, focusable
 	widget.View = widget.buildView()
 
 	widget.View.SetChangedFunc(func() {
-		app.Draw()
+		refreshChan <- widget.key
 	})
 
 	return widget

--- a/wtf/text_widget.go
+++ b/wtf/text_widget.go
@@ -16,6 +16,7 @@ type TextWidget struct {
 	focusChar       string
 	key             string
 	name            string
+	refreshChan     chan<- string
 	refreshInterval int
 
 	View *tview.TextView
@@ -33,6 +34,7 @@ func NewTextWidget(refreshChan chan<- string, commonSettings *cfg.Common, focusa
 		focusChar:       commonSettings.FocusChar(),
 		key:             commonSettings.ConfigKey,
 		name:            commonSettings.Name,
+		refreshChan:     refreshChan,
 		refreshInterval: commonSettings.RefreshInterval,
 	}
 
@@ -46,7 +48,7 @@ func NewTextWidget(refreshChan chan<- string, commonSettings *cfg.Common, focusa
 	widget.View = widget.buildView()
 
 	widget.View.SetChangedFunc(func() {
-		refreshChan <- widget.key
+		widget.refreshChan <- widget.key
 	})
 
 	return widget

--- a/wtf/text_widget.go
+++ b/wtf/text_widget.go
@@ -25,19 +25,12 @@ type TextWidget struct {
 }
 
 func NewTextWidget(app *tview.Application, commonSettings *cfg.Common, focusable bool) TextWidget {
-	configKey := commonSettings.ConfigKey
-
-	focusChar := string('0' + commonSettings.FocusChar)
-	if commonSettings.FocusChar == -1 {
-		focusChar = ""
-	}
-
 	widget := TextWidget{
 		CommonSettings: commonSettings,
 
 		enabled:         commonSettings.Enabled,
 		focusable:       focusable,
-		focusChar:       focusChar,
+		focusChar:       commonSettings.FocusChar(),
 		key:             commonSettings.ConfigKey,
 		name:            commonSettings.Name,
 		refreshInterval: commonSettings.RefreshInterval,
@@ -50,7 +43,11 @@ func NewTextWidget(app *tview.Application, commonSettings *cfg.Common, focusable
 		commonSettings.Position.Height,
 	)
 
-	widget.addView(app, configKey)
+	widget.View = widget.buildView()
+
+	widget.View.SetChangedFunc(func() {
+		app.Draw()
+	})
 
 	return widget
 }
@@ -125,7 +122,7 @@ func (widget *TextWidget) TextView() *tview.TextView {
 
 /* -------------------- Unexported Functions -------------------- */
 
-func (widget *TextWidget) addView(app *tview.Application, configKey string) {
+func (widget *TextWidget) buildView() *tview.TextView {
 	view := tview.NewTextView()
 
 	view.SetBackgroundColor(ColorFor(widget.CommonSettings.Colors.Background))
@@ -138,9 +135,5 @@ func (widget *TextWidget) addView(app *tview.Application, configKey string) {
 	view.SetTitle(widget.ContextualTitle(widget.CommonSettings.Title))
 	view.SetWrap(false)
 
-	view.SetChangedFunc(func() {
-		app.Draw()
-	})
-
-	widget.View = view
+	return view
 }


### PR DESCRIPTION
This swaps out the hard-coded `app.Draw()` call in `TextWidget` for use of `refreshChan`, widgets signalling on a channel that they want the app to redraw.

This simplifies some modules and complicates others. It remains to be seen if this is a good idea.