### PR TITLE
Decouple modules from global config

### DIFF
--- a/cfg/common_settings.go
+++ b/cfg/common_settings.go
@@ -56,6 +56,7 @@ type Common struct {
 	Enabled         bool
 	RefreshInterval int
 	Title           string
+	Config          *config.Config
 
 	focusChar int
 }
@@ -93,6 +94,7 @@ func NewCommonSettingsFromModule(name string, moduleConfig *config.Config, globa
 		Enabled:         moduleConfig.UBool("enabled", false),
 		RefreshInterval: moduleConfig.UInt("refreshInterval", 300),
 		Title:           moduleConfig.UString("title", name),
+		Config:          moduleConfig,
 
 		focusChar: moduleConfig.UInt("focusChar", -1),
 	}

--- a/cfg/common_settings.go
+++ b/cfg/common_settings.go
@@ -26,8 +26,7 @@ type Colors struct {
 }
 
 type Module struct {
-	ConfigKey string
-	Name      string
+	Name string
 }
 
 type Position struct {
@@ -61,53 +60,51 @@ type Common struct {
 	focusChar int
 }
 
-func NewCommonSettingsFromYAML(name, configKey string, ymlConfig *config.Config) *Common {
-	colorsPath := "wtf.colors"
-	modulePath := "wtf.mods." + configKey
-	positionPath := "wtf.mods." + configKey + ".position"
+func NewCommonSettingsFromModule(name string, moduleConfig *config.Config, globalSettings *config.Config) *Common {
+	colorsConfig, _ := globalSettings.Get("wtf.colors")
+	positionPath := "position"
 	sigilsPath := "wtf.sigils"
 
 	common := Common{
 		Colors: Colors{
-			Background:      ymlConfig.UString(modulePath+".background", ymlConfig.UString(colorsPath+".background", "black")),
-			BorderFocusable: ymlConfig.UString(colorsPath+".border.focusable", "red"),
-			BorderFocused:   ymlConfig.UString(colorsPath+".border.focused", "orange"),
-			BorderNormal:    ymlConfig.UString(colorsPath+".border.normal", "gray"),
-			Checked:         ymlConfig.UString(colorsPath+".checked", "white"),
-			Foreground:      ymlConfig.UString(modulePath+".foreground", ymlConfig.UString(colorsPath+".foreground", "white")),
-			HighlightFore:   ymlConfig.UString(colorsPath+".highlight.fore", "black"),
-			HighlightBack:   ymlConfig.UString(colorsPath+".highlight.back", "green"),
-			Text:            ymlConfig.UString(modulePath+".colors.text", ymlConfig.UString(colorsPath+".text", "white")),
-			Title:           ymlConfig.UString(modulePath+".colors.title", ymlConfig.UString(colorsPath+".title", "white")),
+			Background:      moduleConfig.UString("background", globalSettings.UString("background", "black")),
+			BorderFocusable: colorsConfig.UString("border.focusable", "red"),
+			BorderFocused:   colorsConfig.UString("border.focused", "orange"),
+			BorderNormal:    colorsConfig.UString("border.normal", "gray"),
+			Checked:         colorsConfig.UString("checked", "white"),
+			Foreground:      moduleConfig.UString("foreground", colorsConfig.UString("foreground", "white")),
+			HighlightFore:   colorsConfig.UString("highlight.fore", "black"),
+			HighlightBack:   colorsConfig.UString("highlight.back", "green"),
+			Text:            moduleConfig.UString("colors.text", colorsConfig.UString("text", "white")),
+			Title:           moduleConfig.UString("colors.title", colorsConfig.UString("title", "white")),
 		},
 
 		Module: Module{
-			ConfigKey: configKey,
-			Name:      name,
+			Name: name,
 		},
 
 		Position: Position{
-			Height: ymlConfig.UInt(positionPath + ".height"),
-			Left:   ymlConfig.UInt(positionPath + ".left"),
-			Top:    ymlConfig.UInt(positionPath + ".top"),
-			Width:  ymlConfig.UInt(positionPath + ".width"),
+			Height: moduleConfig.UInt(positionPath + ".height"),
+			Left:   moduleConfig.UInt(positionPath + ".left"),
+			Top:    moduleConfig.UInt(positionPath + ".top"),
+			Width:  moduleConfig.UInt(positionPath + ".width"),
 		},
 
-		Enabled:         ymlConfig.UBool(modulePath+".enabled", false),
-		RefreshInterval: ymlConfig.UInt(modulePath+".refreshInterval", 300),
-		Title:           ymlConfig.UString(modulePath+".title", name),
+		Enabled:         moduleConfig.UBool("enabled", false),
+		RefreshInterval: moduleConfig.UInt("refreshInterval", 300),
+		Title:           moduleConfig.UString("title", name),
 
-		focusChar: ymlConfig.UInt(modulePath+".focusChar", -1),
+		focusChar: moduleConfig.UInt("focusChar", -1),
 	}
 
-	common.Colors.Rows.Even = ymlConfig.UString(modulePath+".colors.rows.even", ymlConfig.UString(colorsPath+".rows.even", "white"))
-	common.Colors.Rows.Odd = ymlConfig.UString(modulePath+".colors.rows.even", ymlConfig.UString(colorsPath+".rows.odd", "lightblue"))
+	common.Colors.Rows.Even = moduleConfig.UString("colors.rows.even", moduleConfig.UString("rows.even", "white"))
+	common.Colors.Rows.Odd = moduleConfig.UString("colors.rows.even", moduleConfig.UString("rows.odd", "lightblue"))
 
-	common.Sigils.Checkbox.Checked = ymlConfig.UString(sigilsPath+".Checkbox.Checked", "x")
-	common.Sigils.Checkbox.Unchecked = ymlConfig.UString(sigilsPath+".Checkbox.Unchecked", " ")
+	common.Sigils.Checkbox.Checked = globalSettings.UString(sigilsPath+".Checkbox.Checked", "x")
+	common.Sigils.Checkbox.Unchecked = globalSettings.UString(sigilsPath+".Checkbox.Unchecked", " ")
 
-	common.Sigils.Paging.Normal = ymlConfig.UString(sigilsPath+".Paging.Normal", ymlConfig.UString("wtf.paging.pageSigil", "*"))
-	common.Sigils.Paging.Selected = ymlConfig.UString(sigilsPath+".Paging.Select", ymlConfig.UString("wtf.paging.selectedSigil", "_"))
+	common.Sigils.Paging.Normal = globalSettings.UString(sigilsPath+".Paging.Normal", globalSettings.UString("wtf.paging.pageSigil", "*"))
+	common.Sigils.Paging.Selected = globalSettings.UString(sigilsPath+".Paging.Select", globalSettings.UString("wtf.paging.selectedSigil", "_"))
 
 	return &common
 }

--- a/cfg/config_files.go
+++ b/cfg/config_files.go
@@ -17,6 +17,8 @@ const ConfigDirV1 = "~/.wtf/"
 // ConfigDirV2 defines the path to the second version of the configuration. Use this.
 const ConfigDirV2 = "~/.config/wtf/"
 
+var Config *config.Config
+
 /* -------------------- Config Migration -------------------- */
 
 // MigrateOldConfig copies any existing configuration from the old location
@@ -130,6 +132,7 @@ func LoadConfigFile(filePath string) *config.Config {
 		fmt.Printf(" %s\n", err.Error())
 		os.Exit(1)
 	}
+	Config = cfg
 
 	return cfg
 }

--- a/cfg/config_files.go
+++ b/cfg/config_files.go
@@ -17,8 +17,6 @@ const ConfigDirV1 = "~/.wtf/"
 // ConfigDirV2 defines the path to the second version of the configuration. Use this.
 const ConfigDirV2 = "~/.config/wtf/"
 
-var Config *config.Config
-
 /* -------------------- Config Migration -------------------- */
 
 // MigrateOldConfig copies any existing configuration from the old location
@@ -132,7 +130,6 @@ func LoadConfigFile(filePath string) *config.Config {
 		fmt.Printf(" %s\n", err.Error())
 		os.Exit(1)
 	}
-	Config = cfg
 
 	return cfg
 }

--- a/logger/settings.go
+++ b/logger/settings.go
@@ -11,9 +11,9 @@ type Settings struct {
 	common *cfg.Common
 }
 
-func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
+func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
+		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
 	}
 
 	return &settings

