### PR TITLE
Increase the pagination limit for github

### DIFF
--- a/modules/github/github_repo.go
+++ b/modules/github/github_repo.go
@@ -160,6 +160,7 @@ func (repo *GithubRepo) loadPullRequests() ([]*ghb.PullRequest, error) {
 	}
 
 	opts := &ghb.PullRequestListOptions{}
+	opts.ListOptions.PerPage = 100
 
 	prs, _, err := github.PullRequests.List(context.Background(), repo.Owner, repo.Name, opts)
 


### PR DESCRIPTION
Currently, we are only getting a subset of PRs. For very active repos, this might mean I don't see any of my PRs
This isn't an explicit fix (iterating through pages would be), but at least lessens the problem