### PR TITLE
add FreeBSD support to power module

### DIFF
--- a/modules/power/source.go
+++ b/modules/power/source.go
@@ -1,4 +1,5 @@
 // +build !linux
+// +build !freebsd
 
 package power
 

--- a/modules/power/source_freebsd.go
+++ b/modules/power/source_freebsd.go
@@ -1,0 +1,15 @@
+// +build freebsd
+
+package power
+
+// powerSource returns the name of the current power source, probably one of
+// "AC Power" or "Battery Power"
+func powerSource() string {
+	switch batteryState {
+	case "1":
+		return "AC Power"
+	case "0":
+		return "Battery Power"
+	}
+	return batteryState
+}


### PR DESCRIPTION
uses the FreeBSD apm command to get charge status
and battery percentage

Signed-off-by: Christopher Hall <hsw@ms2.hinet.net>