--- a/main.go
+++ b/main.go
@@ -86,9 +86,9 @@ func watchForConfigChanges(app *tview.Application, configFilePath string, grid *
 				wtf.ValidateWidgets(widgets)
 				runningWidgets = widgets
 
-				focusTracker = wtf.NewFocusTracker(app, widgets)
+				focusTracker = wtf.NewFocusTracker(app, widgets, config)
 
-				display := wtf.NewDisplay(widgets)
+				display := wtf.NewDisplay(widgets, config)
 				pages.AddPage("grid", display.Grid, true, true)
 			case err := <-watch.Error:
 				log.Fatalln(err)
@@ -132,6 +132,8 @@ func main() {
 		return
 	}
 
+	wtf.OpenFileUtil = config.UString("wtf.openFileUtil", "open")
+
 	app := tview.NewApplication()
 	pages := tview.NewPages()
 
@@ -139,9 +141,9 @@ func main() {
 	wtf.ValidateWidgets(widgets)
 	runningWidgets = widgets
 
-	focusTracker = wtf.NewFocusTracker(app, widgets)
+	focusTracker = wtf.NewFocusTracker(app, widgets, config)
 
-	display := wtf.NewDisplay(widgets)
+	display := wtf.NewDisplay(widgets, config)
 	pages.AddPage("grid", display.Grid, true, true)
 
 	app.SetInputCapture(keyboardIntercept)

--- a/main.go
+++ b/main.go
@@ -64,10 +64,6 @@ func refreshAllWidgets(widgets []wtf.Wtfable) {
 }
 
 func setTerm() {
-	err := os.Setenv("TERM", cfg.Config.UString("wtf.term", os.Getenv("TERM")))
-	if err != nil {
-		return
-	}
 }
 
 func watchForConfigChanges(app *tview.Application, configFilePath string, grid *tview.Grid, pages *tview.Pages) {
@@ -131,7 +127,10 @@ func main() {
 		defer profile.Start(profile.MemProfile).Stop()
 	}
 
-	setTerm()
+	err := os.Setenv("TERM", config.UString("wtf.term", os.Getenv("TERM")))
+	if err != nil {
+		return
+	}
 
 	app := tview.NewApplication()
 	pages := tview.NewPages()

--- a/maker/widget_maker.go
+++ b/maker/widget_maker.go
@@ -3,9 +3,9 @@ package maker
 import (
 	"github.com/olebedev/config"
 	"github.com/rivo/tview"
-	"github.com/wtfutil/wtf/bargraph"
 	"github.com/wtfutil/wtf/logger"
 	"github.com/wtfutil/wtf/modules/bamboohr"
+	"github.com/wtfutil/wtf/modules/bargraph"
 	"github.com/wtfutil/wtf/modules/circleci"
 	"github.com/wtfutil/wtf/modules/clocks"
 	"github.com/wtfutil/wtf/modules/cmdrunner"
@@ -67,7 +67,8 @@ func MakeWidget(
 		settings := bamboohr.NewSettingsFromYAML("BambooHR", moduleConfig, globalConfig)
 		widget = bamboohr.NewWidget(app, settings)
 	case "bargraph":
-		widget = bargraph.NewWidget(app)
+		settings := bargraph.NewSettingsFromYAML(widgetName, moduleConfig, globalConfig)
+		widget = bargraph.NewWidget(app, settings)
 	case "bittrex":
 		settings := bittrex.NewSettingsFromYAML("Bittrex", moduleConfig, globalConfig)
 		widget = bittrex.NewWidget(app, settings)

--- a/maker/widget_maker.go
+++ b/maker/widget_maker.go
@@ -52,147 +52,153 @@ import (
 	"github.com/wtfutil/wtf/wtf"
 )
 
-func MakeWidget(app *tview.Application, pages *tview.Pages, widgetName string) wtf.Wtfable {
+func MakeWidget(
+	app *tview.Application,
+	pages *tview.Pages,
+	widgetName string,
+	moduleConfig *config.Config,
+	globalConfig *config.Config,
+) wtf.Wtfable {
 	var widget wtf.Wtfable
 
 	// Always in alphabetical order
 	switch widgetName {
 	case "bamboohr":
-		settings := bamboohr.NewSettingsFromYAML("BambooHR", wtf.Config)
+		settings := bamboohr.NewSettingsFromYAML("BambooHR", moduleConfig, globalConfig)
 		widget = bamboohr.NewWidget(app, settings)
 	case "bargraph":
 		widget = bargraph.NewWidget(app)
 	case "bittrex":
-		settings := bittrex.NewSettingsFromYAML("Bittrex", wtf.Config)
+		settings := bittrex.NewSettingsFromYAML("Bittrex", moduleConfig, globalConfig)
 		widget = bittrex.NewWidget(app, settings)
 	case "blockfolio":
-		settings := blockfolio.NewSettingsFromYAML("Blockfolio", wtf.Config)
+		settings := blockfolio.NewSettingsFromYAML("Blockfolio", moduleConfig, globalConfig)
 		widget = blockfolio.NewWidget(app, settings)
 	case "circleci":
-		settings := circleci.NewSettingsFromYAML("CircleCI", wtf.Config)
+		settings := circleci.NewSettingsFromYAML("CircleCI", moduleConfig, globalConfig)
 		widget = circleci.NewWidget(app, settings)
 	case "clocks":
-		settings := clocks.NewSettingsFromYAML("Clocks", wtf.Config)
+		settings := clocks.NewSettingsFromYAML("Clocks", moduleConfig, globalConfig)
 		widget = clocks.NewWidget(app, settings)
 	case "cmdrunner":
-		settings := cmdrunner.NewSettingsFromYAML("CmdRunner", wtf.Config)
+		settings := cmdrunner.NewSettingsFromYAML("CmdRunner", moduleConfig, globalConfig)
 		widget = cmdrunner.NewWidget(app, settings)
 	case "cryptolive":
-		settings := cryptolive.NewSettingsFromYAML("CryptoLive", wtf.Config)
+		settings := cryptolive.NewSettingsFromYAML("CryptoLive", moduleConfig, globalConfig)
 		widget = cryptolive.NewWidget(app, settings)
 	case "datadog":
-		settings := datadog.NewSettingsFromYAML("DataDog", wtf.Config)
+		settings := datadog.NewSettingsFromYAML("DataDog", moduleConfig, globalConfig)
 		widget = datadog.NewWidget(app, settings)
 	case "gcal":
-		settings := gcal.NewSettingsFromYAML("Calendar", wtf.Config)
+		settings := gcal.NewSettingsFromYAML("Calendar", moduleConfig, globalConfig)
 		widget = gcal.NewWidget(app, settings)
 	case "gerrit":
-		settings := gerrit.NewSettingsFromYAML("Gerrit", wtf.Config)
+		settings := gerrit.NewSettingsFromYAML("Gerrit", moduleConfig, globalConfig)
 		widget = gerrit.NewWidget(app, pages, settings)
 	case "git":
-		settings := git.NewSettingsFromYAML("Git", wtf.Config)
+		settings := git.NewSettingsFromYAML("Git", moduleConfig, globalConfig)
 		widget = git.NewWidget(app, pages, settings)
 	case "github":
-		settings := github.NewSettingsFromYAML("GitHub", wtf.Config)
+		settings := github.NewSettingsFromYAML("GitHub", moduleConfig, globalConfig)
 		widget = github.NewWidget(app, pages, settings)
 	case "gitlab":
-		settings := gitlab.NewSettingsFromYAML("GitLab", wtf.Config)
+		settings := gitlab.NewSettingsFromYAML("GitLab", moduleConfig, globalConfig)
 		widget = gitlab.NewWidget(app, pages, settings)
 	case "gitter":
-		settings := gitter.NewSettingsFromYAML("Gitter", wtf.Config)
+		settings := gitter.NewSettingsFromYAML("Gitter", moduleConfig, globalConfig)
 		widget = gitter.NewWidget(app, pages, settings)
 	case "gspreadsheets":
-		settings := gspreadsheets.NewSettingsFromYAML("Google Spreadsheets", wtf.Config)
+		settings := gspreadsheets.NewSettingsFromYAML("Google Spreadsheets", moduleConfig, globalConfig)
 		widget = gspreadsheets.NewWidget(app, settings)
 	case "hackernews":
-		settings := hackernews.NewSettingsFromYAML("HackerNews", wtf.Config)
+		settings := hackernews.NewSettingsFromYAML("HackerNews", moduleConfig, globalConfig)
 		widget = hackernews.NewWidget(app, pages, settings)
 	case "ipapi":
-		settings := ipapi.NewSettingsFromYAML("IPAPI", wtf.Config)
+		settings := ipapi.NewSettingsFromYAML("IPAPI", moduleConfig, globalConfig)
 		widget = ipapi.NewWidget(app, settings)
 	case "ipinfo":
-		settings := ipinfo.NewSettingsFromYAML("IPInfo", wtf.Config)
+		settings := ipinfo.NewSettingsFromYAML("IPInfo", moduleConfig, globalConfig)
 		widget = ipinfo.NewWidget(app, settings)
 	case "jenkins":
-		settings := jenkins.NewSettingsFromYAML("Jenkins", wtf.Config)
+		settings := jenkins.NewSettingsFromYAML("Jenkins", moduleConfig, globalConfig)
 		widget = jenkins.NewWidget(app, pages, settings)
 	case "jira":
-		settings := jira.NewSettingsFromYAML("Jira", wtf.Config)
+		settings := jira.NewSettingsFromYAML("Jira", moduleConfig, globalConfig)
 		widget = jira.NewWidget(app, pages, settings)
 	case "logger":
-		settings := logger.NewSettingsFromYAML("Log", wtf.Config)
+		settings := logger.NewSettingsFromYAML("Log", moduleConfig, globalConfig)
 		widget = logger.NewWidget(app, settings)
 	case "mercurial":
-		settings := mercurial.NewSettingsFromYAML("Mercurial", wtf.Config)
+		settings := mercurial.NewSettingsFromYAML("Mercurial", moduleConfig, globalConfig)
 		widget = mercurial.NewWidget(app, pages, settings)
 	case "nbascore":
-		settings := nbascore.NewSettingsFromYAML("NBA Score", wtf.Config)
+		settings := nbascore.NewSettingsFromYAML("NBA Score", moduleConfig, globalConfig)
 		widget = nbascore.NewWidget(app, pages, settings)
 	case "newrelic":
-		settings := newrelic.NewSettingsFromYAML("NewRelic", wtf.Config)
+		settings := newrelic.NewSettingsFromYAML("NewRelic", moduleConfig, globalConfig)
 		widget = newrelic.NewWidget(app, settings)
 	case "opsgenie":
-		settings := opsgenie.NewSettingsFromYAML("OpsGenie", wtf.Config)
+		settings := opsgenie.NewSettingsFromYAML("OpsGenie", moduleConfig, globalConfig)
 		widget = opsgenie.NewWidget(app, settings)
 	case "pagerduty":
-		settings := pagerduty.NewSettingsFromYAML("PagerDuty", wtf.Config)
+		settings := pagerduty.NewSettingsFromYAML("PagerDuty", moduleConfig, globalConfig)
 		widget = pagerduty.NewWidget(app, settings)
 	case "power":
-		settings := power.NewSettingsFromYAML("Power", wtf.Config)
+		settings := power.NewSettingsFromYAML("Power", moduleConfig, globalConfig)
 		widget = power.NewWidget(app, settings)
 	case "prettyweather":
-		settings := prettyweather.NewSettingsFromYAML("Pretty Weather", wtf.Config)
+		settings := prettyweather.NewSettingsFromYAML("Pretty Weather", moduleConfig, globalConfig)
 		widget = prettyweather.NewWidget(app, settings)
 	case "resourceusage":
-		settings := resourceusage.NewSettingsFromYAML("Resource Usage", wtf.Config)
+		settings := resourceusage.NewSettingsFromYAML("Resource Usage", moduleConfig, globalConfig)
 		widget = resourceusage.NewWidget(app, settings)
 	case "rollbar":
-		settings := rollbar.NewSettingsFromYAML("Rollbar", wtf.Config)
+		settings := rollbar.NewSettingsFromYAML("Rollbar", moduleConfig, globalConfig)
 		widget = rollbar.NewWidget(app, pages, settings)
 	case "security":
-		settings := security.NewSettingsFromYAML("Security", wtf.Config)
+		settings := security.NewSettingsFromYAML("Security", moduleConfig, globalConfig)
 		widget = security.NewWidget(app, settings)
 	case "spotify":
-		settings := spotify.NewSettingsFromYAML("Spotify", wtf.Config)
+		settings := spotify.NewSettingsFromYAML("Spotify", moduleConfig, globalConfig)
 		widget = spotify.NewWidget(app, pages, settings)
 	case "spotifyweb":
-		settings := spotifyweb.NewSettingsFromYAML("Spotify Web", wtf.Config)
+		settings := spotifyweb.NewSettingsFromYAML("Spotify Web", moduleConfig, globalConfig)
 		widget = spotifyweb.NewWidget(app, pages, settings)
 	case "status":
-		settings := status.NewSettingsFromYAML("Status", wtf.Config)
+		settings := status.NewSettingsFromYAML("Status", moduleConfig, globalConfig)
 		widget = status.NewWidget(app, settings)
 	// case "system":
-	// 	settings := system.NewSettingsFromYAML("System", wtf.Config)
+	// 	settings := system.NewSettingsFromYAML("System", moduleConfig, globalConfig)
 	// 	widget = system.NewWidget(app, date, version, settings)
 	case "textfile":
-		settings := textfile.NewSettingsFromYAML("Textfile", wtf.Config)
+		settings := textfile.NewSettingsFromYAML("Textfile", moduleConfig, globalConfig)
 		widget = textfile.NewWidget(app, pages, settings)
 	case "todo":
-		settings := todo.NewSettingsFromYAML("Todo", wtf.Config)
+		settings := todo.NewSettingsFromYAML("Todo", moduleConfig, globalConfig)
 		widget = todo.NewWidget(app, pages, settings)
 	case "todoist":
-		settings := todoist.NewSettingsFromYAML("Todoist", wtf.Config)
+		settings := todoist.NewSettingsFromYAML("Todoist", moduleConfig, globalConfig)
 		widget = todoist.NewWidget(app, pages, settings)
 	case "travisci":
-		settings := travisci.NewSettingsFromYAML("TravisCI", wtf.Config)
+		settings := travisci.NewSettingsFromYAML("TravisCI", moduleConfig, globalConfig)
 		widget = travisci.NewWidget(app, pages, settings)
 	case "trello":
-		settings := trello.NewSettingsFromYAML("Trello", wtf.Config)
+		settings := trello.NewSettingsFromYAML("Trello", moduleConfig, globalConfig)
 		widget = trello.NewWidget(app, settings)
 	case "twitter":
-		settings := twitter.NewSettingsFromYAML("Twitter", wtf.Config)
+		settings := twitter.NewSettingsFromYAML("Twitter", moduleConfig, globalConfig)
 		widget = twitter.NewWidget(app, pages, settings)
 	case "victorops":
-		settings := victorops.NewSettingsFromYAML("VictorOps - OnCall", wtf.Config)
+		settings := victorops.NewSettingsFromYAML("VictorOps - OnCall", moduleConfig, globalConfig)
 		widget = victorops.NewWidget(app, settings)
 	case "weather":
-		settings := weather.NewSettingsFromYAML("Weather", wtf.Config)
+		settings := weather.NewSettingsFromYAML("Weather", moduleConfig, globalConfig)
 		widget = weather.NewWidget(app, pages, settings)
 	case "zendesk":
-		settings := zendesk.NewSettingsFromYAML("Zendesk", wtf.Config)
+		settings := zendesk.NewSettingsFromYAML("Zendesk", moduleConfig, globalConfig)
 		widget = zendesk.NewWidget(app, settings)
 	default:
-		settings := unknown.NewSettingsFromYAML(widgetName, wtf.Config)
+		settings := unknown.NewSettingsFromYAML(widgetName, moduleConfig, globalConfig)
 		widget = unknown.NewWidget(app, widgetName, settings)
 	}
 
@@ -205,8 +211,9 @@ func MakeWidgets(app *tview.Application, pages *tview.Pages, config *config.Conf
 	mods, _ := config.Map("wtf.mods")
 
 	for mod := range mods {
-		if enabled := config.UBool("wtf.mods."+mod+".enabled", false); enabled {
-			widget := MakeWidget(app, pages, mod)
+		modConfig, _ := config.Get("wtf.mods." + mod)
+		if enabled := modConfig.UBool("enabled", false); enabled {
+			widget := MakeWidget(app, pages, mod, modConfig, config)
 			widgets = append(widgets, widget)
 		}
 	}

--- a/modules/bamboohr/settings.go
+++ b/modules/bamboohr/settings.go
@@ -16,14 +16,13 @@ type Settings struct {
 	subdomain string
 }
 
-func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
-	localConfig, _ := ymlConfig.Get("wtf.mods." + configKey)
+func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
+		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
 
-		apiKey:    localConfig.UString("apiKey", os.Getenv("WTF_BAMBOO_HR_TOKEN")),
-		subdomain: localConfig.UString("subdomain", os.Getenv("WTF_BAMBOO_HR_SUBDOMAIN")),
+		apiKey:    ymlConfig.UString("apiKey", os.Getenv("WTF_BAMBOO_HR_TOKEN")),
+		subdomain: ymlConfig.UString("subdomain", os.Getenv("WTF_BAMBOO_HR_SUBDOMAIN")),
 	}
 
 	return &settings

--- a/modules/bargraph/settings.go
+++ b/modules/bargraph/settings.go
@@ -1,0 +1,18 @@
+package bargraph
+
+import (
+	"github.com/olebedev/config"
+	"github.com/wtfutil/wtf/cfg"
+)
+
+type Settings struct {
+	common *cfg.Common
+}
+
+func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
+	settings := Settings{
+		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
+	}
+
+	return &settings
+}

--- a/modules/bargraph/widget.go
+++ b/modules/bargraph/widget.go
@@ -23,9 +23,9 @@ type Widget struct {
 }
 
 // NewWidget Make new instance of widget
-func NewWidget(app *tview.Application) *Widget {
+func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		BarGraph: wtf.NewBarGraph(app, "Sample Bar Graph", "bargraph", false),
+		BarGraph: wtf.NewBarGraph(app, "Sample Bar Graph", settings.common, false),
 
 		app: app,
 	}

--- a/modules/circleci/settings.go
+++ b/modules/circleci/settings.go
@@ -15,13 +15,12 @@ type Settings struct {
 	apiKey string
 }
 
-func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
-	localConfig, _ := ymlConfig.Get("wtf.mods." + configKey)
+func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
+		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
 
-		apiKey: localConfig.UString("apiKey", os.Getenv("WTF_CIRCLE_API_KEY")),
+		apiKey: ymlConfig.UString("apiKey", os.Getenv("WTF_CIRCLE_API_KEY")),
 	}
 
 	return &settings

--- a/modules/clocks/setting.go
+++ b/modules/clocks/setting.go
@@ -25,20 +25,19 @@ type Settings struct {
 	sort       string
 }
 
-func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
-	localConfig, _ := ymlConfig.Get("wtf.mods." + configKey)
+func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
+		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
 
-		dateFormat: localConfig.UString("dateFormat", wtf.SimpleDateFormat),
-		timeFormat: localConfig.UString("timeFormat", wtf.SimpleTimeFormat),
-		locations:  localConfig.UMap("locations"),
-		sort:       localConfig.UString("sort"),
+		dateFormat: ymlConfig.UString("dateFormat", wtf.SimpleDateFormat),
+		timeFormat: ymlConfig.UString("timeFormat", wtf.SimpleTimeFormat),
+		locations:  ymlConfig.UMap("locations"),
+		sort:       ymlConfig.UString("sort"),
 	}
 
-	settings.colors.rows.even = localConfig.UString("colors.rows.even", "white")
-	settings.colors.rows.odd = localConfig.UString("colors.rows.odd", "blue")
+	settings.colors.rows.even = ymlConfig.UString("colors.rows.even", "white")
+	settings.colors.rows.odd = ymlConfig.UString("colors.rows.odd", "blue")
 
 	return &settings
 }

--- a/modules/cmdrunner/settings.go
+++ b/modules/cmdrunner/settings.go
@@ -15,14 +15,13 @@ type Settings struct {
 	cmd  string
 }
 
-func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
-	localConfig, _ := ymlConfig.Get("wtf.mods." + configKey)
+func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
+		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
 
-		args: wtf.ToStrs(localConfig.UList("args")),
-		cmd:  localConfig.UString("cmd"),
+		args: wtf.ToStrs(ymlConfig.UList("args")),
+		cmd:  ymlConfig.UString("cmd"),
 	}
 
 	return &settings

--- a/modules/cryptoexchanges/bittrex/settings.go
+++ b/modules/cryptoexchanges/bittrex/settings.go
@@ -34,22 +34,21 @@ type Settings struct {
 	summary
 }
 
-func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
-	localConfig, _ := ymlConfig.Get("wtf.mods." + configKey)
+func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
+		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
 	}
 
-	settings.colors.base.name = localConfig.UString("colors.base.name")
-	settings.colors.base.displayName = localConfig.UString("colors.base.displayName")
+	settings.colors.base.name = ymlConfig.UString("colors.base.name")
+	settings.colors.base.displayName = ymlConfig.UString("colors.base.displayName")
 
-	settings.colors.market.name = localConfig.UString("colors.market.name")
-	settings.colors.market.field = localConfig.UString("colors.market.field")
-	settings.colors.market.value = localConfig.UString("colors.market.value")
+	settings.colors.market.name = ymlConfig.UString("colors.market.name")
+	settings.colors.market.field = ymlConfig.UString("colors.market.field")
+	settings.colors.market.value = ymlConfig.UString("colors.market.value")
 
 	settings.summary.currencies = make(map[string]*currency)
-	for key, val := range localConfig.UMap("summary") {
+	for key, val := range ymlConfig.UMap("summary") {
 		coercedVal := val.(map[string]interface{})
 
 		currency := &currency{

--- a/modules/cryptoexchanges/blockfolio/settings.go
+++ b/modules/cryptoexchanges/blockfolio/settings.go
@@ -21,14 +21,13 @@ type Settings struct {
 	displayHoldings bool
 }
 
-func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
-	localConfig, _ := ymlConfig.Get("wtf.mods." + configKey)
+func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
+		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
 
-		deviceToken:     localConfig.UString("device_token"),
-		displayHoldings: localConfig.UBool("displayHoldings", true),
+		deviceToken:     ymlConfig.UString("device_token"),
+		displayHoldings: ymlConfig.UBool("displayHoldings", true),
 	}
 
 	return &settings

--- a/modules/cryptoexchanges/cryptolive/price/settings.go
+++ b/modules/cryptoexchanges/cryptolive/price/settings.go
@@ -40,29 +40,28 @@ type Settings struct {
 	currencies map[string]*currency
 }
 
-func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
-	localConfig, _ := ymlConfig.Get("wtf.mods." + configKey)
+func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
+		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
 	}
 
-	settings.colors.from.name = localConfig.UString("colors.from.name")
-	settings.colors.from.displayName = localConfig.UString("colors.from.displayName")
+	settings.colors.from.name = ymlConfig.UString("colors.from.name")
+	settings.colors.from.displayName = ymlConfig.UString("colors.from.displayName")
 
-	settings.colors.to.name = localConfig.UString("colors.to.name")
-	settings.colors.to.price = localConfig.UString("colors.to.price")
+	settings.colors.to.name = ymlConfig.UString("colors.to.name")
+	settings.colors.to.price = ymlConfig.UString("colors.to.price")
 
-	settings.colors.top.from.name = localConfig.UString("colors.top.from.name")
-	settings.colors.top.from.displayName = localConfig.UString("colors.top.from.displayName")
+	settings.colors.top.from.name = ymlConfig.UString("colors.top.from.name")
+	settings.colors.top.from.displayName = ymlConfig.UString("colors.top.from.displayName")
 
-	settings.colors.top.to.name = localConfig.UString("colors.top.to.name")
-	settings.colors.top.to.field = localConfig.UString("colors.top.to.field")
-	settings.colors.top.to.value = localConfig.UString("colors.top.to.value")
+	settings.colors.top.to.name = ymlConfig.UString("colors.top.to.name")
+	settings.colors.top.to.field = ymlConfig.UString("colors.top.to.field")
+	settings.colors.top.to.value = ymlConfig.UString("colors.top.to.value")
 
 	settings.currencies = make(map[string]*currency)
 
-	for key, val := range localConfig.UMap("currencies") {
+	for key, val := range ymlConfig.UMap("currencies") {
 		coercedVal := val.(map[string]interface{})
 
 		currency := &currency{

--- a/modules/cryptoexchanges/cryptolive/settings.go
+++ b/modules/cryptoexchanges/cryptolive/settings.go
@@ -42,34 +42,33 @@ type Settings struct {
 	toplistSettings *toplist.Settings
 }
 
-func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
-	localConfig, _ := ymlConfig.Get("wtf.mods." + configKey)
+func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
-	currencies, _ := localConfig.Map("currencies")
-	top, _ := localConfig.Map("top")
+	currencies, _ := ymlConfig.Map("currencies")
+	top, _ := ymlConfig.Map("top")
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
+		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
 
 		currencies: currencies,
 		top:        top,
 
-		priceSettings:   price.NewSettingsFromYAML(name, ymlConfig),
-		toplistSettings: toplist.NewSettingsFromYAML(name, ymlConfig),
+		priceSettings:   price.NewSettingsFromYAML(name, ymlConfig, globalConfig),
+		toplistSettings: toplist.NewSettingsFromYAML(name, ymlConfig, globalConfig),
 	}
 
-	settings.colors.from.name = localConfig.UString("colors.from.name")
-	settings.colors.from.displayName = localConfig.UString("colors.from.displayName")
+	settings.colors.from.name = ymlConfig.UString("colors.from.name")
+	settings.colors.from.displayName = ymlConfig.UString("colors.from.displayName")
 
-	settings.colors.to.name = localConfig.UString("colors.to.name")
-	settings.colors.to.price = localConfig.UString("colors.to.price")
+	settings.colors.to.name = ymlConfig.UString("colors.to.name")
+	settings.colors.to.price = ymlConfig.UString("colors.to.price")
 
-	settings.colors.top.from.name = localConfig.UString("colors.top.from.name")
-	settings.colors.top.from.displayName = localConfig.UString("colors.top.from.displayName")
+	settings.colors.top.from.name = ymlConfig.UString("colors.top.from.name")
+	settings.colors.top.from.displayName = ymlConfig.UString("colors.top.from.displayName")
 
-	settings.colors.top.to.name = localConfig.UString("colors.top.to.name")
-	settings.colors.top.to.field = localConfig.UString("colors.top.to.field")
-	settings.colors.top.to.value = localConfig.UString("colors.top.to.value")
+	settings.colors.top.to.name = ymlConfig.UString("colors.top.to.name")
+	settings.colors.top.to.field = ymlConfig.UString("colors.top.to.field")
+	settings.colors.top.to.value = ymlConfig.UString("colors.top.to.value")
 
 	return &settings
 }

--- a/modules/cryptoexchanges/cryptolive/toplist/settings.go
+++ b/modules/cryptoexchanges/cryptolive/toplist/settings.go
@@ -42,29 +42,28 @@ type Settings struct {
 	top        map[string]*currency
 }
 
-func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
-	localConfig, _ := ymlConfig.Get("wtf.mods." + configKey)
+func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
+		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
 	}
 
-	settings.colors.from.name = localConfig.UString("colors.from.name")
-	settings.colors.from.displayName = localConfig.UString("colors.from.displayName")
+	settings.colors.from.name = ymlConfig.UString("colors.from.name")
+	settings.colors.from.displayName = ymlConfig.UString("colors.from.displayName")
 
-	settings.colors.to.name = localConfig.UString("colors.to.name")
-	settings.colors.to.price = localConfig.UString("colors.to.price")
+	settings.colors.to.name = ymlConfig.UString("colors.to.name")
+	settings.colors.to.price = ymlConfig.UString("colors.to.price")
 
-	settings.colors.top.from.name = localConfig.UString("colors.top.from.name")
-	settings.colors.top.from.displayName = localConfig.UString("colors.top.from.displayName")
+	settings.colors.top.from.name = ymlConfig.UString("colors.top.from.name")
+	settings.colors.top.from.displayName = ymlConfig.UString("colors.top.from.displayName")
 
-	settings.colors.top.to.name = localConfig.UString("colors.top.to.name")
-	settings.colors.top.to.field = localConfig.UString("colors.top.to.field")
-	settings.colors.top.to.value = localConfig.UString("colors.top.to.value")
+	settings.colors.top.to.name = ymlConfig.UString("colors.top.to.name")
+	settings.colors.top.to.field = ymlConfig.UString("colors.top.to.field")
+	settings.colors.top.to.value = ymlConfig.UString("colors.top.to.value")
 
 	settings.currencies = make(map[string]*currency)
 
-	for key, val := range localConfig.UMap("currencies") {
+	for key, val := range ymlConfig.UMap("currencies") {
 		coercedVal := val.(map[string]interface{})
 
 		limit, _ := coercedVal["limit"].(int)
@@ -78,7 +77,7 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
 		settings.currencies[key] = currency
 	}
 
-	for key, val := range localConfig.UMap("top") {
+	for key, val := range ymlConfig.UMap("top") {
 		coercedVal := val.(map[string]interface{})
 
 		limit, _ := coercedVal["limit"].(int)

--- a/modules/datadog/settings.go
+++ b/modules/datadog/settings.go
@@ -17,15 +17,14 @@ type Settings struct {
 	tags           []interface{}
 }
 
-func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
-	localConfig, _ := ymlConfig.Get("wtf.mods." + configKey)
+func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
+		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
 
-		apiKey:         localConfig.UString("apiKey", os.Getenv("WTF_DATADOG_API_KEY")),
-		applicationKey: localConfig.UString("applicationKey", os.Getenv("WTF_DATADOG_APPLICATION_KEY")),
-		tags:           localConfig.UList("monitors.tags"),
+		apiKey:         ymlConfig.UString("apiKey", os.Getenv("WTF_DATADOG_API_KEY")),
+		applicationKey: ymlConfig.UString("applicationKey", os.Getenv("WTF_DATADOG_APPLICATION_KEY")),
+		tags:           ymlConfig.UList("monitors.tags"),
 	}
 
 	return &settings

--- a/modules/gcal/settings.go
+++ b/modules/gcal/settings.go
@@ -32,28 +32,27 @@ type Settings struct {
 	withLocation          bool
 }
 
-func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
-	localConfig, _ := ymlConfig.Get("wtf.mods." + configKey)
+func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
+		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
 
-		conflictIcon:          localConfig.UString("conflictIcon", "🚨"),
-		currentIcon:           localConfig.UString("currentIcon", "🔸"),
-		displayResponseStatus: localConfig.UBool("displayResponseStatus", true),
-		email:                 localConfig.UString("email", ""),
-		eventCount:            localConfig.UInt("eventCount", 10),
-		multiCalendar:         localConfig.UBool("multiCalendar", false),
-		secretFile:            localConfig.UString("secretFile", ""),
-		showDeclined:          localConfig.UBool("showDeclined", false),
-		textInterval:          localConfig.UInt("textInterval", 30),
-		withLocation:          localConfig.UBool("withLocation", true),
+		conflictIcon:          ymlConfig.UString("conflictIcon", "🚨"),
+		currentIcon:           ymlConfig.UString("currentIcon", "🔸"),
+		displayResponseStatus: ymlConfig.UBool("displayResponseStatus", true),
+		email:                 ymlConfig.UString("email", ""),
+		eventCount:            ymlConfig.UInt("eventCount", 10),
+		multiCalendar:         ymlConfig.UBool("multiCalendar", false),
+		secretFile:            ymlConfig.UString("secretFile", ""),
+		showDeclined:          ymlConfig.UBool("showDeclined", false),
+		textInterval:          ymlConfig.UInt("textInterval", 30),
+		withLocation:          ymlConfig.UBool("withLocation", true),
 	}
 
-	settings.colors.day = localConfig.UString("colors.day", "forestgreen")
-	settings.colors.description = localConfig.UString("colors.description", "white")
-	settings.colors.past = localConfig.UString("colors.past", "gray")
-	settings.colors.title = localConfig.UString("colors.title", "white")
+	settings.colors.day = ymlConfig.UString("colors.day", "forestgreen")
+	settings.colors.description = ymlConfig.UString("colors.description", "white")
+	settings.colors.past = ymlConfig.UString("colors.past", "gray")
+	settings.colors.title = ymlConfig.UString("colors.title", "white")
 
 	return &settings
 }

--- a/modules/gerrit/settings.go
+++ b/modules/gerrit/settings.go
@@ -27,21 +27,20 @@ type Settings struct {
 	verifyServerCertificate bool
 }
 
-func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
-	localConfig, _ := ymlConfig.Get("wtf.mods." + configKey)
+func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
+		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
 
-		domain:                  localConfig.UString("domain", ""),
-		password:                localConfig.UString("password", os.Getenv("WTF_GERRIT_PASSWORD")),
-		projects:                localConfig.UList("projects"),
-		username:                localConfig.UString("username", ""),
-		verifyServerCertificate: localConfig.UBool("verifyServerCertificate", true),
+		domain:                  ymlConfig.UString("domain", ""),
+		password:                ymlConfig.UString("password", os.Getenv("WTF_GERRIT_PASSWORD")),
+		projects:                ymlConfig.UList("projects"),
+		username:                ymlConfig.UString("username", ""),
+		verifyServerCertificate: ymlConfig.UBool("verifyServerCertificate", true),
 	}
 
-	settings.colors.rows.even = localConfig.UString("colors.rows.even", "white")
-	settings.colors.rows.odd = localConfig.UString("colors.rows.odd", "blue")
+	settings.colors.rows.even = ymlConfig.UString("colors.rows.even", "white")
+	settings.colors.rows.odd = ymlConfig.UString("colors.rows.odd", "blue")
 
 	return &settings
 }

--- a/modules/git/settings.go
+++ b/modules/git/settings.go
@@ -16,16 +16,15 @@ type Settings struct {
 	repositories []interface{}
 }
 
-func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
-	localConfig, _ := ymlConfig.Get("wtf.mods." + configKey)
+func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
+		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
 
-		commitCount:  localConfig.UInt("commitCount", 10),
-		commitFormat: localConfig.UString("commitFormat", "[forestgreen]%h [white]%s [grey]%an on %cd[white]"),
-		dateFormat:   localConfig.UString("dateFormat", "%b %d, %Y"),
-		repositories: localConfig.UList("repositories"),
+		commitCount:  ymlConfig.UInt("commitCount", 10),
+		commitFormat: ymlConfig.UString("commitFormat", "[forestgreen]%h [white]%s [grey]%an on %cd[white]"),
+		dateFormat:   ymlConfig.UString("dateFormat", "%b %d, %Y"),
+		repositories: ymlConfig.UList("repositories"),
 	}
 
 	return &settings

