### PR TITLE
20190804 Reorganization

### DIFF
--- a/app/widget_maker.go
+++ b/app/widget_maker.go
@@ -1,4 +1,4 @@
-package maker
+package app
 
 import (
 	"github.com/olebedev/config"

--- a/app/wtf_app.go
+++ b/app/wtf_app.go
@@ -9,7 +9,6 @@ import (
 	"github.com/radovskyb/watcher"
 	"github.com/rivo/tview"
 	"github.com/wtfutil/wtf/cfg"
-	"github.com/wtfutil/wtf/maker"
 	"github.com/wtfutil/wtf/utils"
 	"github.com/wtfutil/wtf/wtf"
 )
@@ -39,7 +38,7 @@ func NewWtfApp(app *tview.Application, config *config.Config, configFilePath str
 	}
 
 	wtfApp.app.SetInputCapture(wtfApp.keyboardIntercept)
-	wtfApp.widgets = maker.MakeWidgets(wtfApp.app, wtfApp.pages, wtfApp.config)
+	wtfApp.widgets = MakeWidgets(wtfApp.app, wtfApp.pages, wtfApp.config)
 	wtfApp.display = NewDisplay(wtfApp.widgets, wtfApp.config)
 	wtfApp.focusTracker = NewFocusTracker(wtfApp.app, wtfApp.widgets, wtfApp.config)
 	wtfApp.validator = NewModuleValidator()

--- a/help/help.go
+++ b/help/help.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/olebedev/config"
-	"github.com/wtfutil/wtf/maker"
+	"github.com/wtfutil/wtf/app"
 	"github.com/wtfutil/wtf/utils"
 )
 
@@ -18,7 +18,7 @@ func Display(moduleName string, config *config.Config) {
 }
 
 func helpFor(moduleName string, config *config.Config) string {
-	widget := maker.MakeWidget(nil, nil, moduleName, config)
+	widget := app.MakeWidget(nil, nil, moduleName, config)
 
 	result := ""
 	result += utils.StripColorTags(widget.HelpText())

--- a/modules/bamboohr/widget.go
+++ b/modules/bamboohr/widget.go
@@ -5,20 +5,21 @@ import (
 	"time"
 
 	"github.com/rivo/tview"
+	"github.com/wtfutil/wtf/view"
 	"github.com/wtfutil/wtf/wtf"
 )
 
 const APIURI = "https://api.bamboohr.com/api/gateway.php"
 
 type Widget struct {
-	wtf.TextWidget
+	view.TextWidget
 
 	settings *Settings
 }
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, settings.common, false),
+		TextWidget: view.NewTextWidget(app, settings.common, false),
 
 		settings: settings,
 	}

--- a/modules/bargraph/widget.go
+++ b/modules/bargraph/widget.go
@@ -9,7 +9,7 @@ import (
 	"math/rand"
 	"time"
 
-	"github.com/wtfutil/wtf/wtf"
+	"github.com/wtfutil/wtf/view"
 )
 
 var started = false
@@ -17,7 +17,7 @@ var ok = true
 
 // Widget define wtf widget to register widget later
 type Widget struct {
-	wtf.BarGraph
+	view.BarGraph
 
 	app *tview.Application
 }
@@ -25,7 +25,7 @@ type Widget struct {
 // NewWidget Make new instance of widget
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		BarGraph: wtf.NewBarGraph(app, "Sample Bar Graph", settings.common, false),
+		BarGraph: view.NewBarGraph(app, "Sample Bar Graph", settings.common, false),
 
 		app: app,
 	}
