### PR TITLE
Fix help for modules

### DIFF
--- a/help/help.go
+++ b/help/help.go
@@ -9,16 +9,23 @@ import (
 )
 
 // Display displays the output of the --help argument
-func Display(moduleName string, config *config.Config) {
+func Display(moduleName string, cfg *config.Config) {
 	if moduleName == "" {
 		fmt.Println("\n  --module takes a module name as an argument, i.e: '--module=github'")
 	} else {
-		fmt.Printf("%s\n", helpFor(moduleName, config))
+		fmt.Printf("%s\n", helpFor(moduleName, cfg))
 	}
 }
 
-func helpFor(moduleName string, config *config.Config) string {
-	widget := app.MakeWidget(nil, nil, moduleName, config)
+func helpFor(moduleName string, cfg *config.Config) string {
+	cfg.Set("wtf.mods."+moduleName+".enabled", true)
+	widget := app.MakeWidget(nil, nil, moduleName, cfg)
+
+	// Since we are forcing enabled config, if no module
+	// exists, we will get the unknown one
+	if widget.CommonSettings().Title == "Unknown" {
+		return "Unable to find module " + moduleName
+	}
 
 	result := ""
 	result += utils.StripColorTags(widget.HelpText())


### PR DESCRIPTION
This does 2 things:
1. Forces a module to be 'enabled' on the help route, so that it works
2. Better handling when no module is actually found

Addresses #529 