--- a/modules/git/widget.go
+++ b/modules/git/widget.go
@@ -42,7 +42,7 @@ type Widget struct {
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
 		HelpfulWidget:     wtf.NewHelpfulWidget(app, pages, HelpText),
-		MultiSourceWidget: wtf.NewMultiSourceWidget(settings.common.ConfigKey, "repository", "repositories"),
+		MultiSourceWidget: wtf.NewMultiSourceWidget(settings.common.Name, "repository", "repositories"),
 		TextWidget:        wtf.NewTextWidget(app, settings.common, true),
 
 		app:      app,

--- a/modules/git/widget.go
+++ b/modules/git/widget.go
@@ -42,7 +42,7 @@ type Widget struct {
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
 		HelpfulWidget:     wtf.NewHelpfulWidget(app, pages, HelpText),
-		MultiSourceWidget: wtf.NewMultiSourceWidget(settings.common.Name, "repository", "repositories"),
+		MultiSourceWidget: wtf.NewMultiSourceWidget(settings.common, "repository", "repositories"),
 		TextWidget:        wtf.NewTextWidget(app, settings.common, true),
 
 		app:      app,

--- a/modules/github/settings.go
+++ b/modules/github/settings.go
@@ -20,18 +20,17 @@ type Settings struct {
 	username     string
 }
 
-func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
-	localConfig, _ := ymlConfig.Get("wtf.mods." + configKey)
+func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
+		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
 
-		apiKey:       localConfig.UString("apiKey", os.Getenv("WTF_GITHUB_TOKEN")),
-		baseURL:      localConfig.UString("baseURL", os.Getenv("WTF_GITHUB_BASE_URL")),
-		enableStatus: localConfig.UBool("enableStatus", false),
-		repositories: localConfig.UMap("repositories"),
-		uploadURL:    localConfig.UString("uploadURL", os.Getenv("WTF_GITHUB_UPLOAD_URL")),
-		username:     localConfig.UString("username"),
+		apiKey:       ymlConfig.UString("apiKey", os.Getenv("WTF_GITHUB_TOKEN")),
+		baseURL:      ymlConfig.UString("baseURL", os.Getenv("WTF_GITHUB_BASE_URL")),
+		enableStatus: ymlConfig.UBool("enableStatus", false),
+		repositories: ymlConfig.UMap("repositories"),
+		uploadURL:    ymlConfig.UString("uploadURL", os.Getenv("WTF_GITHUB_UPLOAD_URL")),
+		username:     ymlConfig.UString("username"),
 	}
 
 	return &settings

--- a/modules/gitlab/settings.go
+++ b/modules/gitlab/settings.go
@@ -18,16 +18,15 @@ type Settings struct {
 	username string
 }
 
-func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
-	localConfig, _ := ymlConfig.Get("wtf.mods." + configKey)
+func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
+		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
 
-		apiKey:   localConfig.UString("apiKey", os.Getenv("WTF_GITLAB_TOKEN")),
-		domain:   localConfig.UString("domain"),
-		projects: localConfig.UMap("projects"),
-		username: localConfig.UString("username"),
+		apiKey:   ymlConfig.UString("apiKey", os.Getenv("WTF_GITLAB_TOKEN")),
+		domain:   ymlConfig.UString("domain"),
+		projects: ymlConfig.UMap("projects"),
+		username: ymlConfig.UString("username"),
 	}
 
 	return &settings

