### PR TITLE
Fix cryptolive widget

### DIFF
--- a/modules/cryptoexchanges/cryptolive/price/widget.go
+++ b/modules/cryptoexchanges/cryptolive/price/widget.go
@@ -45,17 +45,14 @@ func (widget *Widget) setList() {
 
 // Refresh & update after interval time
 func (widget *Widget) Refresh(wg *sync.WaitGroup) {
-	if len(widget.list.items) == 0 {
-		return
+	if len(widget.list.items) != 0 {
+		widget.updateCurrencies()
+		if !ok {
+			widget.Result = fmt.Sprint("Please check your internet connection!")
+		} else {
+			widget.display()
+		}
 	}
-
-	widget.updateCurrencies()
-
-	if !ok {
-		widget.Result = fmt.Sprint("Please check your internet connection!")
-		return
-	}
-	widget.display()
 	wg.Done()
 }
 

--- a/modules/cryptoexchanges/cryptolive/toplist/settings.go
+++ b/modules/cryptoexchanges/cryptolive/toplist/settings.go
@@ -37,9 +37,8 @@ type currency struct {
 
 type Settings struct {
 	colors
-	common     *cfg.Common
-	currencies map[string]*currency
-	top        map[string]*currency
+	common *cfg.Common
+	top    map[string]*currency
 }
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
@@ -61,21 +60,7 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	settings.colors.top.to.field = ymlConfig.UString("colors.top.to.field")
 	settings.colors.top.to.value = ymlConfig.UString("colors.top.to.value")
 
-	settings.currencies = make(map[string]*currency)
-
-	for key, val := range ymlConfig.UMap("currencies") {
-		coercedVal := val.(map[string]interface{})
-
-		limit, _ := coercedVal["limit"].(int)
-
-		currency := &currency{
-			displayName: coercedVal["displayName"].(string),
-			limit:       limit,
-			to:          coercedVal["to"].([]interface{}),
-		}
-
-		settings.currencies[key] = currency
-	}
+	settings.top = make(map[string]*currency)
 
 	for key, val := range ymlConfig.UMap("top") {
 		coercedVal := val.(map[string]interface{})
@@ -88,7 +73,7 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 			to:          coercedVal["to"].([]interface{}),
 		}
 
-		settings.currencies[key] = currency
+		settings.top[key] = currency
 	}
 
 	return &settings

--- a/modules/cryptoexchanges/cryptolive/toplist/widget.go
+++ b/modules/cryptoexchanges/cryptolive/toplist/widget.go
@@ -55,13 +55,12 @@ func (widget *Widget) makeToList(symbol string, limit int) (list []*tCurrency) {
 
 // Refresh & update after interval time
 func (widget *Widget) Refresh(wg *sync.WaitGroup) {
-	if len(widget.list.items) == 0 {
-		return
+	if len(widget.list.items) != 0 {
+
+		widget.updateData()
+
+		widget.display()
 	}
-
-	widget.updateData()
-
-	widget.display()
 	wg.Done()
 }
 


### PR DESCRIPTION
Addresses #481
Inverts the item list return, to make sure we always trigger wg.Done and not hang the widget
Clean up config for toplist widget, as we were assigning to `currencies` rather than `top` erroneously