### PR TITLE
Support case-insensitive 'apiKey' config keys

### DIFF
--- a/modules/bamboohr/settings.go
+++ b/modules/bamboohr/settings.go
@@ -20,7 +20,7 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	settings := Settings{
 		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
 
-		apiKey:    ymlConfig.UString("apiKey", os.Getenv("WTF_BAMBOO_HR_TOKEN")),
+		apiKey:    ymlConfig.UString("apiKey", ymlConfig.UString("apikey", os.Getenv("WTF_BAMBOO_HR_TOKEN"))),
 		subdomain: ymlConfig.UString("subdomain", os.Getenv("WTF_BAMBOO_HR_SUBDOMAIN")),
 	}
 

--- a/modules/circleci/settings.go
+++ b/modules/circleci/settings.go
@@ -20,7 +20,7 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	settings := Settings{
 		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
 
-		apiKey: ymlConfig.UString("apiKey", os.Getenv("WTF_CIRCLE_API_KEY")),
+		apiKey: ymlConfig.UString("apiKey", ymlConfig.UString("apikey", os.Getenv("WTF_CIRCLE_API_KEY"))),
 	}
 
 	return &settings

--- a/modules/datadog/settings.go
+++ b/modules/datadog/settings.go
@@ -22,7 +22,7 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	settings := Settings{
 		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
 
-		apiKey:         ymlConfig.UString("apiKey", os.Getenv("WTF_DATADOG_API_KEY")),
+		apiKey:         ymlConfig.UString("apiKey", ymlConfig.UString("apikey", os.Getenv("WTF_DATADOG_API_KEY"))),
 		applicationKey: ymlConfig.UString("applicationKey", os.Getenv("WTF_DATADOG_APPLICATION_KEY")),
 		tags:           ymlConfig.UList("monitors.tags"),
 	}

