### PR TITLE
add time zone support to google calendar module

### DIFF
--- a/modules/gcal/client.go
+++ b/modules/gcal/client.go
@@ -56,8 +56,10 @@ func (widget *Widget) Fetch() ([]*CalEvent, error) {
 	startTime := fromMidnight().Format(time.RFC3339)
 	eventLimit := int64(widget.settings.eventCount)
 
+	timezone := widget.settings.timeZone
+
 	for _, calendarId := range calendarIds {
-		calendarEvents, err := srv.Events.List(calendarId).ShowDeleted(false).TimeMin(startTime).MaxResults(eventLimit).SingleEvents(true).OrderBy("startTime").Do()
+		calendarEvents, err := srv.Events.List(calendarId).TimeZone(timezone).ShowDeleted(false).TimeMin(startTime).MaxResults(eventLimit).SingleEvents(true).OrderBy("startTime").Do()
 		if err != nil {
 			break
 		}

--- a/modules/gcal/settings.go
+++ b/modules/gcal/settings.go
@@ -29,6 +29,7 @@ type Settings struct {
 	secretFile            string `help:"Your Google client secret JSON file." values:"A string representing a file path to the JSON secret file."`
 	showDeclined          bool   `help:"Whether or not to display events you’ve declined to attend." values:"true or false" optional:true`
 	withLocation          bool   `help:"Whether or not to show the location of the appointment." values:"true or false"`
+	timeZone              string `help:"Time zone used in the calendar." values:"A valid time zone string"`
 }
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
@@ -39,12 +40,13 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 		conflictIcon:          ymlConfig.UString("conflictIcon", "🚨"),
 		currentIcon:           ymlConfig.UString("currentIcon", "🔸"),
 		displayResponseStatus: ymlConfig.UBool("displayResponseStatus", true),
-		email:                 ymlConfig.UString("email", ""),
-		eventCount:            ymlConfig.UInt("eventCount", 10),
-		multiCalendar:         ymlConfig.UBool("multiCalendar", false),
-		secretFile:            ymlConfig.UString("secretFile", ""),
-		showDeclined:          ymlConfig.UBool("showDeclined", false),
-		withLocation:          ymlConfig.UBool("withLocation", true),
+		email:         ymlConfig.UString("email", ""),
+		eventCount:    ymlConfig.UInt("eventCount", 10),
+		multiCalendar: ymlConfig.UBool("multiCalendar", false),
+		secretFile:    ymlConfig.UString("secretFile", ""),
+		showDeclined:  ymlConfig.UBool("showDeclined", false),
+		withLocation:  ymlConfig.UBool("withLocation", true),
+		timeZone:      ymlConfig.UString("timeZone", "America/New_York"),
 	}
 
 	settings.colors.day = ymlConfig.UString("colors.day", "forestgreen")

--- a/modules/gcal/settings.go
+++ b/modules/gcal/settings.go
@@ -46,7 +46,7 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 		secretFile:    ymlConfig.UString("secretFile", ""),
 		showDeclined:  ymlConfig.UBool("showDeclined", false),
 		withLocation:  ymlConfig.UBool("withLocation", true),
-		timeZone:      ymlConfig.UString("timeZone", "America/New_York"),
+		timeZone:      ymlConfig.UString("timeZone", ""),
 	}
 
 	settings.colors.day = ymlConfig.UString("colors.day", "forestgreen")


### PR DESCRIPTION
Fixes issue #382.
Now we're able to change the time zone. The default value remains the same as before, the one set in your Google calendar settings.