### PR TITLE
Fix rollbar rendering

### DIFF
--- a/modules/rollbar/widget.go
+++ b/modules/rollbar/widget.go
@@ -54,7 +54,7 @@ func (widget *Widget) Refresh() {
 	widget.items = &items.Results
 	widget.SetItemCount(len(widget.items.Items))
 
-	widget.Refresh()
+	widget.Render()
 }
 
 /* -------------------- Unexported Functions -------------------- */


### PR DESCRIPTION
We should be calling Render after a refresh, not calling refresh for an infinite loop
Fixes #507