### PR TITLE
Added to opsgenie module region selection

### DIFF
--- a/modules/opsgenie/client.go
+++ b/modules/opsgenie/client.go
@@ -24,13 +24,22 @@ type Parent struct {
 	Enabled bool   `json:"enabled"`
 }
 
+var opsGenieAPIUrl = map[string]string{
+	"default": "https://api.opsgenie.com",
+	"europe":  "https://api.eu.opsgenie.com",
+}
+
 /* -------------------- Exported Functions -------------------- */
 
 func (widget *Widget) Fetch(scheduleIdentifierType string, schedules []string) ([]*OnCallResponse, error) {
 	agregatedResponses := []*OnCallResponse{}
+	region := "default"
 
 	for _, sched := range schedules {
-		scheduleUrl := fmt.Sprintf("https://api.opsgenie.com/v2/schedules/%s/on-calls?scheduleIdentifierType=%s&flat=true", sched, scheduleIdentifierType)
+		if widget.settings.isEurope {
+			region = "europe"
+		}
+		scheduleUrl := fmt.Sprintf("%s/v2/schedules/%s/on-calls?scheduleIdentifierType=%s&flat=true", opsGenieAPIUrl[region], sched, scheduleIdentifierType)
 		response, err := opsGenieRequest(scheduleUrl, widget.settings.apiKey)
 		agregatedResponses = append(agregatedResponses, response)
 		if err != nil {

--- a/modules/opsgenie/settings.go
+++ b/modules/opsgenie/settings.go
@@ -13,7 +13,7 @@ type Settings struct {
 	common *cfg.Common
 
 	apiKey                 string   `help:"Your OpsGenie API token."`
-	isEurope               bool     `help:"Defines if European servers should be used." optional:"true"`
+	region                 string   `help:"Defines region to use. Possible options: us (by default), eu." optional:"true"`
 	displayEmpty           bool     `help:"Whether schedules with no assigned person on-call should be displayed." optional:"true"`
 	schedule               []string `help:"A list of names of the schedule(s) to retrieve."`
 	scheduleIdentifierType string   `help:"Type of the schedule identifier." values:"id or name" optional:"true"`
@@ -25,7 +25,7 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
 
 		apiKey:                 ymlConfig.UString("apiKey", os.Getenv("WTF_OPS_GENIE_API_KEY")),
-		isEurope:               ymlConfig.UBool("isEurope", false),
+		region:                 ymlConfig.UString("region", "us"),
 		displayEmpty:           ymlConfig.UBool("displayEmpty", true),
 		scheduleIdentifierType: ymlConfig.UString("scheduleIdentifierType", "id"),
 	}

--- a/modules/opsgenie/settings.go
+++ b/modules/opsgenie/settings.go
@@ -13,6 +13,7 @@ type Settings struct {
 	common *cfg.Common
 
 	apiKey                 string   `help:"Your OpsGenie API token."`
+	isEurope               bool     `help:"Defines if European servers should be used." optional:"true"`
 	displayEmpty           bool     `help:"Whether schedules with no assigned person on-call should be displayed." optional:"true"`
 	schedule               []string `help:"A list of names of the schedule(s) to retrieve."`
 	scheduleIdentifierType string   `help:"Type of the schedule identifier." values:"id or name" optional:"true"`
@@ -24,6 +25,7 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
 
 		apiKey:                 ymlConfig.UString("apiKey", os.Getenv("WTF_OPS_GENIE_API_KEY")),
+		isEurope:               ymlConfig.UBool("isEurope", false),
 		displayEmpty:           ymlConfig.UBool("displayEmpty", true),
 		scheduleIdentifierType: ymlConfig.UString("scheduleIdentifierType", "id"),
 	}


### PR DESCRIPTION
According to OpsGenie API documentation:

`If using the EU instance of Opsgenie, the URL needs to be https://api.eu.opsgenie.com for requests to be successful.`

P.S.
I'm not developer but I tried to do all my best to do this change :)