--- a/modules/gitter/settings.go
+++ b/modules/gitter/settings.go
@@ -17,15 +17,14 @@ type Settings struct {
 	roomURI          string
 }
 
-func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
-	localConfig, _ := ymlConfig.Get("wtf.mods." + configKey)
+func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
+		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
 
-		apiToken:         localConfig.UString("apiToken", os.Getenv("WTF_GITTER_API_TOKEN")),
-		numberOfMessages: localConfig.UInt("numberOfMessages", 10),
-		roomURI:          localConfig.UString("roomUri", "wtfutil/Lobby"),
+		apiToken:         ymlConfig.UString("apiToken", os.Getenv("WTF_GITTER_API_TOKEN")),
+		numberOfMessages: ymlConfig.UInt("numberOfMessages", 10),
+		roomURI:          ymlConfig.UString("roomUri", "wtfutil/Lobby"),
 	}
 
 	return &settings

--- a/modules/gspreadsheets/settings.go
+++ b/modules/gspreadsheets/settings.go
@@ -21,18 +21,17 @@ type Settings struct {
 	sheetID       string
 }
 
-func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
-	localConfig, _ := ymlConfig.Get("wtf.mods." + configKey)
+func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
+		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
 
-		cellNames:  localConfig.UList("cells.names"),
-		secretFile: localConfig.UString("secretFile"),
-		sheetID:    localConfig.UString("sheetId"),
+		cellNames:  ymlConfig.UList("cells.names"),
+		secretFile: ymlConfig.UString("secretFile"),
+		sheetID:    ymlConfig.UString("sheetId"),
 	}
 
