### PR TITLE
fix(gcal): remove possible extraneous variation codepoint

### DIFF
--- a/modules/gcal/display.go
+++ b/modules/gcal/display.go
@@ -214,7 +214,7 @@ func (widget *Widget) responseIcon(calEvent *CalEvent) string {
 
 	switch calEvent.ResponseFor(widget.settings.email) {
 	case "accepted":
-		return icon + "✔︎"
+		return icon + "✔"
 	case "declined":
 		return icon + "✘"
 	case "needsAction":


### PR DESCRIPTION
My layout was breaking:

![gcal_layout](https://user-images.githubusercontent.com/38514/57396760-02243700-71c3-11e9-8a7a-9428d659da67.png)

I found an extraneous codepoint after the check mark glyph

    ' ︎' U+FE0E Dec:65038 VARIATION SELECTOR-15 &#xFE0E; /\%ufe0e "\ufe0e"

This PR removes it.