@@ -43,13 +43,13 @@ func MakeGraph(widget *Widget) {
 
 	//this could come from config
 	const lineCount = 8
-	var stats [lineCount]wtf.Bar
+	var stats [lineCount]view.Bar
 
 	barTime := time.Now()
 	for i := 0; i < lineCount; i++ {
 		barTime = barTime.Add(time.Duration(time.Minute))
 
-		bar := wtf.Bar{
+		bar := view.Bar{
 			Label:   barTime.Format("15:04"),
 			Percent: rand.Intn(100-5) + 5,
 		}

--- a/modules/circleci/widget.go
+++ b/modules/circleci/widget.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 
 	"github.com/rivo/tview"
-	"github.com/wtfutil/wtf/wtf"
+	"github.com/wtfutil/wtf/view"
 )
 
 type Widget struct {
-	wtf.TextWidget
+	view.TextWidget
 	*Client
 
 	settings *Settings
@@ -16,7 +16,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, settings.common, false),
+		TextWidget: view.NewTextWidget(app, settings.common, false),
 		Client:     NewClient(settings.apiKey),
 
 		settings: settings,

--- a/modules/clocks/widget.go
+++ b/modules/clocks/widget.go
@@ -5,11 +5,11 @@ import (
 	"time"
 
 	"github.com/rivo/tview"
-	"github.com/wtfutil/wtf/wtf"
+	"github.com/wtfutil/wtf/view"
 )
 
 type Widget struct {
-	wtf.TextWidget
+	view.TextWidget
 
 	app        *tview.Application
 	clockColl  ClockCollection
@@ -20,7 +20,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, settings.common, false),
+		TextWidget: view.NewTextWidget(app, settings.common, false),
 
 		app:        app,
 		settings:   settings,

--- a/modules/cmdrunner/widget.go
+++ b/modules/cmdrunner/widget.go
@@ -6,11 +6,12 @@ import (
 	"strings"
 
 	"github.com/rivo/tview"
+	"github.com/wtfutil/wtf/view"
 	"github.com/wtfutil/wtf/wtf"
 )
 
 type Widget struct {
-	wtf.TextWidget
+	view.TextWidget
 
 	args     []string
 	cmd      string
@@ -20,7 +21,7 @@ type Widget struct {
 // NewWidget creates a new instance of the widget
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, settings.common, false),
+		TextWidget: view.NewTextWidget(app, settings.common, false),
 
 		args:     settings.args,
 		cmd:      settings.cmd,

--- a/modules/cryptoexchanges/bittrex/widget.go
+++ b/modules/cryptoexchanges/bittrex/widget.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 
 	"github.com/rivo/tview"
-	"github.com/wtfutil/wtf/wtf"
+	"github.com/wtfutil/wtf/view"
 )
 
 var ok = true
@@ -18,7 +18,7 @@ const baseURL = "https://bittrex.com/api/v1.1/public/getmarketsummary"
 
 // Widget define wtf widget to register widget later
 type Widget struct {
-	wtf.TextWidget
+	view.TextWidget
 
 	settings *Settings
 	summaryList
@@ -27,7 +27,7 @@ type Widget struct {
 // NewWidget Make new instance of widget
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, settings.common, false),
+		TextWidget: view.NewTextWidget(app, settings.common, false),
 
 		settings:    settings,
 		summaryList: summaryList{},

--- a/modules/cryptoexchanges/blockfolio/widget.go
+++ b/modules/cryptoexchanges/blockfolio/widget.go
@@ -8,11 +8,11 @@ import (
 	"net/http"
 
 	"github.com/rivo/tview"
-	"github.com/wtfutil/wtf/wtf"
+	"github.com/wtfutil/wtf/view"
 )
 
 type Widget struct {
-	wtf.TextWidget
+	view.TextWidget
 
 	device_token string
 	settings     *Settings
@@ -20,7 +20,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, settings.common, false),
+		TextWidget: view.NewTextWidget(app, settings.common, false),
 
 		device_token: settings.deviceToken,
 		settings:     settings,

--- a/modules/cryptoexchanges/cryptolive/widget.go
+++ b/modules/cryptoexchanges/cryptolive/widget.go
@@ -7,12 +7,12 @@ import (
 	"github.com/rivo/tview"
 	"github.com/wtfutil/wtf/modules/cryptoexchanges/cryptolive/price"
 	"github.com/wtfutil/wtf/modules/cryptoexchanges/cryptolive/toplist"
-	"github.com/wtfutil/wtf/wtf"
+	"github.com/wtfutil/wtf/view"
 )
 
 // Widget define wtf widget to register widget later
 type Widget struct {
-	wtf.TextWidget
+	view.TextWidget
 
 	priceWidget   *price.Widget
 	toplistWidget *toplist.Widget
@@ -22,7 +22,7 @@ type Widget struct {
 // NewWidget Make new instance of widget
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, settings.common, false),
+		TextWidget: view.NewTextWidget(app, settings.common, false),
 
 		priceWidget:   price.NewWidget(settings.priceSettings),
 		toplistWidget: toplist.NewWidget(settings.toplistSettings),

--- a/modules/datadog/widget.go
+++ b/modules/datadog/widget.go
@@ -4,13 +4,14 @@ import (
 	"fmt"
 
 	"github.com/rivo/tview"
+	"github.com/wtfutil/wtf/view"
 	"github.com/wtfutil/wtf/wtf"
 	datadog "github.com/zorkian/go-datadog-api"
 )
 
 type Widget struct {
-	wtf.KeyboardWidget
-	wtf.ScrollableWidget
+	view.KeyboardWidget
+	view.ScrollableWidget
 
 	monitors []datadog.Monitor
 	settings *Settings
@@ -18,8 +19,8 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		KeyboardWidget:   wtf.NewKeyboardWidget(app, pages, settings.common),
-		ScrollableWidget: wtf.NewScrollableWidget(app, settings.common, true),
+		KeyboardWidget:   view.NewKeyboardWidget(app, pages, settings.common),
+		ScrollableWidget: view.NewScrollableWidget(app, settings.common, true),
 
 		settings: settings,
 	}

--- a/modules/feedreader/widget.go
+++ b/modules/feedreader/widget.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/mmcdole/gofeed"
 	"github.com/rivo/tview"
+	"github.com/wtfutil/wtf/view"
 	"github.com/wtfutil/wtf/wtf"
 )
 
@@ -22,8 +23,8 @@ type FeedItem struct {
 
 // Widget is the container for RSS and Atom data
 type Widget struct {
-	wtf.KeyboardWidget
-	wtf.ScrollableWidget
+	view.KeyboardWidget
+	view.ScrollableWidget
 
 	stories  []*FeedItem
 	parser   *gofeed.Parser
@@ -33,8 +34,8 @@ type Widget struct {
 // NewWidget creates a new instance of a widget
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := &Widget{
-		KeyboardWidget:   wtf.NewKeyboardWidget(app, pages, settings.common),
-		ScrollableWidget: wtf.NewScrollableWidget(app, settings.common, true),
+		KeyboardWidget:   view.NewKeyboardWidget(app, pages, settings.common),
+		ScrollableWidget: view.NewScrollableWidget(app, settings.common, true),
 
 		parser:   gofeed.NewParser(),
 		settings: settings,

--- a/modules/gcal/widget.go
+++ b/modules/gcal/widget.go
@@ -2,11 +2,11 @@ package gcal
 
 import (
 	"github.com/rivo/tview"
-	"github.com/wtfutil/wtf/wtf"
+	"github.com/wtfutil/wtf/view"
 )
 
 type Widget struct {
-	wtf.TextWidget
+	view.TextWidget
 
 	app       *tview.Application
 	calEvents []*CalEvent
@@ -15,7 +15,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, settings.common, true),
+		TextWidget: view.NewTextWidget(app, settings.common, true),
 
 		app:      app,
 		settings: settings,

--- a/modules/gerrit/widget.go
+++ b/modules/gerrit/widget.go
@@ -8,12 +8,13 @@ import (
 
 	glb "github.com/andygrunwald/go-gerrit"
 	"github.com/rivo/tview"
+	"github.com/wtfutil/wtf/view"
 	"github.com/wtfutil/wtf/wtf"
 )
 
 type Widget struct {
-	wtf.KeyboardWidget
-	wtf.TextWidget
+	view.KeyboardWidget
+	view.TextWidget
 
 	gerrit *glb.Client
 
@@ -30,8 +31,8 @@ var (
 
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		KeyboardWidget: wtf.NewKeyboardWidget(app, pages, settings.common),
-		TextWidget:     wtf.NewTextWidget(app, settings.common, true),
+		KeyboardWidget: view.NewKeyboardWidget(app, pages, settings.common),
+		TextWidget:     view.NewTextWidget(app, settings.common, true),
 
 		Idx: 0,
 

--- a/modules/git/widget.go
+++ b/modules/git/widget.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gdamore/tcell"
 	"github.com/rivo/tview"
+	"github.com/wtfutil/wtf/view"
 	"github.com/wtfutil/wtf/wtf"
 )
 
@@ -16,9 +17,9 @@ const modalWidth = 80
 const modalHeight = 7
 
 type Widget struct {
-	wtf.KeyboardWidget
-	wtf.MultiSourceWidget
-	wtf.TextWidget
+	view.KeyboardWidget
+	view.MultiSourceWidget
+	view.TextWidget
 
 	GitRepos []*GitRepo
 
@@ -29,9 +30,9 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		KeyboardWidget:    wtf.NewKeyboardWidget(app, pages, settings.common),
-		MultiSourceWidget: wtf.NewMultiSourceWidget(settings.common, "repository", "repositories"),
-		TextWidget:        wtf.NewTextWidget(app, settings.common, true),
+		KeyboardWidget:    view.NewKeyboardWidget(app, pages, settings.common),
+		MultiSourceWidget: view.NewMultiSourceWidget(settings.common, "repository", "repositories"),
+		TextWidget:        view.NewTextWidget(app, settings.common, true),
 
 		app:      app,
 		pages:    pages,

--- a/modules/github/widget.go
+++ b/modules/github/widget.go
@@ -4,13 +4,13 @@ import (
 	"strings"
 
 	"github.com/rivo/tview"
-	"github.com/wtfutil/wtf/wtf"
+	"github.com/wtfutil/wtf/view"
 )
 
 type Widget struct {
-	wtf.MultiSourceWidget
-	wtf.KeyboardWidget
-	wtf.TextWidget
+	view.MultiSourceWidget
+	view.KeyboardWidget
+	view.TextWidget
 
 	GithubRepos []*GithubRepo
 
@@ -19,9 +19,9 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		KeyboardWidget:    wtf.NewKeyboardWidget(app, pages, settings.common),
-		MultiSourceWidget: wtf.NewMultiSourceWidget(settings.common, "repository", "repositories"),
-		TextWidget:        wtf.NewTextWidget(app, settings.common, true),
+		KeyboardWidget:    view.NewKeyboardWidget(app, pages, settings.common),
+		MultiSourceWidget: view.NewMultiSourceWidget(settings.common, "repository", "repositories"),
+		TextWidget:        view.NewTextWidget(app, settings.common, true),
 
 		settings: settings,
 	}

--- a/modules/gitlab/widget.go
+++ b/modules/gitlab/widget.go
@@ -2,14 +2,14 @@ package gitlab
 
 import (
 	"github.com/rivo/tview"
-	"github.com/wtfutil/wtf/wtf"
+	"github.com/wtfutil/wtf/view"
 	glb "github.com/xanzy/go-gitlab"
 )
 
 type Widget struct {
-	wtf.KeyboardWidget
-	wtf.MultiSourceWidget
-	wtf.TextWidget
+	view.KeyboardWidget
+	view.MultiSourceWidget
+	view.TextWidget
 
 	GitlabProjects []*GitlabProject
 
@@ -26,9 +26,9 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 	}
 
 	widget := Widget{
-		KeyboardWidget:    wtf.NewKeyboardWidget(app, pages, settings.common),
-		MultiSourceWidget: wtf.NewMultiSourceWidget(settings.common, "repository", "repositories"),
-		TextWidget:        wtf.NewTextWidget(app, settings.common, true),
+		KeyboardWidget:    view.NewKeyboardWidget(app, pages, settings.common),
+		MultiSourceWidget: view.NewMultiSourceWidget(settings.common, "repository", "repositories"),
+		TextWidget:        view.NewTextWidget(app, settings.common, true),
 
 		gitlab:   gitlab,
 		settings: settings,

--- a/modules/gitter/widget.go
+++ b/modules/gitter/widget.go
@@ -4,13 +4,14 @@ import (
 	"fmt"
 
 	"github.com/rivo/tview"
+	"github.com/wtfutil/wtf/view"
 	"github.com/wtfutil/wtf/wtf"
 )
 
 // A Widget represents a Gitter widget
 type Widget struct {
-	wtf.KeyboardWidget
-	wtf.ScrollableWidget
+	view.KeyboardWidget
+	view.ScrollableWidget
 
 	messages []Message
 	settings *Settings
@@ -19,8 +20,8 @@ type Widget struct {
 // NewWidget creates a new instance of a widget
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		KeyboardWidget:   wtf.NewKeyboardWidget(app, pages, settings.common),
-		ScrollableWidget: wtf.NewScrollableWidget(app, settings.common, true),
+		KeyboardWidget:   view.NewKeyboardWidget(app, pages, settings.common),
+		ScrollableWidget: view.NewScrollableWidget(app, settings.common, true),
 
 		settings: settings,
 	}

--- a/modules/googleanalytics/widget.go
+++ b/modules/googleanalytics/widget.go
@@ -2,18 +2,18 @@ package googleanalytics
 
 import (
 	"github.com/rivo/tview"
-	"github.com/wtfutil/wtf/wtf"
+	"github.com/wtfutil/wtf/view"
 )
 
 type Widget struct {
-	wtf.TextWidget
+	view.TextWidget
 
 	settings *Settings
 }
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, settings.common, false),
+		TextWidget: view.NewTextWidget(app, settings.common, false),
 
 		settings: settings,
 	}

--- a/modules/gspreadsheets/widget.go
+++ b/modules/gspreadsheets/widget.go
@@ -4,19 +4,20 @@ import (
 	"fmt"
 
 	"github.com/rivo/tview"
+	"github.com/wtfutil/wtf/view"
 	"github.com/wtfutil/wtf/wtf"
 	sheets "google.golang.org/api/sheets/v4"
 )
 
 type Widget struct {
-	wtf.TextWidget
+	view.TextWidget
 
 	settings *Settings
 }
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, settings.common, false),
+		TextWidget: view.NewTextWidget(app, settings.common, false),
 
 		settings: settings,
 	}

--- a/modules/hackernews/widget.go
+++ b/modules/hackernews/widget.go
@@ -6,12 +6,13 @@ import (
 	"strings"
 
 	"github.com/rivo/tview"
+	"github.com/wtfutil/wtf/view"
 	"github.com/wtfutil/wtf/wtf"
 )
 
 type Widget struct {
-	wtf.KeyboardWidget
-	wtf.ScrollableWidget
+	view.KeyboardWidget
+	view.ScrollableWidget
 
 	stories  []Story
 	settings *Settings
@@ -19,8 +20,8 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := &Widget{
-		KeyboardWidget:   wtf.NewKeyboardWidget(app, pages, settings.common),
-		ScrollableWidget: wtf.NewScrollableWidget(app, settings.common, true),
+		KeyboardWidget:   view.NewKeyboardWidget(app, pages, settings.common),
+		ScrollableWidget: view.NewScrollableWidget(app, settings.common, true),
 
 		settings: settings,
 	}

--- a/modules/hibp/widget.go
+++ b/modules/hibp/widget.go
@@ -4,12 +4,12 @@ import (
 	"fmt"
 
 	"github.com/rivo/tview"
-	"github.com/wtfutil/wtf/wtf"
+	"github.com/wtfutil/wtf/view"
 )
 
 // Widget is the container for hibp data
 type Widget struct {
-	wtf.TextWidget
+	view.TextWidget
 
 	accounts []string
 	settings *Settings
@@ -18,7 +18,7 @@ type Widget struct {
 // NewWidget creates a new instance of a widget
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := &Widget{
-		TextWidget: wtf.NewTextWidget(app, settings.common, false),
+		TextWidget: view.NewTextWidget(app, settings.common, false),
 
 		settings: settings,
 	}

--- a/modules/ipaddresses/ipapi/widget.go
+++ b/modules/ipaddresses/ipapi/widget.go
@@ -9,12 +9,12 @@ import (
 	"text/template"
 
 	"github.com/rivo/tview"
-	"github.com/wtfutil/wtf/wtf"
+	"github.com/wtfutil/wtf/view"
 )
 
 // Widget widget struct
 type Widget struct {
-	wtf.TextWidget
+	view.TextWidget
 
 	result   string
 	settings *Settings
@@ -38,7 +38,7 @@ type ipinfo struct {
 // NewWidget constructor
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, settings.common, false),
+		TextWidget: view.NewTextWidget(app, settings.common, false),
 
 		settings: settings,
 	}

--- a/modules/ipaddresses/ipinfo/widget.go
+++ b/modules/ipaddresses/ipinfo/widget.go
@@ -8,11 +8,11 @@ import (
 	"text/template"
 
 	"github.com/rivo/tview"
-	"github.com/wtfutil/wtf/wtf"
+	"github.com/wtfutil/wtf/view"
 )
 
 type Widget struct {
-	wtf.TextWidget
+	view.TextWidget
 
 	result   string
 	settings *Settings
@@ -31,7 +31,7 @@ type ipinfo struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, settings.common, false),
+		TextWidget: view.NewTextWidget(app, settings.common, false),
 
 		settings: settings,
 	}

--- a/modules/jenkins/widget.go
+++ b/modules/jenkins/widget.go
@@ -5,12 +5,13 @@ import (
 	"regexp"
 
 	"github.com/rivo/tview"
+	"github.com/wtfutil/wtf/view"
 	"github.com/wtfutil/wtf/wtf"
 )
 
 type Widget struct {
-	wtf.KeyboardWidget
-	wtf.ScrollableWidget
+	view.KeyboardWidget
+	view.ScrollableWidget
 
 	settings *Settings
 	view     *View
@@ -18,8 +19,8 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		KeyboardWidget:   wtf.NewKeyboardWidget(app, pages, settings.common),
-		ScrollableWidget: wtf.NewScrollableWidget(app, settings.common, true),
+		KeyboardWidget:   view.NewKeyboardWidget(app, pages, settings.common),
+		ScrollableWidget: view.NewScrollableWidget(app, settings.common, true),
 
 		settings: settings,
 	}

--- a/modules/jira/widget.go
+++ b/modules/jira/widget.go
@@ -4,12 +4,13 @@ import (
 	"fmt"
 
 	"github.com/rivo/tview"
+	"github.com/wtfutil/wtf/view"
 	"github.com/wtfutil/wtf/wtf"
 )
 
 type Widget struct {
-	wtf.KeyboardWidget
-	wtf.ScrollableWidget
+	view.KeyboardWidget
+	view.ScrollableWidget
 
 	result   *SearchResult
 	settings *Settings
@@ -17,8 +18,8 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		KeyboardWidget:   wtf.NewKeyboardWidget(app, pages, settings.common),
-		ScrollableWidget: wtf.NewScrollableWidget(app, settings.common, true),
+		KeyboardWidget:   view.NewKeyboardWidget(app, pages, settings.common),
+		ScrollableWidget: view.NewScrollableWidget(app, settings.common, true),
 
 		settings: settings,
 	}

--- a/modules/logger/widget.go
+++ b/modules/logger/widget.go
@@ -7,13 +7,13 @@ import (
 
 	"github.com/rivo/tview"
 	log "github.com/wtfutil/wtf/logger"
-	"github.com/wtfutil/wtf/wtf"
+	"github.com/wtfutil/wtf/view"
 )
 
 const maxBufferSize int64 = 1024
 
 type Widget struct {
-	wtf.TextWidget
+	view.TextWidget
 
 	app      *tview.Application
 	filePath string
@@ -22,7 +22,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, settings.common, true),
+		TextWidget: view.NewTextWidget(app, settings.common, true),
 
 		app:      app,
 		filePath: log.LogFilePath(),

--- a/modules/mercurial/widget.go
+++ b/modules/mercurial/widget.go
@@ -3,6 +3,7 @@ package mercurial
 import (
 	"github.com/gdamore/tcell"
 	"github.com/rivo/tview"
+	"github.com/wtfutil/wtf/view"
 	"github.com/wtfutil/wtf/wtf"
 )
 
@@ -12,9 +13,9 @@ const modalHeight = 7
 
 // A Widget represents a Mercurial widget
 type Widget struct {
-	wtf.KeyboardWidget
-	wtf.MultiSourceWidget
-	wtf.TextWidget
+	view.KeyboardWidget
+	view.MultiSourceWidget
+	view.TextWidget
 
 	app      *tview.Application
 	Data     []*MercurialRepo
@@ -25,9 +26,9 @@ type Widget struct {
 // NewWidget creates a new instance of a widget
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		KeyboardWidget:    wtf.NewKeyboardWidget(app, pages, settings.common),
-		MultiSourceWidget: wtf.NewMultiSourceWidget(settings.common, "repository", "repositories"),
-		TextWidget:        wtf.NewTextWidget(app, settings.common, true),
+		KeyboardWidget:    view.NewKeyboardWidget(app, pages, settings.common),
+		MultiSourceWidget: view.NewMultiSourceWidget(settings.common, "repository", "repositories"),
+		TextWidget:        view.NewTextWidget(app, settings.common, true),
 
 		app:      app,
 		pages:    pages,

--- a/modules/nbascore/widget.go
+++ b/modules/nbascore/widget.go
@@ -9,13 +9,14 @@ import (
 	"time"
 
 	"github.com/rivo/tview"
+	"github.com/wtfutil/wtf/view"
 	"github.com/wtfutil/wtf/wtf"
 )
 
 // A Widget represents an NBA Score  widget
 type Widget struct {
-	wtf.KeyboardWidget
-	wtf.TextWidget
+	view.KeyboardWidget
+	view.TextWidget
 
 	language string
 	result   string
@@ -27,8 +28,8 @@ var offset = 0
 // NewWidget creates a new instance of a widget
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		KeyboardWidget: wtf.NewKeyboardWidget(app, pages, settings.common),
-		TextWidget:     wtf.NewTextWidget(app, settings.common, true),
+		KeyboardWidget: view.NewKeyboardWidget(app, pages, settings.common),
+		TextWidget:     view.NewTextWidget(app, settings.common, true),
 
 		settings: settings,
 	}

--- a/modules/newrelic/widget.go
+++ b/modules/newrelic/widget.go
@@ -4,12 +4,13 @@ import (
 	"fmt"
 
 	"github.com/rivo/tview"
+	"github.com/wtfutil/wtf/view"
 	"github.com/wtfutil/wtf/wtf"
 	nr "github.com/yfronto/newrelic"
 )
 
 type Widget struct {
-	wtf.TextWidget
+	view.TextWidget
 
 	client   *Client
 	settings *Settings
@@ -17,7 +18,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, settings.common, false),
+		TextWidget: view.NewTextWidget(app, settings.common, false),
 
 		settings: settings,
 	}

--- a/modules/opsgenie/widget.go
+++ b/modules/opsgenie/widget.go
@@ -5,18 +5,19 @@ import (
 	"strings"
 
 	"github.com/rivo/tview"
+	"github.com/wtfutil/wtf/view"
 	"github.com/wtfutil/wtf/wtf"
 )
 
 type Widget struct {
-	wtf.TextWidget
+	view.TextWidget
 
 	settings *Settings
 }
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, settings.common, false),
+		TextWidget: view.NewTextWidget(app, settings.common, false),
 
 		settings: settings,
 	}

--- a/modules/pagerduty/widget.go
+++ b/modules/pagerduty/widget.go
@@ -6,18 +6,19 @@ import (
 
 	"github.com/PagerDuty/go-pagerduty"
 	"github.com/rivo/tview"
+	"github.com/wtfutil/wtf/view"
 	"github.com/wtfutil/wtf/wtf"
 )
 
 type Widget struct {
-	wtf.TextWidget
+	view.TextWidget
 
 	settings *Settings
 }
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, settings.common, false),
+		TextWidget: view.NewTextWidget(app, settings.common, false),
 
 		settings: settings,
 	}

--- a/modules/power/widget.go
+++ b/modules/power/widget.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 
 	"github.com/rivo/tview"
-	"github.com/wtfutil/wtf/wtf"
+	"github.com/wtfutil/wtf/view"
 )
 
 type Widget struct {
-	wtf.TextWidget
+	view.TextWidget
 
 	Battery *Battery
 
@@ -17,7 +17,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, settings.common, false),
+		TextWidget: view.NewTextWidget(app, settings.common, false),
 
 		Battery: NewBattery(),
 

--- a/modules/resourceusage/widget.go
+++ b/modules/resourceusage/widget.go
@@ -1,14 +1,15 @@
 package resourceusage
 
 import (
-	"code.cloudfoundry.org/bytefmt"
 	"fmt"
+	"math"
+	"time"
+
+	"code.cloudfoundry.org/bytefmt"
 	"github.com/rivo/tview"
 	"github.com/shirou/gopsutil/cpu"
 	"github.com/shirou/gopsutil/mem"
-	"github.com/wtfutil/wtf/wtf"
-	"math"
-	"time"
+	"github.com/wtfutil/wtf/view"
 )
 
 var started = false
@@ -16,7 +17,7 @@ var ok = true
 
 // Widget define wtf widget to register widget later
 type Widget struct {
-	wtf.BarGraph
+	view.BarGraph
 
 	app      *tview.Application
 	settings *Settings
@@ -25,7 +26,7 @@ type Widget struct {
 // NewWidget Make new instance of widget
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		BarGraph: wtf.NewBarGraph(app, settings.common.Name, settings.common, false),
+		BarGraph: view.NewBarGraph(app, settings.common.Name, settings.common, false),
 
 		app:      app,
 		settings: settings,
@@ -46,14 +47,14 @@ func MakeGraph(widget *Widget) {
 		return
 	}
 
-	var stats = make([]wtf.Bar, len(cpuStats)+2)
+	var stats = make([]view.Bar, len(cpuStats)+2)
 
 	for i, stat := range cpuStats {
 		// Stats sometimes jump outside the 0-100 range, possibly due to timing
 		stat = math.Min(100, stat)
 		stat = math.Max(0, stat)
 
-		bar := wtf.Bar{
+		bar := view.Bar{
 			Label:      fmt.Sprint(i),
 			Percent:    int(stat),
 			ValueLabel: fmt.Sprintf("%d%%", int(stat)),
@@ -76,7 +77,7 @@ func MakeGraph(widget *Widget) {
 		usedMemLabel = usedMemLabel[:len(usedMemLabel)-1]
 	}
 
-	stats[memIndex] = wtf.Bar{
+	stats[memIndex] = view.Bar{
 		Label:      "Mem",
 		Percent:    int(memInfo.UsedPercent),
 		ValueLabel: fmt.Sprintf("%s/%s", usedMemLabel, totalMemLabel),
@@ -96,7 +97,7 @@ func MakeGraph(widget *Widget) {
 		usedSwapLabel = usedSwapLabel[:len(usedSwapLabel)-1]
 	}
 
-	stats[swapIndex] = wtf.Bar{
+	stats[swapIndex] = view.Bar{
 		Label:      "Swp",
 		Percent:    int(swapPercent * 100),
 		ValueLabel: fmt.Sprintf("%s/%s", usedSwapLabel, totalSwapLabel),

--- a/modules/rollbar/widget.go
+++ b/modules/rollbar/widget.go
@@ -4,13 +4,14 @@ import (
 	"fmt"
 
 	"github.com/rivo/tview"
+	"github.com/wtfutil/wtf/view"
 	"github.com/wtfutil/wtf/wtf"
 )
 
 // A Widget represents a Rollbar widget
 type Widget struct {
-	wtf.KeyboardWidget
-	wtf.ScrollableWidget
+	view.KeyboardWidget
+	view.ScrollableWidget
 
 	items    *Result
 	settings *Settings
@@ -19,8 +20,8 @@ type Widget struct {
 // NewWidget creates a new instance of a widget
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		KeyboardWidget:   wtf.NewKeyboardWidget(app, pages, settings.common),
-		ScrollableWidget: wtf.NewScrollableWidget(app, settings.common, true),
+		KeyboardWidget:   view.NewKeyboardWidget(app, pages, settings.common),
+		ScrollableWidget: view.NewScrollableWidget(app, settings.common, true),
 
 		settings: settings,
 	}

--- a/modules/security/widget.go
+++ b/modules/security/widget.go
@@ -5,18 +5,18 @@ import (
 	"strings"
 
 	"github.com/rivo/tview"
-	"github.com/wtfutil/wtf/wtf"
+	"github.com/wtfutil/wtf/view"
 )
 
 type Widget struct {
-	wtf.TextWidget
+	view.TextWidget
 
 	settings *Settings
 }
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, settings.common, false),
+		TextWidget: view.NewTextWidget(app, settings.common, false),
 
 		settings: settings,
 	}

--- a/modules/spotify/widget.go
+++ b/modules/spotify/widget.go
@@ -5,13 +5,14 @@ import (
 
 	"github.com/rivo/tview"
 	"github.com/sticreations/spotigopher/spotigopher"
+	"github.com/wtfutil/wtf/view"
 	"github.com/wtfutil/wtf/wtf"
 )
 
 // A Widget represents a Spotify widget
 type Widget struct {
-	wtf.KeyboardWidget
-	wtf.TextWidget
+	view.KeyboardWidget
+	view.TextWidget
 
 	client   spotigopher.SpotifyClient
 	settings *Settings
@@ -21,8 +22,8 @@ type Widget struct {
 // NewWidget creates a new instance of a widget
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		KeyboardWidget: wtf.NewKeyboardWidget(app, pages, settings.common),
-		TextWidget:     wtf.NewTextWidget(app, settings.common, true),
+		KeyboardWidget: view.NewKeyboardWidget(app, pages, settings.common),
+		TextWidget:     view.NewTextWidget(app, settings.common, true),
 
 		Info:   spotigopher.Info{},
 		client: spotigopher.NewClient(),

--- a/modules/spotifyweb/widget.go
+++ b/modules/spotifyweb/widget.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/rivo/tview"
+	"github.com/wtfutil/wtf/view"
 	"github.com/wtfutil/wtf/wtf"
 	"github.com/zmb3/spotify"
 )
@@ -22,8 +23,8 @@ type Info struct {
 
 // Widget is the struct used by all WTF widgets to transfer to the main widget controller
 type Widget struct {
-	wtf.KeyboardWidget
-	wtf.TextWidget
+	view.KeyboardWidget
+	view.TextWidget
 
 	Info
 
@@ -68,8 +69,8 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 	var playerState *spotify.PlayerState
 
 	widget := Widget{
-		KeyboardWidget: wtf.NewKeyboardWidget(app, pages, settings.common),
-		TextWidget:     wtf.NewTextWidget(app, settings.common, true),
+		KeyboardWidget: view.NewKeyboardWidget(app, pages, settings.common),
+		TextWidget:     view.NewTextWidget(app, settings.common, true),
 
 		Info: Info{},
 

--- a/modules/status/widget.go
+++ b/modules/status/widget.go
@@ -2,11 +2,11 @@ package status
 
 import (
 	"github.com/rivo/tview"
-	"github.com/wtfutil/wtf/wtf"
+	"github.com/wtfutil/wtf/view"
 )
 
 type Widget struct {
-	wtf.TextWidget
+	view.TextWidget
 
 	CurrentIcon int
 
@@ -15,7 +15,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, settings.common, false),
+		TextWidget: view.NewTextWidget(app, settings.common, false),
 
 		CurrentIcon: 0,
 

--- a/modules/system/widget.go
+++ b/modules/system/widget.go
@@ -5,11 +5,12 @@ import (
 	"time"
 
 	"github.com/rivo/tview"
+	"github.com/wtfutil/wtf/view"
 	"github.com/wtfutil/wtf/wtf"
 )
 
 type Widget struct {
-	wtf.TextWidget
+	view.TextWidget
 
 	Date    string
 	Version string
@@ -20,7 +21,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, date, version string, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, settings.common, false),
+		TextWidget: view.NewTextWidget(app, settings.common, false),
 
 		Date: date,
 

--- a/modules/textfile/widget.go
+++ b/modules/textfile/widget.go
@@ -14,7 +14,7 @@ import (
 	"github.com/radovskyb/watcher"
 	"github.com/rivo/tview"
 	"github.com/wtfutil/wtf/utils"
-	"github.com/wtfutil/wtf/wtf"
+	"github.com/wtfutil/wtf/view"
 )
 
 const (
@@ -22,9 +22,9 @@ const (
 )
 
 type Widget struct {
-	wtf.KeyboardWidget
-	wtf.MultiSourceWidget
-	wtf.TextWidget
+	view.KeyboardWidget
+	view.MultiSourceWidget
+	view.TextWidget
 
 	settings *Settings
 }
@@ -32,9 +32,9 @@ type Widget struct {
 // NewWidget creates a new instance of a widget
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		KeyboardWidget:    wtf.NewKeyboardWidget(app, pages, settings.common),
-		MultiSourceWidget: wtf.NewMultiSourceWidget(settings.common, "filePath", "filePaths"),
-		TextWidget:        wtf.NewTextWidget(app, settings.common, true),
+		KeyboardWidget:    view.NewKeyboardWidget(app, pages, settings.common),
+		MultiSourceWidget: view.NewMultiSourceWidget(settings.common, "filePath", "filePaths"),
+		TextWidget:        view.NewTextWidget(app, settings.common, true),
 
 		settings: settings,
 	}

--- a/modules/todo/widget.go
+++ b/modules/todo/widget.go
@@ -8,18 +8,21 @@ import (
 	"github.com/rivo/tview"
 	"github.com/wtfutil/wtf/cfg"
 	"github.com/wtfutil/wtf/checklist"
+	"github.com/wtfutil/wtf/view"
 	"github.com/wtfutil/wtf/wtf"
 	"gopkg.in/yaml.v2"
 )
 
-const offscreen = -1000
-const modalWidth = 80
-const modalHeight = 7
+const (
+	offscreen   = -1000
+	modalWidth  = 80
+	modalHeight = 7
+)
 
 // A Widget represents a Todo widget
 type Widget struct {
-	wtf.KeyboardWidget
-	wtf.TextWidget
+	view.KeyboardWidget
+	view.TextWidget
 
 	app      *tview.Application
 	settings *Settings
@@ -31,8 +34,8 @@ type Widget struct {
 // NewWidget creates a new instance of a widget
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		KeyboardWidget: wtf.NewKeyboardWidget(app, pages, settings.common),
-		TextWidget:     wtf.NewTextWidget(app, settings.common, true),
+		KeyboardWidget: view.NewKeyboardWidget(app, pages, settings.common),
+		TextWidget:     view.NewTextWidget(app, settings.common, true),
 
 		app:      app,
 		settings: settings,

--- a/modules/todoist/widget.go
+++ b/modules/todoist/widget.go
@@ -3,14 +3,14 @@ package todoist
 import (
 	"github.com/darkSasori/todoist"
 	"github.com/rivo/tview"
-	"github.com/wtfutil/wtf/wtf"
+	"github.com/wtfutil/wtf/view"
 )
 
 // A Widget represents a Todoist widget
 type Widget struct {
-	wtf.KeyboardWidget
-	wtf.MultiSourceWidget
-	wtf.ScrollableWidget
+	view.KeyboardWidget
+	view.MultiSourceWidget
+	view.ScrollableWidget
 
 	projects []*Project
 	settings *Settings
@@ -19,9 +19,9 @@ type Widget struct {
 // NewWidget creates a new instance of a widget
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		KeyboardWidget:    wtf.NewKeyboardWidget(app, pages, settings.common),
-		MultiSourceWidget: wtf.NewMultiSourceWidget(settings.common, "project", "projects"),
-		ScrollableWidget:  wtf.NewScrollableWidget(app, settings.common, true),
+		KeyboardWidget:    view.NewKeyboardWidget(app, pages, settings.common),
+		MultiSourceWidget: view.NewMultiSourceWidget(settings.common, "project", "projects"),
+		ScrollableWidget:  view.NewScrollableWidget(app, settings.common, true),
 
 		settings: settings,
 	}

--- a/modules/transmission/widget.go
+++ b/modules/transmission/widget.go
@@ -5,13 +5,13 @@ import (
 
 	"github.com/hekmon/transmissionrpc"
 	"github.com/rivo/tview"
-	"github.com/wtfutil/wtf/wtf"
+	"github.com/wtfutil/wtf/view"
 )
 
 // Widget is the container for transmission data
 type Widget struct {
-	wtf.KeyboardWidget
-	wtf.ScrollableWidget
+	view.KeyboardWidget
+	view.ScrollableWidget
 
 	client   *transmissionrpc.Client
 	settings *Settings
@@ -21,8 +21,8 @@ type Widget struct {
 // NewWidget creates a new instance of a widget
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		KeyboardWidget:   wtf.NewKeyboardWidget(app, pages, settings.common),
-		ScrollableWidget: wtf.NewScrollableWidget(app, settings.common, true),
+		KeyboardWidget:   view.NewKeyboardWidget(app, pages, settings.common),
+		ScrollableWidget: view.NewScrollableWidget(app, settings.common, true),
 
 		settings: settings,
 	}

--- a/modules/travisci/widget.go
+++ b/modules/travisci/widget.go
@@ -5,12 +5,13 @@ import (
 	"strings"
 
 	"github.com/rivo/tview"
+	"github.com/wtfutil/wtf/view"
 	"github.com/wtfutil/wtf/wtf"
 )
 
 type Widget struct {
-	wtf.KeyboardWidget
-	wtf.ScrollableWidget
+	view.KeyboardWidget
+	view.ScrollableWidget
 
 	builds   *Builds
 	settings *Settings
@@ -18,8 +19,8 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		KeyboardWidget:   wtf.NewKeyboardWidget(app, pages, settings.common),
-		ScrollableWidget: wtf.NewScrollableWidget(app, settings.common, true),
+		KeyboardWidget:   view.NewKeyboardWidget(app, pages, settings.common),
+		ScrollableWidget: view.NewScrollableWidget(app, settings.common, true),
 
 		settings: settings,
 	}

--- a/modules/trello/widget.go
+++ b/modules/trello/widget.go
@@ -5,18 +5,18 @@ import (
 
 	"github.com/adlio/trello"
 	"github.com/rivo/tview"
-	"github.com/wtfutil/wtf/wtf"
+	"github.com/wtfutil/wtf/view"
 )
 
 type Widget struct {
-	wtf.TextWidget
+	view.TextWidget
 
 	settings *Settings
 }
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, settings.common, false),
+		TextWidget: view.NewTextWidget(app, settings.common, false),
 
 		settings: settings,
 	}

--- a/modules/twitter/widget.go
+++ b/modules/twitter/widget.go
@@ -7,13 +7,14 @@ import (
 
 	"github.com/dustin/go-humanize"
 	"github.com/rivo/tview"
+	"github.com/wtfutil/wtf/view"
 	"github.com/wtfutil/wtf/wtf"
 )
 
 type Widget struct {
-	wtf.KeyboardWidget
-	wtf.MultiSourceWidget
-	wtf.TextWidget
+	view.KeyboardWidget
+	view.MultiSourceWidget
+	view.TextWidget
 
 	client   *Client
 	idx      int
@@ -23,9 +24,9 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		KeyboardWidget:    wtf.NewKeyboardWidget(app, pages, settings.common),
-		MultiSourceWidget: wtf.NewMultiSourceWidget(settings.common, "screenName", "screenNames"),
-		TextWidget:        wtf.NewTextWidget(app, settings.common, true),
+		KeyboardWidget:    view.NewKeyboardWidget(app, pages, settings.common),
+		MultiSourceWidget: view.NewMultiSourceWidget(settings.common, "screenName", "screenNames"),
+		TextWidget:        view.NewTextWidget(app, settings.common, true),
 
 		idx:      0,
 		settings: settings,

--- a/modules/unknown/widget.go
+++ b/modules/unknown/widget.go
@@ -4,18 +4,18 @@ import (
 	"fmt"
 
 	"github.com/rivo/tview"
-	"github.com/wtfutil/wtf/wtf"
+	"github.com/wtfutil/wtf/view"
 )
 
 type Widget struct {
-	wtf.TextWidget
+	view.TextWidget
 
 	settings *Settings
 }
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, settings.common, false),
+		TextWidget: view.NewTextWidget(app, settings.common, false),
 
 		settings: settings,
 	}

--- a/modules/victorops/widget.go
+++ b/modules/victorops/widget.go
@@ -4,12 +4,12 @@ import (
 	"fmt"
 
 	"github.com/rivo/tview"
-	"github.com/wtfutil/wtf/wtf"
+	"github.com/wtfutil/wtf/view"
 )
 
 // Widget contains text info
 type Widget struct {
-	wtf.TextWidget
+	view.TextWidget
 
 	teams    []OnCallTeam
 	settings *Settings
@@ -18,7 +18,7 @@ type Widget struct {
 // NewWidget creates a new widget
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, settings.common, true),
+		TextWidget: view.NewTextWidget(app, settings.common, true),
 	}
 
 	widget.View.SetScrollable(true)

--- a/modules/weatherservices/prettyweather/widget.go
+++ b/modules/weatherservices/prettyweather/widget.go
@@ -6,11 +6,12 @@ import (
 	"strings"
 
 	"github.com/rivo/tview"
+	"github.com/wtfutil/wtf/view"
 	"github.com/wtfutil/wtf/wtf"
 )
 
 type Widget struct {
-	wtf.TextWidget
+	view.TextWidget
 
 	result   string
 	settings *Settings
@@ -18,7 +19,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: wtf.NewTextWidget(app, settings.common, false),
+		TextWidget: view.NewTextWidget(app, settings.common, false),
 
 		settings: settings,
 	}

--- a/modules/weatherservices/weather/widget.go
+++ b/modules/weatherservices/weather/widget.go
@@ -3,14 +3,15 @@ package weather
 import (
 	owm "github.com/briandowns/openweathermap"
 	"github.com/rivo/tview"
+	"github.com/wtfutil/wtf/view"
 	"github.com/wtfutil/wtf/wtf"
 )
 
 // Widget is the container for weather data.
 type Widget struct {
-	wtf.KeyboardWidget
-	wtf.MultiSourceWidget
-	wtf.TextWidget
+	view.KeyboardWidget
+	view.MultiSourceWidget
+	view.TextWidget
 
 	// APIKey   string
 	Data []*owm.CurrentWeatherData
@@ -22,9 +23,9 @@ type Widget struct {
 // NewWidget creates and returns a new instance of the weather Widget
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		KeyboardWidget:    wtf.NewKeyboardWidget(app, pages, settings.common),
-		MultiSourceWidget: wtf.NewMultiSourceWidget(settings.common, "cityid", "cityids"),
-		TextWidget:        wtf.NewTextWidget(app, settings.common, true),
+		KeyboardWidget:    view.NewKeyboardWidget(app, pages, settings.common),
+		MultiSourceWidget: view.NewMultiSourceWidget(settings.common, "cityid", "cityids"),
+		TextWidget:        view.NewTextWidget(app, settings.common, true),
 
 		pages:    pages,
 		settings: settings,

--- a/modules/zendesk/widget.go
+++ b/modules/zendesk/widget.go
@@ -5,13 +5,14 @@ import (
 	"log"
 
 	"github.com/rivo/tview"
+	"github.com/wtfutil/wtf/view"
 	"github.com/wtfutil/wtf/wtf"
 )
 
 // A Widget represents a Zendesk widget
 type Widget struct {
-	wtf.KeyboardWidget
-	wtf.ScrollableWidget
+	view.KeyboardWidget
+	view.ScrollableWidget
 
 	result   *TicketArray
 	settings *Settings
@@ -20,8 +21,8 @@ type Widget struct {
 // NewWidget creates a new instance of a widget
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		KeyboardWidget:   wtf.NewKeyboardWidget(app, pages, settings.common),
-		ScrollableWidget: wtf.NewScrollableWidget(app, settings.common, true),
+		KeyboardWidget:   view.NewKeyboardWidget(app, pages, settings.common),
+		ScrollableWidget: view.NewScrollableWidget(app, settings.common, true),
 
 		settings: settings,
 	}

--- a/view/bargraph.go
+++ b/view/bargraph.go
@@ -28,16 +28,7 @@ type Bar struct {
 // NewBarGraph initialize your fancy new graph
 func NewBarGraph(app *tview.Application, name string, commonSettings *cfg.Common, focusable bool) BarGraph {
 	widget := BarGraph{
-		Base: Base{
-			app:             app,
-			bordered:        commonSettings.Bordered,
-			commonSettings:  commonSettings,
-			enabled:         commonSettings.Enabled,
-			focusable:       focusable,
-			name:            commonSettings.Title,
-			quitChan:        make(chan bool),
-			refreshInterval: commonSettings.RefreshInterval,
-		},
+		Base: NewBase(app, commonSettings, focusable),
 
 		maxStars: commonSettings.Config.UInt("graphStars", 20),
 		starChar: commonSettings.Config.UString("graphIcon", "|"),
@@ -49,79 +40,10 @@ func NewBarGraph(app *tview.Application, name string, commonSettings *cfg.Common
 	return widget
 }
 
-func (widget *BarGraph) BorderColor() string {
-	if widget.Focusable() {
-		return widget.commonSettings.Colors.BorderFocusable
-	}
-
-	return widget.commonSettings.Colors.BorderNormal
-}
-
-func (widget *BarGraph) CommonSettings() *cfg.Common {
-	return widget.commonSettings
-}
-
-func (widget *BarGraph) Disable() {
-	widget.enabled = false
-}
-
-func (widget *BarGraph) Disabled() bool {
-	return !widget.Enabled()
-}
-
-func (widget *BarGraph) Enabled() bool {
-	return widget.enabled
-}
-
-func (widget *BarGraph) Focusable() bool {
-	return widget.enabled && widget.focusable
-}
-
-func (widget *BarGraph) FocusChar() string {
-	return ""
-}
-
-func (widget *BarGraph) Key() string {
-	return widget.key
-}
-
-func (widget *BarGraph) Name() string {
-	return widget.name
-}
-
-func (widget *BarGraph) QuitChan() chan bool {
-	return widget.quitChan
-}
-
-// Refreshing returns TRUE if the widget is currently refreshing its data, FALSE if it is not
-func (widget *BarGraph) Refreshing() bool {
-	return widget.refreshing
-}
-
-// RefreshInterval returns how often, in seconds, the widget will return its data
-func (widget *BarGraph) RefreshInterval() int {
-	return widget.refreshInterval
-}
-
-func (widget *BarGraph) SetFocusChar(char string) {
-	return
-}
-
-func (widget *BarGraph) Stop() {
-	widget.enabled = false
-	widget.quitChan <- true
-}
+/* -------------------- Exported Functions -------------------- */
 
 func (widget *BarGraph) TextView() *tview.TextView {
 	return widget.View
-}
-
-func (widget *BarGraph) HelpText() string {
-	return "No help available for this widget"
-}
-
-func (widget *BarGraph) ConfigText() string {
-	return ""
 }
 
 // BuildBars will build a string of * to represent your data of [time][value]

--- a/view/bargraph.go
+++ b/view/bargraph.go
@@ -12,18 +12,20 @@ import (
 
 //BarGraph lets make graphs
 type BarGraph struct {
-	commonSettings *cfg.Common
-	enabled        bool
-	focusable      bool
-	key            string
-	maxStars       int
-	name           string
-	quitChan       chan bool
-	refreshing     bool
-	starChar       string
+	app             *tview.Application
+	bordered        bool
+	commonSettings  *cfg.Common
+	enabled         bool
+	focusable       bool
+	key             string
+	maxStars        int
+	name            string
+	quitChan        chan bool
+	refreshing      bool
+	refreshInterval int
+	starChar        string
 
-	RefreshInt int
-	View       *tview.TextView
+	View *tview.TextView
 }
 
 type Bar struct {
@@ -33,23 +35,23 @@ type Bar struct {
 }
 
 // NewBarGraph initialize your fancy new graph
-func NewBarGraph(app *tview.Application, name string, settings *cfg.Common, focusable bool) BarGraph {
+func NewBarGraph(app *tview.Application, name string, commonSettings *cfg.Common, focusable bool) BarGraph {
 	widget := BarGraph{
-		enabled:        settings.Enabled,
-		focusable:      focusable,
-		maxStars:       settings.Config.UInt("graphStars", 20),
-		name:           settings.Title,
-		quitChan:       make(chan bool),
-		starChar:       settings.Config.UString("graphIcon", "|"),
-		commonSettings: settings,
+		commonSettings: commonSettings,
 
-		RefreshInt: settings.RefreshInterval,
+		app:             app,
+		bordered:        commonSettings.Bordered,
+		enabled:         commonSettings.Enabled,
+		focusable:       focusable,
+		maxStars:        commonSettings.Config.UInt("graphStars", 20),
+		name:            commonSettings.Title,
+		quitChan:        make(chan bool),
+		refreshInterval: commonSettings.RefreshInterval,
+		starChar:        commonSettings.Config.UString("graphIcon", "|"),
 	}
 
 	widget.View = widget.addView()
-	widget.View.SetChangedFunc(func() {
-		app.Draw()
-	})
+	widget.View.SetBorder(widget.bordered)
 
 	return widget
 }
@@ -105,7 +107,7 @@ func (widget *BarGraph) Refreshing() bool {
 
 // RefreshInterval returns how often, in seconds, the widget will return its data
 func (widget *BarGraph) RefreshInterval() int {
-	return widget.RefreshInt
+	return widget.refreshInterval
 }
 
 func (widget *BarGraph) SetFocusChar(char string) {

--- a/view/bargraph.go
+++ b/view/bargraph.go
@@ -34,17 +34,12 @@ func NewBarGraph(app *tview.Application, name string, commonSettings *cfg.Common
 		starChar: commonSettings.Config.UString("graphIcon", "|"),
 	}
 
-	widget.View = widget.addView()
-	widget.View.SetBorder(widget.bordered)
+	widget.View = widget.addView(widget.bordered)
 
 	return widget
 }
 
 /* -------------------- Exported Functions -------------------- */
-
-func (widget *BarGraph) TextView() *tview.TextView {
-	return widget.View
-}
 
 // BuildBars will build a string of * to represent your data of [time][value]
 // time should be passed as a int64
@@ -98,16 +93,20 @@ func BuildStars(data []Bar, maxStars int, starChar string) string {
 	return buffer.String()
 }
 
+func (widget *BarGraph) TextView() *tview.TextView {
+	return widget.View
+}
+
 /* -------------------- Unexported Functions -------------------- */
 
-func (widget *BarGraph) addView() *tview.TextView {
+func (widget *BarGraph) addView(bordered bool) *tview.TextView {
 	view := tview.NewTextView()
 
 	view.SetBackgroundColor(wtf.ColorFor(widget.commonSettings.Colors.Background))
-	view.SetBorder(true)
+	view.SetBorder(bordered)
 	view.SetBorderColor(wtf.ColorFor(widget.BorderColor()))
 	view.SetDynamicColors(true)
-	view.SetTitle(widget.Name())
+	view.SetTitle(widget.ContextualTitle(widget.CommonSettings().Title))
 	view.SetTitleColor(wtf.ColorFor(widget.commonSettings.Colors.Title))
 	view.SetWrap(false)
 

--- a/view/bargraph.go
+++ b/view/bargraph.go
@@ -1,4 +1,4 @@
-package wtf
+package view
 
 import (
 	"bytes"
@@ -7,6 +7,7 @@ import (
 
 	"github.com/rivo/tview"
 	"github.com/wtfutil/wtf/cfg"
+	"github.com/wtfutil/wtf/wtf"
 )
 
 //BarGraph lets make graphs
@@ -185,12 +186,12 @@ func BuildStars(data []Bar, maxStars int, starChar string) string {
 func (widget *BarGraph) addView() *tview.TextView {
 	view := tview.NewTextView()
 
-	view.SetBackgroundColor(ColorFor(widget.commonSettings.Colors.Background))
+	view.SetBackgroundColor(wtf.ColorFor(widget.commonSettings.Colors.Background))
 	view.SetBorder(true)
-	view.SetBorderColor(ColorFor(widget.BorderColor()))
+	view.SetBorderColor(wtf.ColorFor(widget.BorderColor()))
 	view.SetDynamicColors(true)
 	view.SetTitle(widget.Name())
-	view.SetTitleColor(ColorFor(widget.commonSettings.Colors.Title))
+	view.SetTitleColor(wtf.ColorFor(widget.commonSettings.Colors.Title))
 	view.SetWrap(false)
 
 	return view

--- a/view/bargraph.go
+++ b/view/bargraph.go
@@ -12,19 +12,10 @@ import (
 
 //BarGraph lets make graphs
 type BarGraph struct {
-	app             *tview.Application
-	bordered        bool
-	commonSettings  *cfg.Common
-	enabled         bool
-	focusable       bool
-	key             string
-	maxStars        int
-	name            string
-	quitChan        chan bool
-	refreshing      bool
-	refreshInterval int
-	starChar        string
+	maxStars int
+	starChar string
 
+	Base
 	View *tview.TextView
 }
 
@@ -37,17 +28,19 @@ type Bar struct {
 // NewBarGraph initialize your fancy new graph
 func NewBarGraph(app *tview.Application, name string, commonSettings *cfg.Common, focusable bool) BarGraph {
 	widget := BarGraph{
-		commonSettings: commonSettings,
+		Base: Base{
+			app:             app,
+			bordered:        commonSettings.Bordered,
+			commonSettings:  commonSettings,
+			enabled:         commonSettings.Enabled,
+			focusable:       focusable,
+			name:            commonSettings.Title,
+			quitChan:        make(chan bool),
+			refreshInterval: commonSettings.RefreshInterval,
+		},
 
-		app:             app,
-		bordered:        commonSettings.Bordered,
-		enabled:         commonSettings.Enabled,
-		focusable:       focusable,
-		maxStars:        commonSettings.Config.UInt("graphStars", 20),
-		name:            commonSettings.Title,
-		quitChan:        make(chan bool),
-		refreshInterval: commonSettings.RefreshInterval,
-		starChar:        commonSettings.Config.UString("graphIcon", "|"),
+		maxStars: commonSettings.Config.UInt("graphStars", 20),
+		starChar: commonSettings.Config.UString("graphIcon", "|"),
 	}
 
 	widget.View = widget.addView()

--- a/view/bargraph.go
+++ b/view/bargraph.go
@@ -10,7 +10,7 @@ import (
 	"github.com/wtfutil/wtf/wtf"
 )
 
-//BarGraph lets make graphs
+//BarGraph defines the data required to make a bar graph
 type BarGraph struct {
 	maxStars int
 	starChar string
@@ -19,13 +19,14 @@ type BarGraph struct {
 	View *tview.TextView
 }
 
+// Bar defines a single row in the bar graph
 type Bar struct {
 	Label      string
 	Percent    int
 	ValueLabel string
 }
 
-// NewBarGraph initialize your fancy new graph
+// NewBarGraph creates and returns an instance of BarGraph
 func NewBarGraph(app *tview.Application, name string, commonSettings *cfg.Common, focusable bool) BarGraph {
 	widget := BarGraph{
 		Base: NewBase(app, commonSettings, focusable),
@@ -34,7 +35,7 @@ func NewBarGraph(app *tview.Application, name string, commonSettings *cfg.Common
 		starChar: commonSettings.Config.UString("graphIcon", "|"),
 	}
 
-	widget.View = widget.addView(widget.bordered)
+	widget.View = widget.createView(widget.bordered)
 
 	return widget
 }
@@ -56,11 +57,9 @@ func BuildStars(data []Bar, maxStars int, starChar string) string {
 
 	//just getting min and max values
 	for _, bar := range data {
-
 		if len(bar.Label) > longestLabel {
 			longestLabel = len(bar.Label)
 		}
-
 	}
 
 	// each number = how many stars?
@@ -68,7 +67,6 @@ func BuildStars(data []Bar, maxStars int, starChar string) string {
 
 	//build the stars
 	for _, bar := range data {
-
 		//how many stars for this one?
 		var starCount = int(float64(bar.Percent) * starRatio)
 
@@ -99,7 +97,7 @@ func (widget *BarGraph) TextView() *tview.TextView {
 
 /* -------------------- Unexported Functions -------------------- */
 
-func (widget *BarGraph) addView(bordered bool) *tview.TextView {
+func (widget *BarGraph) createView(bordered bool) *tview.TextView {
 	view := tview.NewTextView()
 
 	view.SetBackgroundColor(wtf.ColorFor(widget.commonSettings.Colors.Background))

--- a/view/bargraph_test.go
+++ b/view/bargraph_test.go
@@ -1,4 +1,4 @@
-package wtf
+package view
 
 import (
 	"testing"

--- a/view/base.go
+++ b/view/base.go
@@ -1,8 +1,11 @@
 package view
 
 import (
+	"fmt"
+
 	"github.com/rivo/tview"
 	"github.com/wtfutil/wtf/cfg"
+	"github.com/wtfutil/wtf/utils"
 )
 
 type Base struct {
@@ -12,9 +15,110 @@ type Base struct {
 	enabled         bool
 	focusChar       string
 	focusable       bool
-	key             string
 	name            string
 	quitChan        chan bool
 	refreshing      bool
 	refreshInterval int
+}
+
+func NewBase(app *tview.Application, commonSettings *cfg.Common, focusable bool) Base {
+	base := Base{
+		commonSettings:  commonSettings,
+		app:             app,
+		bordered:        commonSettings.Bordered,
+		enabled:         commonSettings.Enabled,
+		focusChar:       commonSettings.FocusChar(),
+		focusable:       focusable,
+		name:            commonSettings.Name,
+		quitChan:        make(chan bool),
+		refreshInterval: commonSettings.RefreshInterval,
+		refreshing:      false,
+	}
+	return base
+}
+
+/* -------------------- Exported Functions -------------------- */
+
+// Bordered returns whether or not this widget should be drawn with a border
+func (base *Base) Bordered() bool {
+	return base.bordered
+}
+
+func (base *Base) BorderColor() string {
+	if base.Focusable() {
+		return base.commonSettings.Colors.BorderFocusable
+	}
+
+	return base.commonSettings.Colors.BorderNormal
+}
+
+func (base *Base) CommonSettings() *cfg.Common {
+	return base.commonSettings
+}
+
+func (base *Base) ConfigText() string {
+	return utils.HelpFromInterface(cfg.Common{})
+}
+
+func (base *Base) ContextualTitle(defaultStr string) string {
+	if base.FocusChar() == "" {
+		return fmt.Sprintf(" %s ", defaultStr)
+	}
+
+	return fmt.Sprintf(" %s [darkgray::u]%s[::-][green] ", defaultStr, base.FocusChar())
+}
+
+func (base *Base) Disable() {
+	base.enabled = false
+}
+
+func (base *Base) Disabled() bool {
+	return !base.enabled
+}
+
+func (base *Base) Enabled() bool {
+	return base.enabled
+}
+
+func (base *Base) Focusable() bool {
+	return base.enabled && base.focusable
+}
+
+func (base *Base) FocusChar() string {
+	return base.focusChar
+}
+
+func (base *Base) HelpText() string {
+	return fmt.Sprintf("\n  There is no help available for widget %s", base.commonSettings.Module.Type)
+}
+
+func (base *Base) Name() string {
+	return base.name
+}
+
+func (base *Base) QuitChan() chan bool {
+	return base.quitChan
+}
+
+// Refreshing returns TRUE if the base is currently refreshing its data, FALSE if it is not
+func (base *Base) Refreshing() bool {
+	return base.refreshing
+}
+
+// RefreshInterval returns how often, in seconds, the base will return its data
+func (base *Base) RefreshInterval() int {
+	return base.refreshInterval
+}
+
+func (base *Base) SetFocusChar(char string) {
+	base.focusChar = char
+}
+
+func (base *Base) Stop() {
+	base.enabled = false
+	base.quitChan <- true
+}
+
+func (base *Base) String() string {
+	return base.name
 }

--- a/view/base.go
+++ b/view/base.go
@@ -1,0 +1,20 @@
+package view
+
+import (
+	"github.com/rivo/tview"
+	"github.com/wtfutil/wtf/cfg"
+)
+
+type Base struct {
+	app             *tview.Application
+	bordered        bool
+	commonSettings  *cfg.Common
+	enabled         bool
+	focusChar       string
+	focusable       bool
+	key             string
+	name            string
+	quitChan        chan bool
+	refreshing      bool
+	refreshInterval int
+}

--- a/view/keyboard_widget.go
+++ b/view/keyboard_widget.go
@@ -1,4 +1,4 @@
-package wtf
+package view
 
 import (
 	"fmt"
@@ -7,6 +7,7 @@ import (
 	"github.com/gdamore/tcell"
 	"github.com/rivo/tview"
 	"github.com/wtfutil/wtf/cfg"
+	"github.com/wtfutil/wtf/wtf"
 )
 
 type helpItem struct {
@@ -120,7 +121,7 @@ func (widget *KeyboardWidget) ShowHelp() {
 		widget.app.SetFocus(widget.view)
 	}
 
-	modal := NewBillboardModal(widget.HelpText(), closeFunc)
+	modal := wtf.NewBillboardModal(widget.HelpText(), closeFunc)
 
 	widget.pages.AddPage("help", modal, false, true)
 	widget.app.SetFocus(modal)

--- a/view/keyboard_widget_test.go
+++ b/view/keyboard_widget_test.go
@@ -1,4 +1,4 @@
-package wtf
+package view
 
 import (
 	"testing"

--- a/view/multisource_widget.go
+++ b/view/multisource_widget.go
@@ -1,7 +1,8 @@
-package wtf
+package view
 
 import (
 	"github.com/wtfutil/wtf/cfg"
+	"github.com/wtfutil/wtf/wtf"
 )
 
 // MultiSourceWidget is a widget that supports displaying data from multiple sources
@@ -89,7 +90,7 @@ func (widget *MultiSourceWidget) loadSources() {
 	single := widget.moduleConfig.Config.UString(widget.singular, "")
 	multiple := widget.moduleConfig.Config.UList(widget.plural, empty)
 
-	asStrs := ToStrs(multiple)
+	asStrs := wtf.ToStrs(multiple)
 
 	if single != "" {
 		asStrs = append(asStrs, single)

--- a/view/scrollable.go
+++ b/view/scrollable.go
@@ -1,4 +1,4 @@
-package wtf
+package view
 
 import (
 	"strconv"
@@ -16,7 +16,6 @@ type ScrollableWidget struct {
 }
 
 func NewScrollableWidget(app *tview.Application, commonSettings *cfg.Common, focusable bool) ScrollableWidget {
-
 	widget := ScrollableWidget{
 		TextWidget: NewTextWidget(app, commonSettings, focusable),
 	}

--- a/view/scrollable_widget.go
+++ b/view/scrollable_widget.go
@@ -27,6 +27,8 @@ func NewScrollableWidget(app *tview.Application, commonSettings *cfg.Common, foc
 	return widget
 }
 
+/* -------------------- Exported Functions -------------------- */
+
 func (widget *ScrollableWidget) SetRenderFunction(displayFunc func()) {
 	widget.RenderFunction = displayFunc
 }

--- a/view/text_widget.go
+++ b/view/text_widget.go
@@ -10,33 +10,24 @@ import (
 )
 
 type TextWidget struct {
-	app             *tview.Application
-	bordered        bool
-	commonSettings  *cfg.Common
-	enabled         bool
-	focusChar       string
-	focusable       bool
-	name            string
-	quitChan        chan bool
-	refreshInterval int
-	refreshing      bool
-
+	Base
 	View *tview.TextView
 }
 
 func NewTextWidget(app *tview.Application, commonSettings *cfg.Common, focusable bool) TextWidget {
 	widget := TextWidget{
-		commonSettings: commonSettings,
-
-		app:             app,
-		bordered:        commonSettings.Bordered,
-		enabled:         commonSettings.Enabled,
-		focusChar:       commonSettings.FocusChar(),
-		focusable:       focusable,
-		name:            commonSettings.Name,
-		quitChan:        make(chan bool),
-		refreshInterval: commonSettings.RefreshInterval,
-		refreshing:      false,
+		Base: Base{
+			commonSettings:  commonSettings,
+			app:             app,
+			bordered:        commonSettings.Bordered,
+			enabled:         commonSettings.Enabled,
+			focusChar:       commonSettings.FocusChar(),
+			focusable:       focusable,
+			name:            commonSettings.Name,
+			quitChan:        make(chan bool),
+			refreshInterval: commonSettings.RefreshInterval,
+			refreshing:      false,
+		},
 	}
 
 	widget.View = widget.addView()

--- a/view/text_widget.go
+++ b/view/text_widget.go
@@ -16,8 +16,7 @@ func NewTextWidget(app *tview.Application, commonSettings *cfg.Common, focusable
 		Base: NewBase(app, commonSettings, focusable),
 	}
 
-	widget.View = widget.addView()
-	widget.View.SetBorder(widget.bordered)
+	widget.View = widget.addView(widget.bordered)
 
 	return widget
 }
@@ -39,16 +38,15 @@ func (widget *TextWidget) Redraw(title, text string, wrap bool) {
 
 /* -------------------- Unexported Functions -------------------- */
 
-func (widget *TextWidget) addView() *tview.TextView {
+func (widget *TextWidget) addView(bordered bool) *tview.TextView {
 	view := tview.NewTextView()
 
 	view.SetBackgroundColor(wtf.ColorFor(widget.commonSettings.Colors.Background))
+	view.SetBorder(bordered)
 	view.SetBorderColor(wtf.ColorFor(widget.BorderColor()))
+	view.SetDynamicColors(true)
 	view.SetTextColor(wtf.ColorFor(widget.commonSettings.Colors.Text))
 	view.SetTitleColor(wtf.ColorFor(widget.commonSettings.Colors.Title))
-
-	view.SetBorder(true)
-	view.SetDynamicColors(true)
 	view.SetWrap(false)
 
 	return view

--- a/view/text_widget.go
+++ b/view/text_widget.go
@@ -1,11 +1,8 @@
 package view
 
 import (
-	"fmt"
-
 	"github.com/rivo/tview"
 	"github.com/wtfutil/wtf/cfg"
-	"github.com/wtfutil/wtf/utils"
 	"github.com/wtfutil/wtf/wtf"
 )
 
@@ -16,18 +13,7 @@ type TextWidget struct {
 
 func NewTextWidget(app *tview.Application, commonSettings *cfg.Common, focusable bool) TextWidget {
 	widget := TextWidget{
-		Base: Base{
-			commonSettings:  commonSettings,
-			app:             app,
-			bordered:        commonSettings.Bordered,
-			enabled:         commonSettings.Enabled,
-			focusChar:       commonSettings.FocusChar(),
-			focusable:       focusable,
-			name:            commonSettings.Name,
-			quitChan:        make(chan bool),
-			refreshInterval: commonSettings.RefreshInterval,
-			refreshing:      false,
-		},
+		Base: NewBase(app, commonSettings, focusable),
 	}
 
 	widget.View = widget.addView()
@@ -37,90 +23,6 @@ func NewTextWidget(app *tview.Application, commonSettings *cfg.Common, focusable
 }
 
 /* -------------------- Exported Functions -------------------- */
-
-// Bordered returns whether or not this widget should be drawn with a border
-func (widget *TextWidget) Bordered() bool {
-	return widget.bordered
-}
-
-func (widget *TextWidget) BorderColor() string {
-	if widget.Focusable() {
-		return widget.commonSettings.Colors.BorderFocusable
-	}
-
-	return widget.commonSettings.Colors.BorderNormal
-}
-
-func (widget *TextWidget) CommonSettings() *cfg.Common {
-	return widget.commonSettings
-}
-
-func (widget *TextWidget) ConfigText() string {
-	return utils.HelpFromInterface(cfg.Common{})
-}
-
-func (widget *TextWidget) ContextualTitle(defaultStr string) string {
-	if widget.FocusChar() == "" {
-		return fmt.Sprintf(" %s ", defaultStr)
-	}
-
-	return fmt.Sprintf(" %s [darkgray::u]%s[::-][green] ", defaultStr, widget.FocusChar())
-}
-
-func (widget *TextWidget) Disable() {
-	widget.enabled = false
-}
-
-func (widget *TextWidget) Disabled() bool {
-	return !widget.Enabled()
-}
-
-func (widget *TextWidget) Enabled() bool {
-	return widget.enabled
-}
-
-func (widget *TextWidget) Focusable() bool {
-	return widget.enabled && widget.focusable
-}
-
-func (widget *TextWidget) FocusChar() string {
-	return widget.focusChar
-}
-
-func (widget *TextWidget) HelpText() string {
-	return fmt.Sprintf("\n  There is no help available for widget %s", widget.commonSettings.Module.Type)
-}
-
-func (widget *TextWidget) QuitChan() chan bool {
-	return widget.quitChan
-}
-
-func (widget *TextWidget) Name() string {
-	return widget.name
-}
-
-// Refreshing returns TRUE if the widget is currently refreshing its data, FALSE if it is not
-func (widget *TextWidget) Refreshing() bool {
-	return widget.refreshing
-}
-
-// RefreshInterval returns how often, in seconds, the widget will return its data
-func (widget *TextWidget) RefreshInterval() int {
-	return widget.refreshInterval
-}
-
-func (widget *TextWidget) SetFocusChar(char string) {
-	widget.focusChar = char
-}
-
-func (widget *TextWidget) Stop() {
-	widget.enabled = false
-	widget.quitChan <- true
-}
-
-func (widget *TextWidget) String() string {
-	return widget.name
-}
 
 func (widget *TextWidget) TextView() *tview.TextView {
 	return widget.View

--- a/view/text_widget.go
+++ b/view/text_widget.go
@@ -6,17 +6,19 @@ import (
 	"github.com/wtfutil/wtf/wtf"
 )
 
+// TextWidget defines the data necessary to make a text widget
 type TextWidget struct {
 	Base
 	View *tview.TextView
 }
 
+// NewTextWidget creates and returns an instance of TextWidget
 func NewTextWidget(app *tview.Application, commonSettings *cfg.Common, focusable bool) TextWidget {
 	widget := TextWidget{
 		Base: NewBase(app, commonSettings, focusable),
 	}
 
-	widget.View = widget.addView(widget.bordered)
+	widget.View = widget.createView(widget.bordered)
 
 	return widget
 }
@@ -38,7 +40,7 @@ func (widget *TextWidget) Redraw(title, text string, wrap bool) {
 
 /* -------------------- Unexported Functions -------------------- */
 
-func (widget *TextWidget) addView(bordered bool) *tview.TextView {
+func (widget *TextWidget) createView(bordered bool) *tview.TextView {
 	view := tview.NewTextView()
 
 	view.SetBackgroundColor(wtf.ColorFor(widget.commonSettings.Colors.Background))

--- a/view/text_widget.go
+++ b/view/text_widget.go
@@ -10,16 +10,16 @@ import (
 )
 
 type TextWidget struct {
+	app             *tview.Application
 	bordered        bool
 	commonSettings  *cfg.Common
 	enabled         bool
-	focusable       bool
 	focusChar       string
+	focusable       bool
 	name            string
 	quitChan        chan bool
-	refreshing      bool
 	refreshInterval int
-	app             *tview.Application
+	refreshing      bool
 
 	View *tview.TextView
 }
@@ -31,12 +31,12 @@ func NewTextWidget(app *tview.Application, commonSettings *cfg.Common, focusable
 		app:             app,
 		bordered:        commonSettings.Bordered,
 		enabled:         commonSettings.Enabled,
-		focusable:       focusable,
 		focusChar:       commonSettings.FocusChar(),
+		focusable:       focusable,
 		name:            commonSettings.Name,
 		quitChan:        make(chan bool),
-		refreshing:      false,
 		refreshInterval: commonSettings.RefreshInterval,
+		refreshing:      false,
 	}
 
 	widget.View = widget.addView()

--- a/view/text_widget.go
+++ b/view/text_widget.go
@@ -1,4 +1,4 @@
-package wtf
+package view
 
 import (
 	"fmt"
@@ -6,6 +6,7 @@ import (
 	"github.com/rivo/tview"
 	"github.com/wtfutil/wtf/cfg"
 	"github.com/wtfutil/wtf/utils"
+	"github.com/wtfutil/wtf/wtf"
 )
 
 type TextWidget struct {
@@ -148,10 +149,10 @@ func (widget *TextWidget) Redraw(title, text string, wrap bool) {
 func (widget *TextWidget) addView() *tview.TextView {
 	view := tview.NewTextView()
 
-	view.SetBackgroundColor(ColorFor(widget.commonSettings.Colors.Background))
-	view.SetBorderColor(ColorFor(widget.BorderColor()))
-	view.SetTextColor(ColorFor(widget.commonSettings.Colors.Text))
-	view.SetTitleColor(ColorFor(widget.commonSettings.Colors.Title))
+	view.SetBackgroundColor(wtf.ColorFor(widget.commonSettings.Colors.Background))
+	view.SetBorderColor(wtf.ColorFor(widget.BorderColor()))
+	view.SetTextColor(wtf.ColorFor(widget.commonSettings.Colors.Text))
+	view.SetTitleColor(wtf.ColorFor(widget.commonSettings.Colors.Title))
 
 	view.SetBorder(true)
 	view.SetDynamicColors(true)

--- a/view/text_widget_test.go
+++ b/view/text_widget_test.go
@@ -1,4 +1,4 @@
-package wtf
+package view
 
 import (
 	"testing"


### PR DESCRIPTION
Re-organizes the fundamental building blocks of a widget into the /view directory.

The intention is to simplify the amount of boilerplate code necessary to create a foundational view (ie: TextWidget, BarGraph) and remove duplication between the existing ones.