-	settings.colors.values = localConfig.UString("colors.values", "green")
+	settings.colors.values = ymlConfig.UString("colors.values", "green")
 
 	return &settings
 }

--- a/modules/hackernews/settings.go
+++ b/modules/hackernews/settings.go
@@ -14,14 +14,13 @@ type Settings struct {
 	storyType       string
 }
 
-func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
-	localConfig, _ := ymlConfig.Get("wtf.mods." + configKey)
+func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
+		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
 
-		numberOfStories: localConfig.UInt("numberOfStories", 10),
-		storyType:       localConfig.UString("storyType", "top"),
+		numberOfStories: ymlConfig.UInt("numberOfStories", 10),
+		storyType:       ymlConfig.UString("storyType", "top"),
 	}
 
 	return &settings

--- a/modules/ipaddresses/ipapi/settings.go
+++ b/modules/ipaddresses/ipapi/settings.go
@@ -17,15 +17,14 @@ type Settings struct {
 	common *cfg.Common
 }
 
-func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
-	localConfig, _ := ymlConfig.Get("wtf.mods." + configKey)
+func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
+		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
 	}
 
-	settings.colors.name = localConfig.UString("colors.name", "red")
-	settings.colors.value = localConfig.UString("colors.value", "white")
+	settings.colors.name = ymlConfig.UString("colors.name", "red")
+	settings.colors.value = ymlConfig.UString("colors.value", "white")
 
 	return &settings
 }

--- a/modules/ipaddresses/ipinfo/settings.go
+++ b/modules/ipaddresses/ipinfo/settings.go
@@ -17,15 +17,14 @@ type Settings struct {
 	common *cfg.Common
 }
 
-func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
-	localConfig, _ := ymlConfig.Get("wtf.mods." + configKey)
+func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
+		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
 	}
 
-	settings.colors.name = localConfig.UString("colors.name", "red")
-	settings.colors.value = localConfig.UString("colors.value", "white")
+	settings.colors.name = ymlConfig.UString("colors.name", "red")
+	settings.colors.value = ymlConfig.UString("colors.value", "white")
 
 	return &settings
 }

--- a/modules/jenkins/settings.go
+++ b/modules/jenkins/settings.go
@@ -20,18 +20,17 @@ type Settings struct {
 	verifyServerCertificate bool
 }
 
-func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
-	localConfig, _ := ymlConfig.Get("wtf.mods." + configKey)
+func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
+		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
 
-		apiKey:                  localConfig.UString("apiKey", os.Getenv("WTF_JENKINS_API_KEY")),
-		jobNameRegex:            localConfig.UString("jobNameRegex", ".*"),
-		successBallColor:        localConfig.UString("successBallColor", "blue"),
-		url:                     localConfig.UString("url"),
-		user:                    localConfig.UString("user"),
-		verifyServerCertificate: localConfig.UBool("verifyServerCertificate", true),
+		apiKey:                  ymlConfig.UString("apiKey", os.Getenv("WTF_JENKINS_API_KEY")),
+		jobNameRegex:            ymlConfig.UString("jobNameRegex", ".*"),
+		successBallColor:        ymlConfig.UString("successBallColor", "blue"),
+		url:                     ymlConfig.UString("url"),
+		user:                    ymlConfig.UString("user"),
+		verifyServerCertificate: ymlConfig.UBool("verifyServerCertificate", true),
 	}
 
 	return &settings

--- a/modules/jira/settings.go
+++ b/modules/jira/settings.go
@@ -29,24 +29,23 @@ type Settings struct {
 	verifyServerCertificate bool
 }
 
-func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
-	localConfig, _ := ymlConfig.Get("wtf.mods." + configKey)
+func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
+		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
 
-		apiKey:                  localConfig.UString("apiKey", os.Getenv("WTF_JIRA_API_KEY")),
-		domain:                  localConfig.UString("domain"),
-		email:                   localConfig.UString("email"),
-		jql:                     localConfig.UString("jql"),
-		username:                localConfig.UString("username"),
-		verifyServerCertificate: localConfig.UBool("verifyServerCertificate", true),
+		apiKey:                  ymlConfig.UString("apiKey", os.Getenv("WTF_JIRA_API_KEY")),
+		domain:                  ymlConfig.UString("domain"),
+		email:                   ymlConfig.UString("email"),
+		jql:                     ymlConfig.UString("jql"),
+		username:                ymlConfig.UString("username"),
+		verifyServerCertificate: ymlConfig.UBool("verifyServerCertificate", true),
 	}
 
-	settings.colors.rows.even = localConfig.UString("colors.even", "lightblue")
-	settings.colors.rows.odd = localConfig.UString("colors.odd", "white")
+	settings.colors.rows.even = ymlConfig.UString("colors.even", "lightblue")
+	settings.colors.rows.odd = ymlConfig.UString("colors.odd", "white")
 
-	settings.projects = settings.arrayifyProjects(localConfig)
+	settings.projects = settings.arrayifyProjects(ymlConfig, globalConfig)
 
 	return &settings
 }
@@ -54,18 +53,18 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
 /* -------------------- Unexported functions -------------------- */
 
 // arrayifyProjects figures out if we're dealing with a single project or an array of projects
