### PR TITLE
Add new key 'customQueries' to github module

### DIFF
--- a/modules/github/display.go
+++ b/modules/github/display.go
@@ -18,12 +18,14 @@ func (widget *Widget) display() {
 	str := widget.settings.common.SigilStr(len(widget.GithubRepos), widget.Idx, width) + "\n"
 	str += " [red]Stats[white]\n"
 	str += widget.displayStats(repo)
-	str += "\n"
-	str += " [red]Open Review Requests[white]\n"
+	str += "\n [red]Open Review Requests[white]\n"
 	str += widget.displayMyReviewRequests(repo, widget.settings.username)
-	str += "\n"
-	str += " [red]My Pull Requests[white]\n"
+	str += "\n [red]My Pull Requests[white]\n"
 	str += widget.displayMyPullRequests(repo, widget.settings.username)
+	for _, customQuery := range widget.settings.customQueries {
+		str += fmt.Sprintf("\n [red]%s[white]\n", customQuery.title)
+		str += widget.displayCustomQuery(repo, customQuery.filter, customQuery.perPage)
+	}
 
 	widget.TextWidget.Redraw(title, str, false)
 }
@@ -40,6 +42,23 @@ func (widget *Widget) displayMyPullRequests(repo *GithubRepo, username string) s
 		str += fmt.Sprintf(" %s[green]%4d[white] %s\n", widget.mergeString(pr), *pr.Number, *pr.Title)
 	}
 
+	return str
+}
+
+func (widget *Widget) displayCustomQuery(repo *GithubRepo, filter string, perPage int) string {
+	res := repo.customIssueQuery(filter, perPage)
+	if res == nil {
+		return " [grey]Invalid Query[white]\n"
+	}
+
+	if len(res.Issues) == 0 {
+		return " [grey]none[white]\n"
+	}
+
+	str := ""
+	for _, issue := range res.Issues {
+		str += fmt.Sprintf(" [green]%4d[white] %s\n", *issue.Number, *issue.Title)
+	}
 	return str
 }
 

--- a/modules/github/github_repo.go
+++ b/modules/github/github_repo.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	ghb "github.com/google/go-github/v25/github"
@@ -152,9 +153,23 @@ func (repo *GithubRepo) myReviewRequests(username string) []*ghb.PullRequest {
 	return prs
 }
 
+func (repo *GithubRepo) customIssueQuery(filter string, perPage int) *ghb.IssuesSearchResult {
+	github, err := repo.githubClient()
+	if err != nil {
+		return nil
+	}
+
+	opts := &ghb.SearchOptions{}
+	if perPage != 0 {
+		opts.ListOptions.PerPage = perPage
+	}
+
+	prs, _, _ := github.Search.Issues(context.Background(), fmt.Sprintf("%s repo:%s/%s", filter, repo.Owner, repo.Name), opts)
+	return prs
+}
+
 func (repo *GithubRepo) loadPullRequests() ([]*ghb.PullRequest, error) {
 	github, err := repo.githubClient()
-
 	if err != nil {
 		return nil, err
 	}

--- a/modules/github/settings.go
+++ b/modules/github/settings.go
@@ -14,12 +14,19 @@ const defaultTitle = "GitHub"
 type Settings struct {
 	common *cfg.Common
 
-	apiKey       string
-	baseURL      string
-	enableStatus bool
-	repositories []string
-	uploadURL    string
-	username     string
+	apiKey        string
+	baseURL       string
+	customQueries []customQuery
+	enableStatus  bool
+	repositories  []string
+	uploadURL     string
+	username      string
+}
+
+type customQuery struct {
+	title   string
+	filter  string
+	perPage int
 }
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
@@ -34,6 +41,7 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 		username:     ymlConfig.UString("username"),
 	}
 	settings.repositories = parseRepositories(ymlConfig)
+	settings.customQueries = parseCustomQueries(ymlConfig)
 
 	return &settings
 }
@@ -50,5 +58,29 @@ func parseRepositories(ymlConfig *config.Config) []string {
 	}
 
 	result = wtf.ToStrs(ymlConfig.UList("repositories"))
+	return result
+}
+
+func parseCustomQueries(ymlConfig *config.Config) []customQuery {
+	result := []customQuery{}
+	if customQueries, err := ymlConfig.Map("customQueries"); err == nil {
+		for _, query := range customQueries {
+			c := customQuery{}
+			for key, value := range query.(map[string]interface{}) {
+				switch key {
+				case "title":
+					c.title = value.(string)
+				case "filter":
+					c.filter = value.(string)
+				case "perPage":
+					c.perPage = value.(int)
+				}
+			}
+
+			if c.title != "" && c.filter != "" {
+				result = append(result, c)
+			}
+		}
+	}
 	return result
 }


### PR DESCRIPTION
This key allows users to pass an arbitrary amount of queries
that contain custom filters. A simple query that shows all closed
PRs could be written like the following.

```
customQueries:
  closedPullRequests:
    title: "Closed Requests"
    perPage: 10
    filter:
      - "is:closed"
      - "is:pr"
```

Resolves #469

----
[This](https://i.imgur.com/MauSb4R.png) is what it looks like with the following config

```
wtf:
  colors:
  refreshInterval: 1
  mods:
    github:
      enabled: true
      position:
        height: 1
        width: 1
      repositories:
        webrtc: "pion"
      uploadURL: ""
      username: "Sean-Der"
      customQueries:
        othersPRs:
          title: "Others Pull Requests"
          filter:
            - "is:open"
            - "is:pr"
            - "-author:Sean-Der"
        openIssues:
          title: "My Issues"
          filter:
            - "is:issue"
            - "state:open"
            - "author:Sean-Der"
        otherIssues:
          perPage: 10
          title: "Others Issues"
          filter:
            - "is:issue"
            - "state:open"
            - "-author:Sean-Der"
            - "sort:updated-desc"
```