### PR TITLE
Add more configuration options to travisci module

### DIFF
--- a/modules/travisci/client.go
+++ b/modules/travisci/client.go
@@ -15,12 +15,12 @@ var TRAVIS_HOSTS = map[bool]string{
 	true:  "travis-ci.com",
 }
 
-func BuildsFor(apiKey string, pro bool) (*Builds, error) {
+func BuildsFor(settings *Settings) (*Builds, error) {
 	builds := &Builds{}
 
-	travisAPIURL.Host = "api." + TRAVIS_HOSTS[pro]
+	travisAPIURL.Host = "api." + TRAVIS_HOSTS[settings.pro]
 
-	resp, err := travisRequest(apiKey, "builds")
+	resp, err := travisBuildRequest(settings)
 	if err != nil {
 		return builds, err
 	}
@@ -36,9 +36,11 @@ var (
 	travisAPIURL = &url.URL{Scheme: "https", Path: "/"}
 )
 
-func travisRequest(apiKey string, path string) (*http.Response, error) {
+func travisBuildRequest(settings *Settings) (*http.Response, error) {
+	var path string = "builds"
 	params := url.Values{}
-	params.Add("limit", "10")
+	params.Add("limit", settings.limit)
+	params.Add("sort_by", settings.sort_by)
 
 	requestUrl := travisAPIURL.ResolveReference(&url.URL{Path: path, RawQuery: params.Encode()})
 
@@ -47,7 +49,7 @@ func travisRequest(apiKey string, path string) (*http.Response, error) {
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("Travis-API-Version", "3")
 
-	bearer := fmt.Sprintf("token %s", apiKey)
+	bearer := fmt.Sprintf("token %s", settings.apiKey)
 	req.Header.Add("Authorization", bearer)
 	if err != nil {
 		return nil, err

--- a/modules/travisci/settings.go
+++ b/modules/travisci/settings.go
@@ -12,8 +12,11 @@ const defaultTitle = "TravisCI"
 type Settings struct {
 	common *cfg.Common
 
-	apiKey string
-	pro    bool
+	apiKey  string
+	compact bool
+	limit   string
+	pro     bool
+	sort_by string
 }
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
@@ -21,8 +24,11 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	settings := Settings{
 		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
 
-		apiKey: ymlConfig.UString("apiKey", ymlConfig.UString("apikey", os.Getenv("WTF_TRAVIS_API_TOKEN"))),
-		pro:    ymlConfig.UBool("pro", false),
+		apiKey:  ymlConfig.UString("apiKey", ymlConfig.UString("apikey", os.Getenv("WTF_TRAVIS_API_TOKEN"))),
+		pro:     ymlConfig.UBool("pro", false),
+		compact: ymlConfig.UBool("compact", false),
+		limit:   ymlConfig.UString("limit", "10"),
+		sort_by: ymlConfig.UString("sort_by", "id:desc"),
 	}
 
 	return &settings

--- a/modules/travisci/widget.go
+++ b/modules/travisci/widget.go
@@ -42,7 +42,7 @@ func (widget *Widget) Refresh() {
 		return
 	}
 
-	builds, err := BuildsFor(widget.settings.apiKey, widget.settings.pro)
+	builds, err := BuildsFor(widget.settings)
 
 	if err != nil {
 		widget.err = err
@@ -68,10 +68,14 @@ func (widget *Widget) content() (string, string, bool) {
 	if widget.err != nil {
 		str = widget.err.Error()
 	} else {
+		var rowFormat = "[%s] [%s] %s-%s (%s) [%s]%s - [blue]%s"
+		if widget.settings.compact != true {
+			rowFormat += "\n"
+		}
 		for idx, build := range widget.builds.Builds {
 
 			row := fmt.Sprintf(
-				"[%s] [%s] %s-%s (%s) [%s]%s - [blue]%s\n",
+				rowFormat,
 				widget.RowColor(idx),
 				buildColor(&build),
 				build.Repository.Name,


### PR DESCRIPTION
I ran into an issue with the list of builds pulled from https://developer.travis-ci.com/resource/builds#Builds

By default travis sorts the builds by "number:desc,id:desc", which meant that the widget only displayed builds from a 2016 project which had a build number over 1800. Changing the sort to "id:desc" shows the most recently created builds. It is also possible for users to configure their preferred sort fields and the number of builds to display in the widget.

I'll also update the docs repository if these changes are approved.