--- a/modules/github/settings.go
+++ b/modules/github/settings.go
@@ -34,7 +34,7 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	settings := Settings{
 		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
 
-		apiKey:       ymlConfig.UString("apiKey", os.Getenv("WTF_GITHUB_TOKEN")),
+		apiKey:       ymlConfig.UString("apiKey", ymlConfig.UString("apikey", os.Getenv("WTF_GITHUB_TOKEN"))),
 		baseURL:      ymlConfig.UString("baseURL", os.Getenv("WTF_GITHUB_BASE_URL")),
 		enableStatus: ymlConfig.UBool("enableStatus", false),
 		uploadURL:    ymlConfig.UString("uploadURL", os.Getenv("WTF_GITHUB_UPLOAD_URL")),

--- a/modules/gitlab/settings.go
+++ b/modules/gitlab/settings.go
@@ -23,7 +23,7 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	settings := Settings{
 		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
 
-		apiKey:   ymlConfig.UString("apiKey", os.Getenv("WTF_GITLAB_TOKEN")),
+		apiKey:   ymlConfig.UString("apiKey", ymlConfig.UString("apikey", os.Getenv("WTF_GITLAB_TOKEN"))),
 		domain:   ymlConfig.UString("domain"),
 		projects: ymlConfig.UMap("projects"),
 		username: ymlConfig.UString("username"),

--- a/modules/hibp/settings.go
+++ b/modules/hibp/settings.go
@@ -1,6 +1,7 @@
 package hibp
 
 import (
+	"os"
 	"time"
 
 	"github.com/olebedev/config"
@@ -33,7 +34,7 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	settings := &Settings{
 		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
 
-		apiKey:   ymlConfig.UString("apiKey", ""),
+		apiKey:   ymlConfig.UString("apiKey", ymlConfig.UString("apikey", os.Getenv("WTF_HIBP_TOKEN"))),
 		accounts: utils.ToStrs(ymlConfig.UList("accounts")),
 		since:    ymlConfig.UString("since", ""),
 	}

--- a/modules/jenkins/settings.go
+++ b/modules/jenkins/settings.go
@@ -25,7 +25,7 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	settings := Settings{
 		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
 
-		apiKey:                  ymlConfig.UString("apiKey", os.Getenv("WTF_JENKINS_API_KEY")),
+		apiKey:                  ymlConfig.UString("apiKey", ymlConfig.UString("apikey", os.Getenv("WTF_JENKINS_API_KEY"))),
 		jobNameRegex:            ymlConfig.UString("jobNameRegex", ".*"),
 		successBallColor:        ymlConfig.UString("successBallColor", "blue"),
 		url:                     ymlConfig.UString("url"),

--- a/modules/jira/settings.go
+++ b/modules/jira/settings.go
@@ -34,7 +34,7 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	settings := Settings{
 		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
 
-		apiKey:                  ymlConfig.UString("apiKey", os.Getenv("WTF_JIRA_API_KEY")),
+		apiKey:                  ymlConfig.UString("apiKey", ymlConfig.UString("apikey", os.Getenv("WTF_JIRA_API_KEY"))),
 		domain:                  ymlConfig.UString("domain"),
 		email:                   ymlConfig.UString("email"),
 		jql:                     ymlConfig.UString("jql"),

--- a/modules/newrelic/settings.go
+++ b/modules/newrelic/settings.go
@@ -22,7 +22,7 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	settings := Settings{
 		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
 
-		apiKey:        ymlConfig.UString("apiKey", os.Getenv("WTF_NEW_RELIC_API_KEY")),
+		apiKey:        ymlConfig.UString("apiKey", ymlConfig.UString("apikey", os.Getenv("WTF_NEW_RELIC_API_KEY"))),
 		applicationID: ymlConfig.UInt("applicationID"),
 		deployCount:   ymlConfig.UInt("deployCount", 5),
 	}

--- a/modules/opsgenie/settings.go
+++ b/modules/opsgenie/settings.go
@@ -24,7 +24,7 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	settings := Settings{
 		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
 
-		apiKey:                 ymlConfig.UString("apiKey", os.Getenv("WTF_OPS_GENIE_API_KEY")),
+		apiKey:                 ymlConfig.UString("apiKey", ymlConfig.UString("apikey", os.Getenv("WTF_OPS_GENIE_API_KEY"))),
 		region:                 ymlConfig.UString("region", "us"),
 		displayEmpty:           ymlConfig.UBool("displayEmpty", true),
 		scheduleIdentifierType: ymlConfig.UString("scheduleIdentifierType", "id"),

--- a/modules/pagerduty/settings.go
+++ b/modules/pagerduty/settings.go
@@ -24,7 +24,7 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	settings := Settings{
 		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
 
-		apiKey:           ymlConfig.UString("apiKey", os.Getenv("WTF_PAGERDUTY_API_KEY")),
+		apiKey:           ymlConfig.UString("apiKey", ymlConfig.UString("apikey", os.Getenv("WTF_PAGERDUTY_API_KEY"))),
 		escalationFilter: ymlConfig.UList("escalationFilter"),
 		scheduleIDs:      ymlConfig.UList("scheduleIDs", []interface{}{}),
 		showIncidents:    ymlConfig.UBool("showIncidents", true),

--- a/modules/todoist/settings.go
+++ b/modules/todoist/settings.go
@@ -21,7 +21,7 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	settings := Settings{
 		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
 
-		apiKey:   ymlConfig.UString("apiKey", os.Getenv("WTF_TODOIST_TOKEN")),
+		apiKey:   ymlConfig.UString("apiKey", ymlConfig.UString("apikey", os.Getenv("WTF_TODOIST_TOKEN"))),
 		projects: ymlConfig.UList("projects"),
 	}
 

--- a/modules/travisci/settings.go
+++ b/modules/travisci/settings.go
@@ -21,7 +21,7 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	settings := Settings{
 		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
 
-		apiKey: ymlConfig.UString("apiKey", os.Getenv("WTF_TRAVIS_API_TOKEN")),
+		apiKey: ymlConfig.UString("apiKey", ymlConfig.UString("apikey", os.Getenv("WTF_TRAVIS_API_TOKEN"))),
 		pro:    ymlConfig.UBool("pro", false),
 	}
 

--- a/modules/trello/settings.go
+++ b/modules/trello/settings.go
@@ -24,7 +24,7 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	settings := Settings{
 		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
 
-		accessToken: ymlConfig.UString("accessToken", os.Getenv("WTF_TRELLO_ACCESS_TOKEN")),
+		accessToken: ymlConfig.UString("accessToken", ymlConfig.UString("apikey", os.Getenv("WTF_TRELLO_ACCESS_TOKEN"))),
 		apiKey:      ymlConfig.UString("apiKey", os.Getenv("WTF_TRELLO_APP_KEY")),
 		board:       ymlConfig.UString("board"),
 		username:    ymlConfig.UString("username"),

--- a/modules/victorops/settings.go
+++ b/modules/victorops/settings.go
@@ -23,7 +23,7 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
 
 		apiID:  ymlConfig.UString("apiID", os.Getenv("WTF_VICTOROPS_API_ID")),
-		apiKey: ymlConfig.UString("apiKey", os.Getenv("WTF_VICTOROPS_API_KEY")),
+		apiKey: ymlConfig.UString("apiKey", ymlConfig.UString("apikey", os.Getenv("WTF_VICTOROPS_API_KEY"))),
 		team:   ymlConfig.UString("team"),
 	}
 

--- a/modules/weatherservices/weather/settings.go
+++ b/modules/weatherservices/weather/settings.go
@@ -28,7 +28,7 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	settings := Settings{
 		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
 
-		apiKey:   ymlConfig.UString("apiKey", os.Getenv("WTF_OWM_API_KEY")),
+		apiKey:   ymlConfig.UString("apiKey", ymlConfig.UString("apikey", os.Getenv("WTF_OWM_API_KEY"))),
 		cityIDs:  ymlConfig.UList("cityids"),
 		language: ymlConfig.UString("language", "EN"),
 		tempUnit: ymlConfig.UString("tempUnit", "C"),

--- a/modules/zendesk/settings.go
+++ b/modules/zendesk/settings.go
@@ -23,7 +23,7 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	settings := Settings{
 		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
 
-		apiKey:    ymlConfig.UString("apiKey", os.Getenv("ZENDESK_API")),
+		apiKey:    ymlConfig.UString("apiKey", ymlConfig.UString("apikey", os.Getenv("ZENDESK_API"))),
 		status:    ymlConfig.UString("status"),
 		subdomain: ymlConfig.UString("subdomain", os.Getenv("ZENDESK_SUBDOMAIN")),
 		username:  ymlConfig.UString("username"),


### PR DESCRIPTION
'apiKey' is one that people are likely to spell wrong in their configs
as 'apikey'. Given that there's no sanity-checking around required
config values yet, and a missing API key can cause silent failures in
some modules, be liberal in accepting spelling.