-func (settings *Settings) arrayifyProjects(localConfig *config.Config) []string {
+func (settings *Settings) arrayifyProjects(ymlConfig *config.Config, globalConfig *config.Config) []string {
 	projects := []string{}
 
 	// Single project
-	project, err := localConfig.String("project")
+	project, err := ymlConfig.String("project")
 	if err == nil {
 		projects = append(projects, project)
 		return projects
 	}
 
 	// Array of projects
-	projectList := localConfig.UList("project")
+	projectList := ymlConfig.UList("project")
 	for _, projectName := range projectList {
 		if project, ok := projectName.(string); ok {
 			projects = append(projects, project)

--- a/modules/mercurial/settings.go
+++ b/modules/mercurial/settings.go
@@ -15,15 +15,14 @@ type Settings struct {
 	repositories []interface{}
 }
 
-func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
-	localConfig, _ := ymlConfig.Get("wtf.mods." + configKey)
+func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
+		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
 
-		commitCount:  localConfig.UInt("commitCount", 10),
-		commitFormat: localConfig.UString("commitFormat", "[forestgreen]{rev}:{phase} [white]{desc|firstline|strip} [grey]{author|person} {date|age}[white]"),
-		repositories: localConfig.UList("repositories"),
+		commitCount:  ymlConfig.UInt("commitCount", 10),
+		commitFormat: ymlConfig.UString("commitFormat", "[forestgreen]{rev}:{phase} [white]{desc|firstline|strip} [grey]{author|person} {date|age}[white]"),
+		repositories: ymlConfig.UList("repositories"),
 	}
 
 	return &settings

--- a/modules/mercurial/widget.go
+++ b/modules/mercurial/widget.go
@@ -37,7 +37,7 @@ type Widget struct {
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
 		HelpfulWidget:     wtf.NewHelpfulWidget(app, pages, HelpText),
-		MultiSourceWidget: wtf.NewMultiSourceWidget(settings.common.ConfigKey, "repository", "repositories"),
+		MultiSourceWidget: wtf.NewMultiSourceWidget(settings.common.Name, "repository", "repositories"),
 		TextWidget:        wtf.NewTextWidget(app, settings.common, true),
 
 		app:      app,

--- a/modules/mercurial/widget.go
+++ b/modules/mercurial/widget.go
@@ -37,7 +37,7 @@ type Widget struct {
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
 		HelpfulWidget:     wtf.NewHelpfulWidget(app, pages, HelpText),
-		MultiSourceWidget: wtf.NewMultiSourceWidget(settings.common.Name, "repository", "repositories"),
+		MultiSourceWidget: wtf.NewMultiSourceWidget(settings.common, "repository", "repositories"),
 		TextWidget:        wtf.NewTextWidget(app, settings.common, true),
 
 		app:      app,

--- a/modules/nbascore/settings.go
+++ b/modules/nbascore/settings.go
@@ -11,9 +11,9 @@ type Settings struct {
 	common *cfg.Common
 }
 
-func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
+func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
+		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
 	}
 
 	return &settings

--- a/modules/newrelic/settings.go
+++ b/modules/newrelic/settings.go
@@ -17,15 +17,14 @@ type Settings struct {
 	deployCount   int
 }
 
-func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
-	localConfig, _ := ymlConfig.Get("wtf.mods." + configKey)
+func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
+		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
 
-		apiKey:        localConfig.UString("apiKey", os.Getenv("WTF_NEW_RELIC_API_KEY")),
-		applicationID: localConfig.UInt("applicationID"),
-		deployCount:   localConfig.UInt("deployCount", 5),
+		apiKey:        ymlConfig.UString("apiKey", os.Getenv("WTF_NEW_RELIC_API_KEY")),
+		applicationID: ymlConfig.UInt("applicationID"),
+		deployCount:   ymlConfig.UInt("deployCount", 5),
 	}
 
 	return &settings

--- a/modules/opsgenie/settings.go
+++ b/modules/opsgenie/settings.go
@@ -18,35 +18,34 @@ type Settings struct {
 	scheduleIdentifierType string
 }
 
-func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
-	localConfig, _ := ymlConfig.Get("wtf.mods." + configKey)
+func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
+		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
 
-		apiKey:                 localConfig.UString("apiKey", os.Getenv("WTF_OPS_GENIE_API_KEY")),
-		displayEmpty:           localConfig.UBool("displayEmpty", true),
-		scheduleIdentifierType: localConfig.UString("scheduleIdentifierType", "id"),
+		apiKey:                 ymlConfig.UString("apiKey", os.Getenv("WTF_OPS_GENIE_API_KEY")),
+		displayEmpty:           ymlConfig.UBool("displayEmpty", true),
+		scheduleIdentifierType: ymlConfig.UString("scheduleIdentifierType", "id"),
 	}
 
-	settings.schedule = settings.arrayifySchedules(localConfig)
+	settings.schedule = settings.arrayifySchedules(ymlConfig, globalConfig)
 
 	return &settings
 }
 
 // arrayifySchedules figures out if we're dealing with a single project or an array of projects
-func (settings *Settings) arrayifySchedules(localConfig *config.Config) []string {
+func (settings *Settings) arrayifySchedules(ymlConfig *config.Config, globalConfig *config.Config) []string {
 	schedules := []string{}
 
 	// Single schedule
-	schedule, err := localConfig.String("schedule")
+	schedule, err := ymlConfig.String("schedule")
 	if err == nil {
 		schedules = append(schedules, schedule)
 		return schedules
 	}
 
 	// Array of schedules
-	scheduleList := localConfig.UList("schedule")
+	scheduleList := ymlConfig.UList("schedule")
 	for _, scheduleName := range scheduleList {
 		if schedule, ok := scheduleName.(string); ok {
 			schedules = append(schedules, schedule)

--- a/modules/pagerduty/settings.go
+++ b/modules/pagerduty/settings.go
@@ -18,16 +18,15 @@ type Settings struct {
 	showSchedules    bool
 }
 
-func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
-	localConfig, _ := ymlConfig.Get("wtf.mods." + configKey)
+func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
+		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
 
-		apiKey:           localConfig.UString("apiKey", os.Getenv("WTF_PAGERDUTY_API_KEY")),
-		escalationFilter: localConfig.UList("escalationFilter"),
-		showIncidents:    localConfig.UBool("showIncidents", true),
-		showSchedules:    localConfig.UBool("showSchedules", true),
+		apiKey:           ymlConfig.UString("apiKey", os.Getenv("WTF_PAGERDUTY_API_KEY")),
+		escalationFilter: ymlConfig.UList("escalationFilter"),
+		showIncidents:    ymlConfig.UBool("showIncidents", true),
+		showSchedules:    ymlConfig.UBool("showSchedules", true),
 	}
 
 	return &settings

--- a/modules/power/settings.go
+++ b/modules/power/settings.go
@@ -13,9 +13,9 @@ type Settings struct {
 	filePath string
 }
 
-func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
+func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
+		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
 	}
 
 	return &settings

--- a/modules/resourceusage/settings.go
+++ b/modules/resourceusage/settings.go
@@ -11,9 +11,9 @@ type Settings struct {
 	common *cfg.Common
 }
 
-func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
+func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
+		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
 	}
 
 	return &settings

--- a/modules/resourceusage/widget.go
+++ b/modules/resourceusage/widget.go
@@ -25,7 +25,7 @@ type Widget struct {
 // NewWidget Make new instance of widget
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		BarGraph: wtf.NewBarGraph(app, settings.common.Name, settings.common.ConfigKey, false),
+		BarGraph: wtf.NewBarGraph(app, settings.common.Name, settings.common.Name, false),
 
 		app:      app,
 		settings: settings,

--- a/modules/resourceusage/widget.go
+++ b/modules/resourceusage/widget.go
@@ -25,7 +25,7 @@ type Widget struct {
 // NewWidget Make new instance of widget
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		BarGraph: wtf.NewBarGraph(app, settings.common.Name, settings.common.Name, false),
+		BarGraph: wtf.NewBarGraph(app, settings.common.Name, settings.common, false),
 
 		app:      app,
 		settings: settings,

--- a/modules/rollbar/settings.go
+++ b/modules/rollbar/settings.go
@@ -18,18 +18,17 @@ type Settings struct {
 	projectOwner   string
 }
 
-func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
-	localConfig, _ := ymlConfig.Get("wtf.mods." + configKey)
+func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
+		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
 
-		accessToken:    localConfig.UString("accessToken"),
-		activeOnly:     localConfig.UBool("activeOnly", false),
-		assignedToName: localConfig.UString("assignedToName"),
-		count:          localConfig.UInt("count", 10),
-		projectName:    localConfig.UString("projectName", "Items"),
-		projectOwner:   localConfig.UString("projectOwner"),
+		accessToken:    ymlConfig.UString("accessToken"),
+		activeOnly:     ymlConfig.UBool("activeOnly", false),
+		assignedToName: ymlConfig.UString("assignedToName"),
+		count:          ymlConfig.UInt("count", 10),
+		projectName:    ymlConfig.UString("projectName", "Items"),
+		projectOwner:   ymlConfig.UString("projectOwner"),
 	}
 
 	return &settings

--- a/modules/security/settings.go
+++ b/modules/security/settings.go
@@ -11,9 +11,9 @@ type Settings struct {
 	common *cfg.Common
 }
 
-func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
+func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
+		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
 	}
 
 	return &settings

--- a/modules/spotify/settings.go
+++ b/modules/spotify/settings.go
@@ -11,9 +11,9 @@ type Settings struct {
 	common *cfg.Common
 }
 
-func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
+func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
+		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
 	}
 
 	return &settings

--- a/modules/spotifyweb/settings.go
+++ b/modules/spotifyweb/settings.go
@@ -17,15 +17,14 @@ type Settings struct {
 	secretKey    string
 }
 
-func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
-	localConfig, _ := ymlConfig.Get("wtf.mods." + configKey)
+func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
+		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
 
-		callbackPort: localConfig.UString("callbackPort", "8080"),
-		clientID:     localConfig.UString("clientID", os.Getenv("SPOTIFY_ID")),
-		secretKey:    localConfig.UString("secretKey", os.Getenv("SPOTIFY_SECRET")),
+		callbackPort: ymlConfig.UString("callbackPort", "8080"),
+		clientID:     ymlConfig.UString("clientID", os.Getenv("SPOTIFY_ID")),
+		secretKey:    ymlConfig.UString("secretKey", os.Getenv("SPOTIFY_SECRET")),
 	}
 
 	return &settings

--- a/modules/status/settings.go
+++ b/modules/status/settings.go
@@ -11,9 +11,9 @@ type Settings struct {
 	common *cfg.Common
 }
 
-func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
+func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
+		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
 	}
 
 	return &settings

--- a/modules/system/settings.go
+++ b/modules/system/settings.go
@@ -11,9 +11,9 @@ type Settings struct {
 	common *cfg.Common
 }
 
-func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
+func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
+		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
 	}
 
 	return &settings

--- a/modules/textfile/settings.go
+++ b/modules/textfile/settings.go
@@ -15,15 +15,14 @@ type Settings struct {
 	formatStyle string
 }
 
-func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
-	localConfig, _ := ymlConfig.Get("wtf.mods." + configKey)
+func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
+		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
 
-		filePaths:   localConfig.UList("filePaths"),
-		format:      localConfig.UBool("format", false),
-		formatStyle: localConfig.UString("formatStyle", "vim"),
+		filePaths:   ymlConfig.UList("filePaths"),
+		format:      ymlConfig.UBool("format", false),
+		formatStyle: ymlConfig.UString("formatStyle", "vim"),
 	}
 
 	return &settings

