### PR TITLE
use xdg-open as default open method for http/https

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -102,6 +102,8 @@ func OpenFile(path string) {
 		case "darwin":
 			exec.Command("open", path).Start()
 		default:
+			// for the BSDs
+			exec.Command("xdg-open", path).Start()
 		}
 	} else {
 		filePath, _ := ExpandHomeDir(path)


### PR DESCRIPTION
This should be available on all BSD and similar OSs

Signed-off-by: Christopher Hall <hsw@ms2.hinet.net>