### PR TITLE
Allow duplicates of modules

### DIFF
--- a/cfg/common_settings.go
+++ b/cfg/common_settings.go
@@ -61,7 +61,7 @@ type Common struct {
 	focusChar int
 }
 
-func NewCommonSettingsFromModule(name string, moduleConfig *config.Config, globalSettings *config.Config) *Common {
+func NewCommonSettingsFromModule(name, defaultTitle string, moduleConfig *config.Config, globalSettings *config.Config) *Common {
 	colorsConfig, _ := globalSettings.Get("wtf.colors")
 	positionPath := "position"
 	sigilsPath := "wtf.sigils"
@@ -93,7 +93,7 @@ func NewCommonSettingsFromModule(name string, moduleConfig *config.Config, globa
 
 		Enabled:         moduleConfig.UBool("enabled", false),
 		RefreshInterval: moduleConfig.UInt("refreshInterval", 300),
-		Title:           moduleConfig.UString("title", name),
+		Title:           moduleConfig.UString("title", defaultTitle),
 		Config:          moduleConfig,
 
 		focusChar: moduleConfig.UInt("focusChar", -1),

--- a/logger/log.go
+++ b/logger/log.go
@@ -59,7 +59,7 @@ func (widget *Widget) Refresh() {
 	logLines := widget.tailFile()
 
 	widget.app.QueueUpdateDraw(func() {
-		widget.View.SetTitle(widget.Name())
+		widget.View.SetTitle(widget.CommonSettings.Title)
 		widget.View.SetText(widget.contentFrom(logLines))
 	})
 }

--- a/logger/settings.go
+++ b/logger/settings.go
@@ -5,7 +5,7 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const configKey = "logger"
+const defaultTitle = "Logger"
 
 type Settings struct {
 	common *cfg.Common
@@ -13,7 +13,7 @@ type Settings struct {
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
 	}
 
 	return &settings

--- a/maker/widget_maker.go
+++ b/maker/widget_maker.go
@@ -56,147 +56,148 @@ func MakeWidget(
 	app *tview.Application,
 	pages *tview.Pages,
 	widgetName string,
+	widgetType string,
 	moduleConfig *config.Config,
 	globalConfig *config.Config,
 ) wtf.Wtfable {
 	var widget wtf.Wtfable
 
 	// Always in alphabetical order
-	switch widgetName {
+	switch widgetType {
 	case "bamboohr":
-		settings := bamboohr.NewSettingsFromYAML("BambooHR", moduleConfig, globalConfig)
+		settings := bamboohr.NewSettingsFromYAML(widgetName, moduleConfig, globalConfig)
 		widget = bamboohr.NewWidget(app, settings)
 	case "bargraph":
 		settings := bargraph.NewSettingsFromYAML(widgetName, moduleConfig, globalConfig)
 		widget = bargraph.NewWidget(app, settings)
 	case "bittrex":
-		settings := bittrex.NewSettingsFromYAML("Bittrex", moduleConfig, globalConfig)
+		settings := bittrex.NewSettingsFromYAML(widgetName, moduleConfig, globalConfig)
 		widget = bittrex.NewWidget(app, settings)
 	case "blockfolio":
-		settings := blockfolio.NewSettingsFromYAML("Blockfolio", moduleConfig, globalConfig)
+		settings := blockfolio.NewSettingsFromYAML(widgetName, moduleConfig, globalConfig)
 		widget = blockfolio.NewWidget(app, settings)
 	case "circleci":
-		settings := circleci.NewSettingsFromYAML("CircleCI", moduleConfig, globalConfig)
+		settings := circleci.NewSettingsFromYAML(widgetName, moduleConfig, globalConfig)
 		widget = circleci.NewWidget(app, settings)
 	case "clocks":
-		settings := clocks.NewSettingsFromYAML("Clocks", moduleConfig, globalConfig)
+		settings := clocks.NewSettingsFromYAML(widgetName, moduleConfig, globalConfig)
 		widget = clocks.NewWidget(app, settings)
 	case "cmdrunner":
-		settings := cmdrunner.NewSettingsFromYAML("CmdRunner", moduleConfig, globalConfig)
+		settings := cmdrunner.NewSettingsFromYAML(widgetName, moduleConfig, globalConfig)
 		widget = cmdrunner.NewWidget(app, settings)
 	case "cryptolive":
-		settings := cryptolive.NewSettingsFromYAML("CryptoLive", moduleConfig, globalConfig)
+		settings := cryptolive.NewSettingsFromYAML(widgetName, moduleConfig, globalConfig)
 		widget = cryptolive.NewWidget(app, settings)
 	case "datadog":
-		settings := datadog.NewSettingsFromYAML("DataDog", moduleConfig, globalConfig)
+		settings := datadog.NewSettingsFromYAML(widgetName, moduleConfig, globalConfig)
 		widget = datadog.NewWidget(app, settings)
 	case "gcal":
-		settings := gcal.NewSettingsFromYAML("Calendar", moduleConfig, globalConfig)
+		settings := gcal.NewSettingsFromYAML(widgetName, moduleConfig, globalConfig)
 		widget = gcal.NewWidget(app, settings)
 	case "gerrit":
-		settings := gerrit.NewSettingsFromYAML("Gerrit", moduleConfig, globalConfig)
+		settings := gerrit.NewSettingsFromYAML(widgetName, moduleConfig, globalConfig)
 		widget = gerrit.NewWidget(app, pages, settings)
 	case "git":
-		settings := git.NewSettingsFromYAML("Git", moduleConfig, globalConfig)
+		settings := git.NewSettingsFromYAML(widgetName, moduleConfig, globalConfig)
 		widget = git.NewWidget(app, pages, settings)
 	case "github":
-		settings := github.NewSettingsFromYAML("GitHub", moduleConfig, globalConfig)
+		settings := github.NewSettingsFromYAML(widgetName, moduleConfig, globalConfig)
 		widget = github.NewWidget(app, pages, settings)
 	case "gitlab":
-		settings := gitlab.NewSettingsFromYAML("GitLab", moduleConfig, globalConfig)
+		settings := gitlab.NewSettingsFromYAML(widgetName, moduleConfig, globalConfig)
 		widget = gitlab.NewWidget(app, pages, settings)
 	case "gitter":
-		settings := gitter.NewSettingsFromYAML("Gitter", moduleConfig, globalConfig)
+		settings := gitter.NewSettingsFromYAML(widgetName, moduleConfig, globalConfig)
 		widget = gitter.NewWidget(app, pages, settings)
 	case "gspreadsheets":
-		settings := gspreadsheets.NewSettingsFromYAML("Google Spreadsheets", moduleConfig, globalConfig)
+		settings := gspreadsheets.NewSettingsFromYAML(widgetName, moduleConfig, globalConfig)
 		widget = gspreadsheets.NewWidget(app, settings)
 	case "hackernews":
-		settings := hackernews.NewSettingsFromYAML("HackerNews", moduleConfig, globalConfig)
+		settings := hackernews.NewSettingsFromYAML(widgetName, moduleConfig, globalConfig)
 		widget = hackernews.NewWidget(app, pages, settings)
 	case "ipapi":
-		settings := ipapi.NewSettingsFromYAML("IPAPI", moduleConfig, globalConfig)
+		settings := ipapi.NewSettingsFromYAML(widgetName, moduleConfig, globalConfig)
 		widget = ipapi.NewWidget(app, settings)
 	case "ipinfo":
-		settings := ipinfo.NewSettingsFromYAML("IPInfo", moduleConfig, globalConfig)
+		settings := ipinfo.NewSettingsFromYAML(widgetName, moduleConfig, globalConfig)
 		widget = ipinfo.NewWidget(app, settings)
 	case "jenkins":
-		settings := jenkins.NewSettingsFromYAML("Jenkins", moduleConfig, globalConfig)
+		settings := jenkins.NewSettingsFromYAML(widgetName, moduleConfig, globalConfig)
 		widget = jenkins.NewWidget(app, pages, settings)
 	case "jira":
-		settings := jira.NewSettingsFromYAML("Jira", moduleConfig, globalConfig)
+		settings := jira.NewSettingsFromYAML(widgetName, moduleConfig, globalConfig)
 		widget = jira.NewWidget(app, pages, settings)
 	case "logger":
-		settings := logger.NewSettingsFromYAML("Log", moduleConfig, globalConfig)
+		settings := logger.NewSettingsFromYAML(widgetName, moduleConfig, globalConfig)
 		widget = logger.NewWidget(app, settings)
 	case "mercurial":
-		settings := mercurial.NewSettingsFromYAML("Mercurial", moduleConfig, globalConfig)
+		settings := mercurial.NewSettingsFromYAML(widgetName, moduleConfig, globalConfig)
 		widget = mercurial.NewWidget(app, pages, settings)
 	case "nbascore":
-		settings := nbascore.NewSettingsFromYAML("NBA Score", moduleConfig, globalConfig)
+		settings := nbascore.NewSettingsFromYAML(widgetName, moduleConfig, globalConfig)
 		widget = nbascore.NewWidget(app, pages, settings)
 	case "newrelic":
-		settings := newrelic.NewSettingsFromYAML("NewRelic", moduleConfig, globalConfig)
+		settings := newrelic.NewSettingsFromYAML(widgetName, moduleConfig, globalConfig)
 		widget = newrelic.NewWidget(app, settings)
 	case "opsgenie":
-		settings := opsgenie.NewSettingsFromYAML("OpsGenie", moduleConfig, globalConfig)
+		settings := opsgenie.NewSettingsFromYAML(widgetName, moduleConfig, globalConfig)
 		widget = opsgenie.NewWidget(app, settings)
 	case "pagerduty":
-		settings := pagerduty.NewSettingsFromYAML("PagerDuty", moduleConfig, globalConfig)
+		settings := pagerduty.NewSettingsFromYAML(widgetName, moduleConfig, globalConfig)
 		widget = pagerduty.NewWidget(app, settings)
 	case "power":
-		settings := power.NewSettingsFromYAML("Power", moduleConfig, globalConfig)
+		settings := power.NewSettingsFromYAML(widgetName, moduleConfig, globalConfig)
 		widget = power.NewWidget(app, settings)
 	case "prettyweather":
-		settings := prettyweather.NewSettingsFromYAML("Pretty Weather", moduleConfig, globalConfig)
+		settings := prettyweather.NewSettingsFromYAML(widgetName, moduleConfig, globalConfig)
 		widget = prettyweather.NewWidget(app, settings)
 	case "resourceusage":
-		settings := resourceusage.NewSettingsFromYAML("Resource Usage", moduleConfig, globalConfig)
+		settings := resourceusage.NewSettingsFromYAML(widgetName, moduleConfig, globalConfig)
 		widget = resourceusage.NewWidget(app, settings)
 	case "rollbar":
-		settings := rollbar.NewSettingsFromYAML("Rollbar", moduleConfig, globalConfig)
+		settings := rollbar.NewSettingsFromYAML(widgetName, moduleConfig, globalConfig)
 		widget = rollbar.NewWidget(app, pages, settings)
 	case "security":
-		settings := security.NewSettingsFromYAML("Security", moduleConfig, globalConfig)
+		settings := security.NewSettingsFromYAML(widgetName, moduleConfig, globalConfig)
 		widget = security.NewWidget(app, settings)
 	case "spotify":
-		settings := spotify.NewSettingsFromYAML("Spotify", moduleConfig, globalConfig)
+		settings := spotify.NewSettingsFromYAML(widgetName, moduleConfig, globalConfig)
 		widget = spotify.NewWidget(app, pages, settings)
 	case "spotifyweb":
-		settings := spotifyweb.NewSettingsFromYAML("Spotify Web", moduleConfig, globalConfig)
+		settings := spotifyweb.NewSettingsFromYAML(widgetName, moduleConfig, globalConfig)
 		widget = spotifyweb.NewWidget(app, pages, settings)
 	case "status":
-		settings := status.NewSettingsFromYAML("Status", moduleConfig, globalConfig)
+		settings := status.NewSettingsFromYAML(widgetName, moduleConfig, globalConfig)
 		widget = status.NewWidget(app, settings)
 	// case "system":
-	// 	settings := system.NewSettingsFromYAML("System", moduleConfig, globalConfig)
+	// 	settings := system.NewSettingsFromYAML(widgetName, moduleConfig, globalConfig)
 	// 	widget = system.NewWidget(app, date, version, settings)
 	case "textfile":
-		settings := textfile.NewSettingsFromYAML("Textfile", moduleConfig, globalConfig)
+		settings := textfile.NewSettingsFromYAML(widgetName, moduleConfig, globalConfig)
 		widget = textfile.NewWidget(app, pages, settings)
 	case "todo":
-		settings := todo.NewSettingsFromYAML("Todo", moduleConfig, globalConfig)
+		settings := todo.NewSettingsFromYAML(widgetName, moduleConfig, globalConfig)
 		widget = todo.NewWidget(app, pages, settings)
 	case "todoist":
-		settings := todoist.NewSettingsFromYAML("Todoist", moduleConfig, globalConfig)
+		settings := todoist.NewSettingsFromYAML(widgetName, moduleConfig, globalConfig)
 		widget = todoist.NewWidget(app, pages, settings)
 	case "travisci":
-		settings := travisci.NewSettingsFromYAML("TravisCI", moduleConfig, globalConfig)
+		settings := travisci.NewSettingsFromYAML(widgetName, moduleConfig, globalConfig)
 		widget = travisci.NewWidget(app, pages, settings)
 	case "trello":
-		settings := trello.NewSettingsFromYAML("Trello", moduleConfig, globalConfig)
+		settings := trello.NewSettingsFromYAML(widgetName, moduleConfig, globalConfig)
 		widget = trello.NewWidget(app, settings)
 	case "twitter":
-		settings := twitter.NewSettingsFromYAML("Twitter", moduleConfig, globalConfig)
+		settings := twitter.NewSettingsFromYAML(widgetName, moduleConfig, globalConfig)
 		widget = twitter.NewWidget(app, pages, settings)
 	case "victorops":
-		settings := victorops.NewSettingsFromYAML("VictorOps - OnCall", moduleConfig, globalConfig)
+		settings := victorops.NewSettingsFromYAML(widgetName, moduleConfig, globalConfig)
 		widget = victorops.NewWidget(app, settings)
 	case "weather":
-		settings := weather.NewSettingsFromYAML("Weather", moduleConfig, globalConfig)
+		settings := weather.NewSettingsFromYAML(widgetName, moduleConfig, globalConfig)
 		widget = weather.NewWidget(app, pages, settings)
 	case "zendesk":
-		settings := zendesk.NewSettingsFromYAML("Zendesk", moduleConfig, globalConfig)
+		settings := zendesk.NewSettingsFromYAML(widgetName, moduleConfig, globalConfig)
 		widget = zendesk.NewWidget(app, settings)
 	default:
 		settings := unknown.NewSettingsFromYAML(widgetName, moduleConfig, globalConfig)
@@ -213,8 +214,9 @@ func MakeWidgets(app *tview.Application, pages *tview.Pages, config *config.Conf
 
 	for mod := range mods {
 		modConfig, _ := config.Get("wtf.mods." + mod)
+		widgetType := modConfig.UString("type", mod)
 		if enabled := modConfig.UBool("enabled", false); enabled {
-			widget := MakeWidget(app, pages, mod, modConfig, config)
+			widget := MakeWidget(app, pages, mod, widgetType, modConfig, config)
 			widgets = append(widgets, widget)
 		}
 	}

--- a/modules/bamboohr/settings.go
+++ b/modules/bamboohr/settings.go
@@ -7,7 +7,7 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const configKey = "bamboohr"
+const defaultTitle = "BambooHR"
 
 type Settings struct {
 	common *cfg.Common
@@ -19,7 +19,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
 
 		apiKey:    ymlConfig.UString("apiKey", os.Getenv("WTF_BAMBOO_HR_TOKEN")),
 		subdomain: ymlConfig.UString("subdomain", os.Getenv("WTF_BAMBOO_HR_SUBDOMAIN")),

--- a/modules/bargraph/settings.go
+++ b/modules/bargraph/settings.go
@@ -5,13 +5,15 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
+const defaultTitle = "Bargraph"
+
 type Settings struct {
 	common *cfg.Common
 }
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
 	}
 
 	return &settings

--- a/modules/circleci/settings.go
+++ b/modules/circleci/settings.go
@@ -7,7 +7,7 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const configKey = "circleci"
+const defaultTitle = "CircleCI"
 
 type Settings struct {
 	common *cfg.Common
@@ -18,7 +18,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
 
 		apiKey: ymlConfig.UString("apiKey", os.Getenv("WTF_CIRCLE_API_KEY")),
 	}

--- a/modules/clocks/settings.go
+++ b/modules/clocks/settings.go
@@ -6,7 +6,7 @@ import (
 	"github.com/wtfutil/wtf/wtf"
 )
 
-const configKey = "clocks"
+const defaultTitle = "Clocks"
 
 type colors struct {
 	rows struct {
@@ -28,7 +28,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
 
 		dateFormat: ymlConfig.UString("dateFormat", wtf.SimpleDateFormat),
 		timeFormat: ymlConfig.UString("timeFormat", wtf.SimpleTimeFormat),

--- a/modules/cmdrunner/settings.go
+++ b/modules/cmdrunner/settings.go
@@ -6,7 +6,7 @@ import (
 	"github.com/wtfutil/wtf/wtf"
 )
 
-const configKey = "cmdrunner"
+const defaultTitle = "CmdRunner"
 
 type Settings struct {
 	common *cfg.Common
@@ -18,7 +18,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, moduleConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, moduleConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, moduleConfig, globalConfig),
 
 		args: wtf.ToStrs(moduleConfig.UList("args")),
 		cmd:  moduleConfig.UString("cmd"),

--- a/modules/cmdrunner/settings.go
+++ b/modules/cmdrunner/settings.go
@@ -15,13 +15,13 @@ type Settings struct {
 	cmd  string
 }
 
-func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
+func NewSettingsFromYAML(name string, moduleConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, moduleConfig, globalConfig),
 
-		args: wtf.ToStrs(ymlConfig.UList("args")),
-		cmd:  ymlConfig.UString("cmd"),
+		args: wtf.ToStrs(moduleConfig.UList("args")),
+		cmd:  moduleConfig.UString("cmd"),
 	}
 
 	return &settings

--- a/modules/cryptoexchanges/bittrex/settings.go
+++ b/modules/cryptoexchanges/bittrex/settings.go
@@ -5,7 +5,7 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const configKey = "bittrex"
+const defaultTitle = "Bittrex"
 
 type colors struct {
 	base struct {
@@ -37,7 +37,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
 	}
 
 	settings.colors.base.name = ymlConfig.UString("colors.base.name")

--- a/modules/cryptoexchanges/blockfolio/settings.go
+++ b/modules/cryptoexchanges/blockfolio/settings.go
@@ -5,7 +5,7 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const configKey = "blockfolio"
+const defaultTitle = "Blockfolio"
 
 type colors struct {
 	name  string
@@ -24,7 +24,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
 
 		deviceToken:     ymlConfig.UString("device_token"),
 		displayHoldings: ymlConfig.UBool("displayHoldings", true),

--- a/modules/cryptoexchanges/blockfolio/widget.go
+++ b/modules/cryptoexchanges/blockfolio/widget.go
@@ -42,7 +42,7 @@ func (widget *Widget) Refresh() {
 	content := widget.contentFrom(positions)
 
 	widget.app.QueueUpdateDraw(func() {
-		widget.View.SetTitle(" Blockfolio ")
+		widget.View.SetTitle(widget.CommonSettings.Title)
 		widget.View.SetText(content)
 	})
 }

--- a/modules/cryptoexchanges/cryptolive/price/settings.go
+++ b/modules/cryptoexchanges/cryptolive/price/settings.go
@@ -5,7 +5,7 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const configKey = "cryptolive"
+const defaultTitle = "CryptoLive"
 
 type colors struct {
 	from struct {
@@ -43,7 +43,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
 	}
 
 	settings.colors.from.name = ymlConfig.UString("colors.from.name")

--- a/modules/cryptoexchanges/cryptolive/settings.go
+++ b/modules/cryptoexchanges/cryptolive/settings.go
@@ -7,7 +7,7 @@ import (
 	"github.com/wtfutil/wtf/modules/cryptoexchanges/cryptolive/toplist"
 )
 
-const configKey = "cryptolive"
+const defaultTitle = "CryptolLive"
 
 type colors struct {
 	from struct {
@@ -48,7 +48,7 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	top, _ := ymlConfig.Map("top")
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
 
 		currencies: currencies,
 		top:        top,

--- a/modules/cryptoexchanges/cryptolive/toplist/settings.go
+++ b/modules/cryptoexchanges/cryptolive/toplist/settings.go
@@ -5,7 +5,7 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const configKey = "cryptolive"
+const defaultTitle = "CryptoLive"
 
 type colors struct {
 	from struct {
@@ -45,7 +45,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
 	}
 
 	settings.colors.from.name = ymlConfig.UString("colors.from.name")

--- a/modules/datadog/settings.go
+++ b/modules/datadog/settings.go
@@ -7,7 +7,7 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const configKey = "datadog"
+const defaultTitle = "DataDog"
 
 type Settings struct {
 	common *cfg.Common
@@ -20,7 +20,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
 
 		apiKey:         ymlConfig.UString("apiKey", os.Getenv("WTF_DATADOG_API_KEY")),
 		applicationKey: ymlConfig.UString("applicationKey", os.Getenv("WTF_DATADOG_APPLICATION_KEY")),

--- a/modules/gcal/settings.go
+++ b/modules/gcal/settings.go
@@ -5,7 +5,7 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const configKey = "gcal"
+const defaultTitle = "Calendar"
 
 type colors struct {
 	day         string
@@ -35,7 +35,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
 
 		conflictIcon:          ymlConfig.UString("conflictIcon", "🚨"),
 		currentIcon:           ymlConfig.UString("currentIcon", "🔸"),

--- a/modules/gerrit/settings.go
+++ b/modules/gerrit/settings.go
@@ -14,7 +14,7 @@ type colors struct {
 	}
 }
 
-const configKey = "gerrit"
+const defaultTitle = "Gerrit"
 
 type Settings struct {
 	colors
@@ -30,7 +30,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
 
 		domain:                  ymlConfig.UString("domain", ""),
 		password:                ymlConfig.UString("password", os.Getenv("WTF_GERRIT_PASSWORD")),

--- a/modules/git/settings.go
+++ b/modules/git/settings.go
@@ -5,7 +5,7 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const configKey = "git"
+const defaultTitle = "Git"
 
 type Settings struct {
 	common *cfg.Common
@@ -19,7 +19,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
 
 		commitCount:  ymlConfig.UInt("commitCount", 10),
 		commitFormat: ymlConfig.UString("commitFormat", "[forestgreen]%h [white]%s [grey]%an on %cd[white]"),

--- a/modules/github/settings.go
+++ b/modules/github/settings.go
@@ -7,7 +7,7 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const configKey = "github"
+const defaultTitle = "GitHub"
 
 type Settings struct {
 	common *cfg.Common
@@ -23,7 +23,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
 
 		apiKey:       ymlConfig.UString("apiKey", os.Getenv("WTF_GITHUB_TOKEN")),
 		baseURL:      ymlConfig.UString("baseURL", os.Getenv("WTF_GITHUB_BASE_URL")),

--- a/modules/gitlab/settings.go
+++ b/modules/gitlab/settings.go
@@ -7,7 +7,7 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const configKey = "gitlab"
+const defaultTitle = "GitLab"
 
 type Settings struct {
 	common *cfg.Common
@@ -21,7 +21,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
 
 		apiKey:   ymlConfig.UString("apiKey", os.Getenv("WTF_GITLAB_TOKEN")),
 		domain:   ymlConfig.UString("domain"),

--- a/modules/gitter/settings.go
+++ b/modules/gitter/settings.go
@@ -7,7 +7,7 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const configKey = "gitter"
+const defaultTitle = "Gitter"
 
 type Settings struct {
 	common *cfg.Common
@@ -20,7 +20,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
 
 		apiToken:         ymlConfig.UString("apiToken", os.Getenv("WTF_GITTER_API_TOKEN")),
 		numberOfMessages: ymlConfig.UInt("numberOfMessages", 10),

--- a/modules/gitter/widget.go
+++ b/modules/gitter/widget.go
@@ -59,6 +59,7 @@ func (widget *Widget) Refresh() {
 	room, err := GetRoom(widget.settings.roomURI, widget.settings.apiToken)
 	if err != nil {
 		widget.View.SetWrap(true)
+		widget.View.SetTitle(widget.CommonSettings.Title)
 		widget.View.SetText(err.Error())
 		return
 	}
@@ -73,6 +74,7 @@ func (widget *Widget) Refresh() {
 		widget.View.SetWrap(true)
 
 		widget.app.QueueUpdateDraw(func() {
+			widget.View.SetTitle(widget.CommonSettings.Title)
 			widget.View.SetText(err.Error())
 		})
 	} else {

--- a/modules/gspreadsheets/settings.go
+++ b/modules/gspreadsheets/settings.go
@@ -5,7 +5,7 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const configKey = "gspreadsheets"
+const defaultTitle = "Google Spreadsheets"
 
 type colors struct {
 	values string
@@ -24,7 +24,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
 
 		cellNames:  ymlConfig.UList("cells.names"),
 		secretFile: ymlConfig.UString("secretFile"),

--- a/modules/hackernews/settings.go
+++ b/modules/hackernews/settings.go
@@ -5,7 +5,7 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const configKey = "hackernews"
+const defaultTitle = "HackerNews"
 
 type Settings struct {
 	common *cfg.Common
@@ -17,7 +17,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
 
 		numberOfStories: ymlConfig.UInt("numberOfStories", 10),
 		storyType:       ymlConfig.UString("storyType", "top"),

--- a/modules/ipaddresses/ipapi/settings.go
+++ b/modules/ipaddresses/ipapi/settings.go
@@ -5,7 +5,7 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const configKey = "ipapi"
+const defaultTitle = "IP API"
 
 type colors struct {
 	name  string
@@ -20,7 +20,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
 	}
 
 	settings.colors.name = ymlConfig.UString("colors.name", "red")

--- a/modules/ipaddresses/ipinfo/settings.go
+++ b/modules/ipaddresses/ipinfo/settings.go
@@ -5,7 +5,7 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const configKey = "ipinfo"
+const defaultTitle = "IPInfo"
 
 type colors struct {
 	name  string
@@ -20,7 +20,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
 	}
 
 	settings.colors.name = ymlConfig.UString("colors.name", "red")

--- a/modules/jenkins/settings.go
+++ b/modules/jenkins/settings.go
@@ -7,7 +7,7 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const configKey = "jenkins"
+const defaultTitle = "Jenkins"
 
 type Settings struct {
 	common *cfg.Common
@@ -23,7 +23,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
 
 		apiKey:                  ymlConfig.UString("apiKey", os.Getenv("WTF_JENKINS_API_KEY")),
 		jobNameRegex:            ymlConfig.UString("jobNameRegex", ".*"),

--- a/modules/jira/settings.go
+++ b/modules/jira/settings.go
@@ -7,7 +7,7 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const configKey = "jira"
+const defaultTitle = "Jira"
 
 type colors struct {
 	rows struct {
@@ -32,7 +32,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
 
 		apiKey:                  ymlConfig.UString("apiKey", os.Getenv("WTF_JIRA_API_KEY")),
 		domain:                  ymlConfig.UString("domain"),

--- a/modules/mercurial/settings.go
+++ b/modules/mercurial/settings.go
@@ -5,7 +5,7 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const configKey = "mercurial"
+const defaultTitle = "Mercurial"
 
 type Settings struct {
 	common *cfg.Common
@@ -18,7 +18,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
 
 		commitCount:  ymlConfig.UInt("commitCount", 10),
 		commitFormat: ymlConfig.UString("commitFormat", "[forestgreen]{rev}:{phase} [white]{desc|firstline|strip} [grey]{author|person} {date|age}[white]"),

--- a/modules/nbascore/settings.go
+++ b/modules/nbascore/settings.go
@@ -5,7 +5,7 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const configKey = "nbascore"
+const defaultTitle = "NBA Score"
 
 type Settings struct {
 	common *cfg.Common
@@ -13,7 +13,7 @@ type Settings struct {
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
 	}
 
 	return &settings

--- a/modules/newrelic/settings.go
+++ b/modules/newrelic/settings.go
@@ -7,7 +7,7 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const configKey = "newrelic"
+const defaultTitle = "NewRelic"
 
 type Settings struct {
 	common *cfg.Common
@@ -20,7 +20,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
 
 		apiKey:        ymlConfig.UString("apiKey", os.Getenv("WTF_NEW_RELIC_API_KEY")),
 		applicationID: ymlConfig.UInt("applicationID"),

--- a/modules/opsgenie/settings.go
+++ b/modules/opsgenie/settings.go
@@ -7,7 +7,7 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const configKey = "opsgenie"
+const defaultTitle = "OpsGenie"
 
 type Settings struct {
 	common *cfg.Common
@@ -21,7 +21,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
 
 		apiKey:                 ymlConfig.UString("apiKey", os.Getenv("WTF_OPS_GENIE_API_KEY")),
 		displayEmpty:           ymlConfig.UBool("displayEmpty", true),

--- a/modules/pagerduty/settings.go
+++ b/modules/pagerduty/settings.go
@@ -7,7 +7,7 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const configKey = "pagerduty"
+const defaultTitle = "PagerDuty"
 
 type Settings struct {
 	common *cfg.Common
@@ -21,7 +21,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
 
 		apiKey:           ymlConfig.UString("apiKey", os.Getenv("WTF_PAGERDUTY_API_KEY")),
 		escalationFilter: ymlConfig.UList("escalationFilter"),

--- a/modules/power/settings.go
+++ b/modules/power/settings.go
@@ -5,7 +5,7 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const configKey = "power"
+const defaultTitle = "Power"
 
 type Settings struct {
 	common *cfg.Common
@@ -15,7 +15,7 @@ type Settings struct {
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
 	}
 
 	return &settings

--- a/modules/resourceusage/settings.go
+++ b/modules/resourceusage/settings.go
@@ -5,7 +5,7 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const configKey = "resourceusage"
+const defaultTitle = "ResourceUsage"
 
 type Settings struct {
 	common *cfg.Common
@@ -13,7 +13,7 @@ type Settings struct {
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
 	}
 
 	return &settings

--- a/modules/rollbar/settings.go
+++ b/modules/rollbar/settings.go
@@ -5,7 +5,7 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const configKey = "rollbar"
+const defaultTitle = "Rollbar"
 
 type Settings struct {
 	common *cfg.Common
@@ -21,7 +21,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
 
 		accessToken:    ymlConfig.UString("accessToken"),
 		activeOnly:     ymlConfig.UBool("activeOnly", false),

--- a/modules/security/settings.go
+++ b/modules/security/settings.go
@@ -5,7 +5,7 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const configKey = "security"
+const defaultTitle = "Security"
 
 type Settings struct {
 	common *cfg.Common
@@ -13,7 +13,7 @@ type Settings struct {
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
 	}
 
 	return &settings

--- a/modules/spotify/settings.go
+++ b/modules/spotify/settings.go
@@ -5,7 +5,7 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const configKey = "spotify"
+const defaultTitle = "Spotify"
 
 type Settings struct {
 	common *cfg.Common
@@ -13,7 +13,7 @@ type Settings struct {
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
 	}
 
 	return &settings

--- a/modules/spotifyweb/settings.go
+++ b/modules/spotifyweb/settings.go
@@ -7,7 +7,7 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const configKey = "spotifyweb"
+const defaultTitle = "Spotify Web"
 
 type Settings struct {
 	common *cfg.Common
@@ -20,7 +20,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
 
 		callbackPort: ymlConfig.UString("callbackPort", "8080"),
 		clientID:     ymlConfig.UString("clientID", os.Getenv("SPOTIFY_ID")),

--- a/modules/status/settings.go
+++ b/modules/status/settings.go
@@ -5,7 +5,7 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const configKey = "status"
+const defaultTitle = "Status"
 
 type Settings struct {
 	common *cfg.Common
@@ -13,7 +13,7 @@ type Settings struct {
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
 	}
 
 	return &settings

--- a/modules/system/settings.go
+++ b/modules/system/settings.go
@@ -5,7 +5,7 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const configKey = "system"
+const defaultTitle = "System"
 
 type Settings struct {
 	common *cfg.Common
@@ -13,7 +13,7 @@ type Settings struct {
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
 	}
 
 	return &settings

--- a/modules/textfile/settings.go
+++ b/modules/textfile/settings.go
@@ -5,7 +5,7 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const configKey = "textfile"
+const defaultTitle = "Textfile"
 
 type Settings struct {
 	common *cfg.Common
@@ -18,7 +18,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
 
 		filePaths:   ymlConfig.UList("filePaths"),
 		format:      ymlConfig.UBool("format", false),

--- a/modules/todo/settings.go
+++ b/modules/todo/settings.go
@@ -5,7 +5,7 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const configKey = "todo"
+const defaultTitle = "Todo"
 
 type Settings struct {
 	common *cfg.Common
@@ -16,7 +16,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
 
 		filePath: ymlConfig.UString("filename"),
 	}

--- a/modules/todoist/settings.go
+++ b/modules/todoist/settings.go
@@ -7,7 +7,7 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const configKey = "todoist"
+const defaultTitle = "Todoist"
 
 type Settings struct {
 	common *cfg.Common
@@ -19,7 +19,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
 
 		apiKey:   ymlConfig.UString("apiKey", os.Getenv("WTF_TODOIST_TOKEN")),
 		projects: ymlConfig.UList("projects"),

--- a/modules/travisci/settings.go
+++ b/modules/travisci/settings.go
@@ -7,7 +7,7 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const configKey = "travisci"
+const defaultTitle = "TravisCI"
 
 type Settings struct {
 	common *cfg.Common
@@ -19,7 +19,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
 
 		apiKey: ymlConfig.UString("apiKey", os.Getenv("WTF_TRAVIS_API_TOKEN")),
 		pro:    ymlConfig.UBool("pro", false),

--- a/modules/trello/settings.go
+++ b/modules/trello/settings.go
@@ -7,7 +7,7 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const configKey = "trello"
+const defaultTitle = "Trello"
 
 type Settings struct {
 	common *cfg.Common
@@ -22,7 +22,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
 
 		accessToken: ymlConfig.UString("accessToken", os.Getenv("WTF_TRELLO_ACCESS_TOKEN")),
 		apiKey:      ymlConfig.UString("apiKey", os.Getenv("WTF_TRELLO_APP_KEY")),

--- a/modules/twitter/settings.go
+++ b/modules/twitter/settings.go
@@ -7,7 +7,7 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const configKey = "twitter"
+const defaultTitle = "Twitter"
 
 type Settings struct {
 	common *cfg.Common
@@ -20,7 +20,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
 
 		bearerToken: ymlConfig.UString("bearerToken", os.Getenv("WTF_TWITTER_BEARER_TOKEN")),
 		count:       ymlConfig.UInt("count", 5),

--- a/modules/unknown/settings.go
+++ b/modules/unknown/settings.go
@@ -5,7 +5,7 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const configKey = "unkown"
+const defaultTitle = "Unknown"
 
 type Settings struct {
 	common *cfg.Common
@@ -13,7 +13,7 @@ type Settings struct {
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
 	}
 
 	return &settings

--- a/modules/victorops/settings.go
+++ b/modules/victorops/settings.go
@@ -7,7 +7,7 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const configKey = "victorops"
+const defaultTitle = "VictorOps"
 
 type Settings struct {
 	common *cfg.Common
@@ -20,7 +20,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
 
 		apiID:  ymlConfig.UString("apiID", os.Getenv("WTF_VICTOROPS_API_ID")),
 		apiKey: ymlConfig.UString("apiKey", os.Getenv("WTF_VICTOROPS_API_KEY")),

--- a/modules/victorops/widget.go
+++ b/modules/victorops/widget.go
@@ -44,6 +44,7 @@ func (widget *Widget) Refresh() {
 	}
 
 	teams, err := Fetch(widget.settings.apiID, widget.settings.apiKey)
+	widget.View.SetTitle(widget.ContextualTitle(widget.CommonSettings.Title))
 
 	if err != nil {
 		widget.View.SetWrap(true)

--- a/modules/weatherservices/prettyweather/settings.go
+++ b/modules/weatherservices/prettyweather/settings.go
@@ -5,7 +5,7 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const configKey = "prettyweather"
+const defaultTitle = "Pretty Weather"
 
 type Settings struct {
 	common *cfg.Common
@@ -19,7 +19,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
 
 		city:     ymlConfig.UString("city", "Barcelona"),
 		language: ymlConfig.UString("language", "en"),

--- a/modules/weatherservices/weather/settings.go
+++ b/modules/weatherservices/weather/settings.go
@@ -7,7 +7,7 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const configKey = "weather"
+const defaultTitle = "Weather"
 
 type colors struct {
 	current string
@@ -26,7 +26,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
 
 		apiKey:   ymlConfig.UString("apiKey", os.Getenv("WTF_OWM_API_KEY")),
 		cityIDs:  ymlConfig.UList("cityids"),

--- a/modules/zendesk/settings.go
+++ b/modules/zendesk/settings.go
@@ -7,7 +7,7 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const configKey = "zendesk"
+const defaultTitle = "Zendesk"
 
 type Settings struct {
 	common *cfg.Common
@@ -21,7 +21,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
 
 		apiKey:    ymlConfig.UString("apiKey", os.Getenv("ZENDESK_API")),
 		status:    ymlConfig.UString("status"),


### PR DESCRIPTION
This leverages the recent config changes, extending it so that config is literally using passed config, rather than
passed config value
Uses cmdRunner as an example for #181
Because config turns into a map, names are the root keys, and an optional type is provided