--- a/modules/textfile/widget.go
+++ b/modules/textfile/widget.go
@@ -42,7 +42,7 @@ type Widget struct {
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
 		HelpfulWidget:     wtf.NewHelpfulWidget(app, pages, HelpText),
-		MultiSourceWidget: wtf.NewMultiSourceWidget(settings.common.ConfigKey, "filePath", "filePaths"),
+		MultiSourceWidget: wtf.NewMultiSourceWidget(settings.common.Name, "filePath", "filePaths"),
 		TextWidget:        wtf.NewTextWidget(app, settings.common, true),
 
 		app:      app,

--- a/modules/textfile/widget.go
+++ b/modules/textfile/widget.go
@@ -42,7 +42,7 @@ type Widget struct {
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
 		HelpfulWidget:     wtf.NewHelpfulWidget(app, pages, HelpText),
-		MultiSourceWidget: wtf.NewMultiSourceWidget(settings.common.Name, "filePath", "filePaths"),
+		MultiSourceWidget: wtf.NewMultiSourceWidget(settings.common, "filePath", "filePaths"),
 		TextWidget:        wtf.NewTextWidget(app, settings.common, true),
 
 		app:      app,

--- a/modules/todo/settings.go
+++ b/modules/todo/settings.go
@@ -13,13 +13,12 @@ type Settings struct {
 	filePath string
 }
 
-func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
-	localConfig, _ := ymlConfig.Get("wtf.mods." + configKey)
+func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
+		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
 
-		filePath: localConfig.UString("filename"),
+		filePath: ymlConfig.UString("filename"),
 	}
 
 	return &settings

--- a/modules/todoist/settings.go
+++ b/modules/todoist/settings.go
@@ -16,14 +16,13 @@ type Settings struct {
 	projects []interface{}
 }
 
-func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
-	localConfig, _ := ymlConfig.Get("wtf.mods." + configKey)
+func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
+		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
 
-		apiKey:   localConfig.UString("apiKey", os.Getenv("WTF_TODOIST_TOKEN")),
-		projects: localConfig.UList("projects"),
+		apiKey:   ymlConfig.UString("apiKey", os.Getenv("WTF_TODOIST_TOKEN")),
+		projects: ymlConfig.UList("projects"),
 	}
 
 	return &settings

--- a/modules/travisci/settings.go
+++ b/modules/travisci/settings.go
@@ -16,14 +16,13 @@ type Settings struct {
 	pro    bool
 }
 
-func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
-	localConfig, _ := ymlConfig.Get("wtf.mods." + configKey)
+func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
+		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
 
-		apiKey: localConfig.UString("apiKey", os.Getenv("WTF_TRAVIS_API_TOKEN")),
-		pro:    localConfig.UBool("pro", false),
+		apiKey: ymlConfig.UString("apiKey", os.Getenv("WTF_TRAVIS_API_TOKEN")),
+		pro:    ymlConfig.UBool("pro", false),
 	}
 
 	return &settings

--- a/modules/trello/settings.go
+++ b/modules/trello/settings.go
@@ -19,35 +19,34 @@ type Settings struct {
 	username    string
 }
 
-func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
-	localConfig, _ := ymlConfig.Get("wtf.mods." + configKey)
+func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
+		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
 
-		accessToken: localConfig.UString("accessToken", os.Getenv("WTF_TRELLO_ACCESS_TOKEN")),
-		apiKey:      localConfig.UString("apiKey", os.Getenv("WTF_TRELLO_APP_KEY")),
-		board:       localConfig.UString("board"),
-		username:    localConfig.UString("username"),
+		accessToken: ymlConfig.UString("accessToken", os.Getenv("WTF_TRELLO_ACCESS_TOKEN")),
+		apiKey:      ymlConfig.UString("apiKey", os.Getenv("WTF_TRELLO_APP_KEY")),
+		board:       ymlConfig.UString("board"),
+		username:    ymlConfig.UString("username"),
 	}
 
-	settings.list = mapifyList(localConfig)
+	settings.list = mapifyList(ymlConfig, globalConfig)
 
 	return &settings
 }
 
-func mapifyList(localConfig *config.Config) map[string]string {
+func mapifyList(ymlConfig *config.Config, globalConfig *config.Config) map[string]string {
 	lists := make(map[string]string)
 
 	// Single list
-	list, err := localConfig.String("list")
+	list, err := ymlConfig.String("list")
 	if err == nil {
 		lists[list] = ""
 		return lists
 	}
 
 	// Array of lists
-	listList := localConfig.UList("project")
+	listList := ymlConfig.UList("project")
 	for _, listName := range listList {
 		if list, ok := listName.(string); ok {
 			lists[list] = ""

--- a/modules/twitter/settings.go
+++ b/modules/twitter/settings.go
@@ -17,15 +17,14 @@ type Settings struct {
 	screenNames []interface{}
 }
 
-func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
-	localConfig, _ := ymlConfig.Get("wtf.mods." + configKey)
+func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
+		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
 
-		bearerToken: localConfig.UString("bearerToken", os.Getenv("WTF_TWITTER_BEARER_TOKEN")),
-		count:       localConfig.UInt("count", 5),
-		screenNames: localConfig.UList("screenName"),
+		bearerToken: ymlConfig.UString("bearerToken", os.Getenv("WTF_TWITTER_BEARER_TOKEN")),
+		count:       ymlConfig.UInt("count", 5),
+		screenNames: ymlConfig.UList("screenName"),
 	}
 
 	return &settings

--- a/modules/twitter/widget.go
+++ b/modules/twitter/widget.go
@@ -38,7 +38,7 @@ type Widget struct {
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
 		HelpfulWidget:     wtf.NewHelpfulWidget(app, pages, HelpText),
-		MultiSourceWidget: wtf.NewMultiSourceWidget(settings.common.ConfigKey, "screenName", "screenNames"),
+		MultiSourceWidget: wtf.NewMultiSourceWidget(settings.common.Name, "screenName", "screenNames"),
 		TextWidget:        wtf.NewTextWidget(app, settings.common, true),
 
 		app:      app,

--- a/modules/twitter/widget.go
+++ b/modules/twitter/widget.go
@@ -38,7 +38,7 @@ type Widget struct {
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
 		HelpfulWidget:     wtf.NewHelpfulWidget(app, pages, HelpText),
-		MultiSourceWidget: wtf.NewMultiSourceWidget(settings.common.Name, "screenName", "screenNames"),
+		MultiSourceWidget: wtf.NewMultiSourceWidget(settings.common, "screenName", "screenNames"),
 		TextWidget:        wtf.NewTextWidget(app, settings.common, true),
 
 		app:      app,

--- a/modules/unknown/settings.go
+++ b/modules/unknown/settings.go
@@ -11,9 +11,9 @@ type Settings struct {
 	common *cfg.Common
 }
 
-func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
+func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
+		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
 	}
 
 	return &settings

--- a/modules/victorops/settings.go
+++ b/modules/victorops/settings.go
@@ -17,15 +17,14 @@ type Settings struct {
 	team   string
 }
 
-func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
-	localConfig, _ := ymlConfig.Get("wtf.mods." + configKey)
+func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
+		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
 
-		apiID:  localConfig.UString("apiID", os.Getenv("WTF_VICTOROPS_API_ID")),
-		apiKey: localConfig.UString("apiKey", os.Getenv("WTF_VICTOROPS_API_KEY")),
-		team:   localConfig.UString("team"),
+		apiID:  ymlConfig.UString("apiID", os.Getenv("WTF_VICTOROPS_API_ID")),
+		apiKey: ymlConfig.UString("apiKey", os.Getenv("WTF_VICTOROPS_API_KEY")),
+		team:   ymlConfig.UString("team"),
 	}
 
 	return &settings

--- a/modules/weatherservices/prettyweather/settings.go
+++ b/modules/weatherservices/prettyweather/settings.go
@@ -16,16 +16,15 @@ type Settings struct {
 	language string
 }
 
-func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
-	localConfig, _ := ymlConfig.Get("wtf.mods." + configKey)
+func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
+		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
 
-		city:     localConfig.UString("city", "Barcelona"),
-		language: localConfig.UString("language", "en"),
-		unit:     localConfig.UString("unit", "m"),
-		view:     localConfig.UString("view", "0"),
+		city:     ymlConfig.UString("city", "Barcelona"),
+		language: ymlConfig.UString("language", "en"),
+		unit:     ymlConfig.UString("unit", "m"),
+		view:     ymlConfig.UString("view", "0"),
 	}
 
 	return &settings

--- a/modules/weatherservices/weather/settings.go
+++ b/modules/weatherservices/weather/settings.go
@@ -23,19 +23,18 @@ type Settings struct {
 	tempUnit string
 }
 
-func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
-	localConfig, _ := ymlConfig.Get("wtf.mods." + configKey)
+func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
+		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
 
-		apiKey:   localConfig.UString("apiKey", os.Getenv("WTF_OWM_API_KEY")),
-		cityIDs:  localConfig.UList("cityids"),
-		language: localConfig.UString("language", "EN"),
-		tempUnit: localConfig.UString("tempUnit", "C"),
+		apiKey:   ymlConfig.UString("apiKey", os.Getenv("WTF_OWM_API_KEY")),
+		cityIDs:  ymlConfig.UList("cityids"),
+		language: ymlConfig.UString("language", "EN"),
+		tempUnit: ymlConfig.UString("tempUnit", "C"),
 	}
 
-	settings.colors.current = localConfig.UString("colors.current", "green")
+	settings.colors.current = ymlConfig.UString("colors.current", "green")
 
 	return &settings
 }

--- a/modules/zendesk/settings.go
+++ b/modules/zendesk/settings.go
@@ -18,16 +18,15 @@ type Settings struct {
 	username  string
 }
 
-func NewSettingsFromYAML(name string, ymlConfig *config.Config) *Settings {
-	localConfig, _ := ymlConfig.Get("wtf.mods." + configKey)
+func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromYAML(name, configKey, ymlConfig),
+		common: cfg.NewCommonSettingsFromModule(name, ymlConfig, globalConfig),
 
-		apiKey:    localConfig.UString("apiKey", os.Getenv("ZENDESK_API")),
-		status:    localConfig.UString("status"),
-		subdomain: localConfig.UString("subdomain", os.Getenv("ZENDESK_SUBDOMAIN")),
-		username:  localConfig.UString("username"),
+		apiKey:    ymlConfig.UString("apiKey", os.Getenv("ZENDESK_API")),
+		status:    ymlConfig.UString("status"),
+		subdomain: ymlConfig.UString("subdomain", os.Getenv("ZENDESK_SUBDOMAIN")),
+		username:  ymlConfig.UString("username"),
 	}
 
 	return &settings

--- a/wtf/display.go
+++ b/wtf/display.go
@@ -1,21 +1,23 @@
 package wtf
 
 import (
+	"github.com/olebedev/config"
 	"github.com/rivo/tview"
-	"github.com/wtfutil/wtf/cfg"
 )
 
 type Display struct {
-	Grid *tview.Grid
+	Grid   *tview.Grid
+	config *config.Config
 }
 
