### PR TITLE
Find SSID regardless of network manager

### DIFF
--- a/modules/security/wifi.go
+++ b/modules/security/wifi.go
@@ -66,11 +66,10 @@ func wifiInfo() string {
 }
 
 func wifiNameLinux() string {
-	cmd := exec.Command("nmcli", "-t", "-f", "in-use,ssid", "dev", "wifi")
-	out := utils.ExecuteCommand(cmd)
-	name := utils.FindMatch(`\*:(.+)`, out)
+  cmd := exec.Command("/usr/sbin/iwgetid", "-r")
+	name := utils.ExecuteCommand(cmd)
 	if len(name) > 0 {
-		return name[0][1]
+		return name
 	}
 	return ""
 }

--- a/modules/security/wifi.go
+++ b/modules/security/wifi.go
@@ -66,13 +66,11 @@ func wifiInfo() string {
 }
 
 func wifiNameLinux() string {
-  cmd := exec.Command("/usr/sbin/iwgetid", "-r")
-	name := utils.ExecuteCommand(cmd)
-	if len(name) > 0 {
-		return name
-	}
-	return ""
+  cmd, _ := exec.Command("iwgetid", "-r").Output()
+  return string(cmd)
 }
+
+
 
 func wifiNameMacOS() string {
 	name := utils.FindMatch(`s*SSID: (.+)s*`, wifiInfo())


### PR DESCRIPTION
I made this change on my own system, where I used wicd instead of NetworkManager. I _think_ that the wireless-tools package containing `iwgetid`is a standard package on most systems, so this change would potential make the security module work across more Linux systems.

#hacktoberfest