### PR TITLE
Wicd

### DIFF
--- a/modules/security/wifi.go
+++ b/modules/security/wifi.go
@@ -43,10 +43,10 @@ func WifiName() string {
 /* -------------------- Unexported Functions -------------------- */
 
 func wifiEncryptionLinux() string {
-	cmd := exec.Command("nmcli", "-t", "-f", "in-use,security", "dev", "wifi")
-	out := utils.ExecuteCommand(cmd)
+  cmd := exec.Command("/usr/bin/wicd-cli", "--wireless", "-d")
+  out := utils.ExecuteCommand(cmd)
 
-	name := utils.FindMatch(`\*:(.+)`, out)
+	name := utils.FindMatch(`Encryption Method:(.+)`, out)
 
 	if len(name) > 0 {
 		return name[0][1]

--- a/modules/security/wifi.go
+++ b/modules/security/wifi.go
@@ -43,7 +43,7 @@ func WifiName() string {
 /* -------------------- Unexported Functions -------------------- */
 
 func wifiEncryptionLinux() string {
-  cmd := exec.Command("/usr/bin/wicd-cli", "--wireless", "-d")
+  cmd := exec.Command("wicd-cli", "--wireless", "-d")
   out := utils.ExecuteCommand(cmd)
 
 	name := utils.FindMatch(`Encryption Method:(.+)`, out)


### PR DESCRIPTION
This depends on #584 

This change pulls the Wireless encryption method from wicd instead of nmcli. It **Should Not** be merged as is, since many more systems are using NetworkManager than wicd.

I am not a developer, but I figured out this much. I'm hoping that some generous soul will ammend this PR with the Go code making this an elif statement such that if the nmcli output is a failure, it will try this code instead.

With such an elif in place, others could further expand this section to use their networking client of choice.