### PR TITLE
Google Calendar Read Level

### DIFF
--- a/modules/gcal/client.go
+++ b/modules/gcal/client.go
@@ -203,7 +203,7 @@ func (widget *Widget) getCalendarIdList(srv *calendar.Service) ([]string, error)
 	var calendarIds []string
 	var pageToken string
 	for {
-		calendarList, err := srv.CalendarList.List().ShowHidden(false).MinAccessRole("writer").PageToken(pageToken).Do()
+		calendarList, err := srv.CalendarList.List().ShowHidden(false).MinAccessRole(widget.settings.calendarReadLevel).PageToken(pageToken).Do()
 		if err != nil {
 			return nil, err
 		}

--- a/modules/gcal/settings.go
+++ b/modules/gcal/settings.go
@@ -26,10 +26,11 @@ type Settings struct {
 	email                 string `help:"The email address associated with your Google account. Necessary for determining 'responseStatus'." values:"A valid email address string."`
 	eventCount            int    `help:"The number of calendar events to display." values:"A positive integer, 0..n." optional:"true"`
 	multiCalendar         bool   `help:"Whether or not to display your primary calendar or all calendars you have access to." values:"true or false" optional:"true"`
-	secretFile            string `help:"Your Google client secret JSON file." values:"A string representing a file path to the JSON secret file."`
-	showDeclined          bool   `help:"Whether or not to display events you’ve declined to attend." values:"true or false" optional:"true"`
-	withLocation          bool   `help:"Whether or not to show the location of the appointment." values:"true or false"`
-	timezone              string `help:"The time zone used to display calendar event times." values:"A valid TZ database time zone string" optional:"true"`
+	secretFile        	  string `help:"Your Google client secret JSON file." values:"A string representing a file path to the JSON secret file."`
+	showDeclined      	  bool   `help:"Whether or not to display events you’ve declined to attend." values:"true or false" optional:"true"`
+	withLocation      	  bool   `help:"Whether or not to show the location of the appointment." values:"true or false"`
+	timezone          	  string `help:"The time zone used to display calendar event times." values:"A valid TZ database time zone string" optional:"true"`
+	calendarReadLevel 	  string `help:"The calender read level specifies level you want to read events. Default: writer " values:"reader, writer", optional: "true"`
 }
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
@@ -47,6 +48,7 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 		showDeclined:          ymlConfig.UBool("showDeclined", false),
 		withLocation:          ymlConfig.UBool("withLocation", true),
 		timezone:              ymlConfig.UString("timezone", ""),
+		calendarReadLevel:     ymlConfig.UString("calendarReadLevel", "writer"),
 	}
 
 	settings.colors.day = ymlConfig.UString("colors.day", "forestgreen")


### PR DESCRIPTION
This pull request creates a new environment varialble `calendarReadLevel`.

**The reason for this change:** If environment variable is set to `writer` calendars you subscribe to will not show up. However, if the variable is set to `reader` then both your calendars and calendars you subscribe to will show up.

This change keeps the `writer` option as default. 

Further justification: If you subscribe to a calendar, for instance a work calendar, school calendar, then it will not show up with the `writer` role. It will however show up using the `reader` role. 