-func NewDisplay(widgets []Wtfable) *Display {
+func NewDisplay(widgets []Wtfable, config *config.Config) *Display {
 	display := Display{
-		Grid: tview.NewGrid(),
+		Grid:   tview.NewGrid(),
+		config: config,
 	}
 
 	display.build(widgets)
-	display.Grid.SetBackgroundColor(ColorFor(cfg.Config.UString("wtf.colors.background", "black")))
+	display.Grid.SetBackgroundColor(ColorFor(config.UString("wtf.colors.background", "black")))
 
 	return &display
 }
@@ -44,8 +46,8 @@ func (display *Display) add(widget Wtfable) {
 }
 
 func (display *Display) build(widgets []Wtfable) *tview.Grid {
-	display.Grid.SetColumns(ToInts(cfg.Config.UList("wtf.grid.columns"))...)
-	display.Grid.SetRows(ToInts(cfg.Config.UList("wtf.grid.rows"))...)
+	display.Grid.SetColumns(ToInts(display.config.UList("wtf.grid.columns"))...)
+	display.Grid.SetRows(ToInts(display.config.UList("wtf.grid.rows"))...)
 	display.Grid.SetBorder(false)
 
 	for _, widget := range widgets {

--- a/wtf/display.go
+++ b/wtf/display.go
@@ -2,6 +2,7 @@ package wtf
 
 import (
 	"github.com/rivo/tview"
+	"github.com/wtfutil/wtf/cfg"
 )
 
 type Display struct {
@@ -14,7 +15,7 @@ func NewDisplay(widgets []Wtfable) *Display {
 	}
 
 	display.build(widgets)
-	display.Grid.SetBackgroundColor(ColorFor(Config.UString("wtf.colors.background", "black")))
+	display.Grid.SetBackgroundColor(ColorFor(cfg.Config.UString("wtf.colors.background", "black")))
 
 	return &display
 }
@@ -43,8 +44,8 @@ func (display *Display) add(widget Wtfable) {
 }
 
 func (display *Display) build(widgets []Wtfable) *tview.Grid {
-	display.Grid.SetColumns(ToInts(Config.UList("wtf.grid.columns"))...)
-	display.Grid.SetRows(ToInts(Config.UList("wtf.grid.rows"))...)
+	display.Grid.SetColumns(ToInts(cfg.Config.UList("wtf.grid.columns"))...)
+	display.Grid.SetRows(ToInts(cfg.Config.UList("wtf.grid.rows"))...)
 	display.Grid.SetBorder(false)
 
 	for _, widget := range widgets {

--- a/wtf/focus_tracker.go
+++ b/wtf/focus_tracker.go
@@ -2,6 +2,7 @@ package wtf
 
 import (
 	"github.com/rivo/tview"
+	"github.com/wtfutil/wtf/cfg"
 )
 
 type FocusState int
@@ -161,7 +162,7 @@ func (tracker *FocusTracker) focus(idx int) {
 	}
 
 	view := widget.TextView()
-	view.SetBorderColor(ColorFor(Config.UString("wtf.colors.border.focused", "gray")))
+	view.SetBorderColor(ColorFor(cfg.Config.UString("wtf.colors.border.focused", "gray")))
 	tracker.App.SetFocus(view)
 }
 
@@ -208,5 +209,5 @@ func (tracker *FocusTracker) increment() {
 }
 
 func (tracker *FocusTracker) useNavShortcuts() bool {
-	return Config.UBool("wtf.navigation.shortcuts", true)
+	return cfg.Config.UBool("wtf.navigation.shortcuts", true)
 }

--- a/wtf/focus_tracker.go
+++ b/wtf/focus_tracker.go
@@ -1,8 +1,8 @@
 package wtf
 
 import (
+	"github.com/olebedev/config"
 	"github.com/rivo/tview"
-	"github.com/wtfutil/wtf/cfg"
 )
 
 type FocusState int
@@ -19,13 +19,15 @@ type FocusTracker struct {
 	App     *tview.Application
 	Idx     int
 	Widgets []Wtfable
+	config  *config.Config
 }
 
-func NewFocusTracker(app *tview.Application, widgets []Wtfable) FocusTracker {
+func NewFocusTracker(app *tview.Application, widgets []Wtfable, config *config.Config) FocusTracker {
 	focusTracker := FocusTracker{
 		App:     app,
 		Idx:     -1,
 		Widgets: widgets,
+		config:  config,
 	}
 
 	focusTracker.assignHotKeys()
@@ -162,7 +164,7 @@ func (tracker *FocusTracker) focus(idx int) {
 	}
 
 	view := widget.TextView()
-	view.SetBorderColor(ColorFor(cfg.Config.UString("wtf.colors.border.focused", "gray")))
+	view.SetBorderColor(ColorFor(tracker.config.UString("wtf.colors.border.focused", "gray")))
 	tracker.App.SetFocus(view)
 }
 
@@ -209,5 +211,5 @@ func (tracker *FocusTracker) increment() {
 }
 
 func (tracker *FocusTracker) useNavShortcuts() bool {
-	return cfg.Config.UBool("wtf.navigation.shortcuts", true)
+	return tracker.config.UBool("wtf.navigation.shortcuts", true)
 }

--- a/wtf/multisource_widget.go
+++ b/wtf/multisource_widget.go
@@ -2,6 +2,8 @@ package wtf
 
 import (
 	"fmt"
+
+	"github.com/wtfutil/wtf/cfg"
 )
 
 type MultiSourceWidget struct {
@@ -38,8 +40,8 @@ func (widget *MultiSourceWidget) LoadSources() {
 	s := fmt.Sprintf("wtf.mods.%s.%s", widget.module, widget.singular)
 	p := fmt.Sprintf("wtf.mods.%s.%s", widget.module, widget.plural)
 
-	single := Config.UString(s, "")
-	multiple := Config.UList(p, empty)
+	single := cfg.Config.UString(s, "")
+	multiple := cfg.Config.UList(p, empty)
 
 	asStrs := ToStrs(multiple)
 

--- a/wtf/multisource_widget.go
+++ b/wtf/multisource_widget.go
@@ -1,26 +1,24 @@
 package wtf
 
 import (
-	"fmt"
-
 	"github.com/wtfutil/wtf/cfg"
 )
 
 type MultiSourceWidget struct {
-	module   string
-	singular string
-	plural   string
+	moduleConfig *cfg.Common
+	singular     string
+	plural       string
 
 	DisplayFunction func()
 	Idx             int
 	Sources         []string
 }
 
-func NewMultiSourceWidget(module, singular, plural string) MultiSourceWidget {
+func NewMultiSourceWidget(moduleConfig *cfg.Common, singular, plural string) MultiSourceWidget {
 	return MultiSourceWidget{
-		module:   module,
-		singular: singular,
-		plural:   plural,
+		moduleConfig: moduleConfig,
+		singular:     singular,
+		plural:       plural,
 	}
 }
 
@@ -37,11 +35,8 @@ func (widget *MultiSourceWidget) CurrentSource() string {
 func (widget *MultiSourceWidget) LoadSources() {
 	var empty []interface{}
 
-	s := fmt.Sprintf("wtf.mods.%s.%s", widget.module, widget.singular)
-	p := fmt.Sprintf("wtf.mods.%s.%s", widget.module, widget.plural)
-
-	single := cfg.Config.UString(s, "")
-	multiple := cfg.Config.UList(p, empty)
+	single := widget.moduleConfig.Config.UString(widget.singular, "")
+	multiple := widget.moduleConfig.Config.UList(widget.plural, empty)
 
 	asStrs := ToStrs(multiple)
 

--- a/wtf/text_widget.go
+++ b/wtf/text_widget.go
@@ -14,7 +14,6 @@ type TextWidget struct {
 	enabled         bool
 	focusable       bool
 	focusChar       string
-	key             string
 	name            string
 	refreshInterval int
 
@@ -31,7 +30,6 @@ func NewTextWidget(app *tview.Application, commonSettings *cfg.Common, focusable
 		enabled:         commonSettings.Enabled,
 		focusable:       focusable,
 		focusChar:       commonSettings.FocusChar(),
-		key:             commonSettings.ConfigKey,
 		name:            commonSettings.Name,
 		refreshInterval: commonSettings.RefreshInterval,
 	}
@@ -90,10 +88,6 @@ func (widget *TextWidget) FocusChar() string {
 // invalid position parameters (ie: cannot be placed onscreen)
 func (widget *TextWidget) IsPositionable() bool {
 	return widget.Position.IsValid()
-}
-
-func (widget *TextWidget) Key() string {
-	return widget.key
 }
 
 func (widget *TextWidget) Name() string {

--- a/wtf/text_widget.go
+++ b/wtf/text_widget.go
@@ -3,12 +3,9 @@ package wtf
 import (
 	"fmt"
 
-	"github.com/olebedev/config"
 	"github.com/rivo/tview"
 	"github.com/wtfutil/wtf/cfg"
 )
-
-var Config *config.Config
 
 type TextWidget struct {
 	enabled         bool

--- a/wtf/utils.go
+++ b/wtf/utils.go
@@ -7,6 +7,8 @@ import (
 	"regexp"
 	"runtime"
 	"strings"
+
+	"github.com/wtfutil/wtf/cfg"
 )
 
 const SimpleDateFormat = "Jan 2"
@@ -91,7 +93,7 @@ func OpenFile(path string) {
 		}
 	} else {
 		filePath, _ := ExpandHomeDir(path)
-		openFileUtil := Config.UString("wtf.openFileUtil", "open")
+		openFileUtil := cfg.Config.UString("wtf.openFileUtil", "open")
 		cmd := exec.Command(openFileUtil, filePath)
 		ExecuteCommand(cmd)
 	}

--- a/wtf/utils.go
+++ b/wtf/utils.go
@@ -7,8 +7,6 @@ import (
 	"regexp"
 	"runtime"
 	"strings"
-
-	"github.com/wtfutil/wtf/cfg"
 )
 
 const SimpleDateFormat = "Jan 2"
@@ -18,6 +16,8 @@ const FullDateFormat = "Monday, Jan 2"
 const FriendlyDateFormat = "Mon, Jan 2"
 const FriendlyDateTimeFormat = "Mon, Jan 2, 15:04"
 const TimestampFormat = "2006-01-02T15:04:05-0700"
+
+var OpenFileUtil = "open"
 
 func CenterText(str string, width int) string {
 	if width < 0 {
@@ -93,8 +93,7 @@ func OpenFile(path string) {
 		}
 	} else {
 		filePath, _ := ExpandHomeDir(path)
-		openFileUtil := cfg.Config.UString("wtf.openFileUtil", "open")
-		cmd := exec.Command(openFileUtil, filePath)
+		cmd := exec.Command(OpenFileUtil, filePath)
 		ExecuteCommand(cmd)
 	}
 }

--- a/wtf/widget_validator.go
+++ b/wtf/widget_validator.go
@@ -12,7 +12,7 @@ func ValidateWidgets(widgets []Wtfable) (bool, error) {
 
 	for _, widget := range widgets {
 		if widget.Enabled() && !widget.IsPositionable() {
-			errStr := fmt.Sprintf("Widget config has invalid values: %s", widget.Key())
+			errStr := fmt.Sprintf("Widget config has invalid values: %s", widget.Name())
 			log.Fatalln(errStr)
 		}
 	}

--- a/wtf/wtfable.go
+++ b/wtf/wtfable.go
@@ -11,7 +11,6 @@ type Wtfable interface {
 	BorderColor() string
 	FocusChar() string
 	Focusable() bool
-	Key() string
 	Name() string
 	SetFocusChar(string)
 	TextView() *tview.TextView


### PR DESCRIPTION
Rather than referencing wtc.Config, instead pass the global config
Also, look up config for the module early and pass that in sooner, to deal with fewer long paths and get rid of the
ConfigKey variable