### PR TITLE
WTF-547 Open selected GitHub PR

### DIFF
--- a/modules/github/display.go
+++ b/modules/github/display.go
@@ -12,7 +12,6 @@ func (widget *Widget) display() {
 
 func (widget *Widget) content() (string, string, bool) {
 	repo := widget.currentGithubRepo()
-	widget.Unselect()
 
 	title := fmt.Sprintf("%s - %s", widget.CommonSettings().Title, widget.title(repo))
 	if repo == nil {
@@ -38,20 +37,17 @@ func (widget *Widget) content() (string, string, bool) {
 func (widget *Widget) displayMyPullRequests(repo *GithubRepo, username string) string {
 	prs := repo.myPullRequests(username, widget.settings.enableStatus)
 
-	numSelections := widget.GetSelected()
-
 	if len(prs) == 0 {
 		return " [grey]none[white]\n"
 	}
 
-	str := ""
-	for _, pr := range prs {
-		str += fmt.Sprintf(`[green]["%d"]%4d[""][white] %s`, numSelections, *pr.Number, *pr.Title)
-		str += "\n"
-		numSelections++
-	}
+	widget.SetItemCount(len(prs))
 
-	widget.SetItemCount(numSelections)
+	str := ""
+	for idx, pr := range prs {
+		str += fmt.Sprintf(`[green]["%d"]%4d[""][white] %s`, idx, *pr.Number, *pr.Title)
+		str += "\n"
+	}
 
 	return str
 }
@@ -59,7 +55,7 @@ func (widget *Widget) displayMyPullRequests(repo *GithubRepo, username string) s
 func (widget *Widget) displayCustomQuery(repo *GithubRepo, filter string, perPage int) string {
 	res := repo.customIssueQuery(filter, perPage)
 	
-	numSelections := widget.GetSelected()
+	maxItems := widget.GetItemCount()
 	
 	if res == nil {
 		return " [grey]Invalid Query[white]\n"
@@ -70,13 +66,12 @@ func (widget *Widget) displayCustomQuery(repo *GithubRepo, filter string, perPag
 	}
 
 	str := ""
-	for _, issue := range res.Issues {
-		str += fmt.Sprintf(`[green]["%d"]%4d[""][white] %s`, numSelections, *issue.Number, *issue.Title)
+	for idx, issue := range res.Issues {
+		str += fmt.Sprintf(`[green]["%d"]%4d[""][white] %s`, maxItems + idx, *issue.Number, *issue.Title)
 		str += "\n"
-		numSelections++
 	}
 
-	widget.SetItemCount(numSelections)
+	widget.SetItemCount(maxItems + len(res.Issues))
 
 	return str
 }
@@ -84,20 +79,19 @@ func (widget *Widget) displayCustomQuery(repo *GithubRepo, filter string, perPag
 func (widget *Widget) displayMyReviewRequests(repo *GithubRepo, username string) string {
 	prs := repo.myReviewRequests(username)
 
-	numSelections := widget.GetSelected()
+	maxItems := widget.GetItemCount()
 
 	if len(prs) == 0 {
 		return " [grey]none[white]\n"
 	}
 
 	str := ""
-	for _, pr := range prs {
-		str += fmt.Sprintf(`[green]["%d"]%4d[""][white] %s`, numSelections, *pr.Number, *pr.Title)
+	for idx, pr := range prs {
+		str += fmt.Sprintf(`[green]["%d"]%4d[""][white] %s`, maxItems + idx, *pr.Number, *pr.Title)
 		str += "\n"
-		numSelections++
 	}
 
-	widget.SetItemCount(numSelections)
+	widget.SetItemCount(maxItems + len(prs))
 
 	return str
 }

--- a/modules/github/display.go
+++ b/modules/github/display.go
@@ -12,7 +12,6 @@ func (widget *Widget) display() {
 
 func (widget *Widget) content() (string, string, bool) {
 	repo := widget.currentGithubRepo()
-
 	title := fmt.Sprintf("%s - %s", widget.CommonSettings().Title, widget.title(repo))
 	if repo == nil {
 		return title, " GitHub repo data is unavailable ", false
@@ -47,7 +46,7 @@ func (widget *Widget) displayMyPullRequests(repo *GithubRepo, username string) s
 
 	str := ""
 	for idx, pr := range prs {
-		str += fmt.Sprintf(`[green]["%d"]%4d[""][white] %s`, idx, *pr.Number, *pr.Title)
+		str += fmt.Sprintf(`%s[green]["%d"]%4d[""][white] %s`, widget.mergeString(pr), idx, *pr.Number, *pr.Title)
 		str += "\n"
 	}
 

--- a/modules/github/display.go
+++ b/modules/github/display.go
@@ -12,6 +12,15 @@ func (widget *Widget) display() {
 
 func (widget *Widget) content() (string, string, bool) {
 	repo := widget.currentGithubRepo()
+
+	if len(widget.View.GetHighlights()) > 0 {
+		widget.View.ScrollToHighlight()
+	} else {
+		widget.View.ScrollToBeginning()
+	}
+	
+	widget.SetItemCount(len(repo.myReviewRequests((widget.settings.username))))
+	
 	title := fmt.Sprintf("%s - %s", widget.CommonSettings().Title, widget.title(repo))
 	if repo == nil {
 		return title, " GitHub repo data is unavailable ", false
@@ -35,20 +44,22 @@ func (widget *Widget) content() (string, string, bool) {
 
 func (widget *Widget) displayMyPullRequests(repo *GithubRepo, username string) string {
 	prs := repo.myPullRequests(username, widget.settings.enableStatus)
-	
+
 	prLength := len(prs)
 
 	if prLength == 0 {
 		return " [grey]none[white]\n"
 	}
 
-	widget.SetItemCount(prLength)
+	maxItems := widget.GetItemCount()
 
 	str := ""
 	for idx, pr := range prs {
-		str += fmt.Sprintf(`%s[green]["%d"]%4d[""][white] %s`, widget.mergeString(pr), idx, *pr.Number, *pr.Title)
+		str += fmt.Sprintf(`%s[green]["%d"]%4d[""][white] %s`, widget.mergeString(pr), maxItems + idx, *pr.Number, *pr.Title)
 		str += "\n"
 	}
+
+	widget.SetItemCount(maxItems + prLength)
 
 	return str
 }
@@ -82,21 +93,15 @@ func (widget *Widget) displayCustomQuery(repo *GithubRepo, filter string, perPag
 func (widget *Widget) displayMyReviewRequests(repo *GithubRepo, username string) string {
 	prs := repo.myReviewRequests(username)
 
-	prLength := len(prs)
-
-	if prLength == 0 {
+	if len(prs) == 0 {
 		return " [grey]none[white]\n"
 	}
 
-	maxItems := widget.GetItemCount()
-
 	str := ""
 	for idx, pr := range prs {
-		str += fmt.Sprintf(`[green]["%d"]%4d[""][white] %s`, maxItems + idx, *pr.Number, *pr.Title)
+		str += fmt.Sprintf(`[green]["%d"]%4d[""][white] %s`, idx, *pr.Number, *pr.Title)
 		str += "\n"
 	}
-
-	widget.SetItemCount(maxItems + prLength)
 
 	return str
 }

--- a/modules/github/display.go
+++ b/modules/github/display.go
@@ -79,7 +79,7 @@ func (widget *Widget) displayCustomQuery(repo *GithubRepo, filter string, perPag
 	return str
 }
 
-func (widget *Widget) displayMyReviewRequests(repo*GithubRepo, username string) string {
+func (widget *Widget) displayMyReviewRequests(repo *GithubRepo, username string) string {
 	prs := repo.myReviewRequests(username)
 
 	numSelections := widget.GetSelected()

--- a/modules/github/display.go
+++ b/modules/github/display.go
@@ -12,15 +12,18 @@ func (widget *Widget) display() {
 
 func (widget *Widget) content() (string, string, bool) {
 	repo := widget.currentGithubRepo()
+	username := widget.settings.username
 
+	// Choses the correct place to scroll to when changing sources
 	if len(widget.View.GetHighlights()) > 0 {
 		widget.View.ScrollToHighlight()
 	} else {
 		widget.View.ScrollToBeginning()
 	}
-	
-	widget.SetItemCount(len(repo.myReviewRequests((widget.settings.username))))
-	
+
+	// initial maxItems count
+	widget.SetItemCount(len(repo.myReviewRequests((username))))
+
 	title := fmt.Sprintf("%s - %s", widget.CommonSettings().Title, widget.title(repo))
 	if repo == nil {
 		return title, " GitHub repo data is unavailable ", false
@@ -31,9 +34,9 @@ func (widget *Widget) content() (string, string, bool) {
 	str += " [red]Stats[white]\n"
 	str += widget.displayStats(repo)
 	str += "\n [red]Open Review Requests[white]\n"
-	str += widget.displayMyReviewRequests(repo, widget.settings.username)
+	str += widget.displayMyReviewRequests(repo, username)
 	str += "\n [red]My Pull Requests[white]\n"
-	str += widget.displayMyPullRequests(repo, widget.settings.username)
+	str += widget.displayMyPullRequests(repo, username)
 	for _, customQuery := range widget.settings.customQueries {
 		str += fmt.Sprintf("\n [red]%s[white]\n", customQuery.title)
 		str += widget.displayCustomQuery(repo, customQuery.filter, customQuery.perPage)
@@ -55,7 +58,7 @@ func (widget *Widget) displayMyPullRequests(repo *GithubRepo, username string) s
 
 	str := ""
 	for idx, pr := range prs {
-		str += fmt.Sprintf(`%s[green]["%d"]%4d[""][white] %s`, widget.mergeString(pr), maxItems + idx, *pr.Number, *pr.Title)
+		str += fmt.Sprintf(` %s[green]["%d"]%4d[""][white] %s`, widget.mergeString(pr), maxItems + idx, *pr.Number, *pr.Title)
 		str += "\n"
 	}
 
@@ -81,7 +84,7 @@ func (widget *Widget) displayCustomQuery(repo *GithubRepo, filter string, perPag
 
 	str := ""
 	for idx, issue := range res.Issues {
-		str += fmt.Sprintf(`[green]["%d"]%4d[""][white] %s`, maxItems + idx , *issue.Number, *issue.Title)
+		str += fmt.Sprintf(` [green]["%d"]%4d[""][white] %s`, maxItems + idx , *issue.Number, *issue.Title)
 		str += "\n"
 	}
 
@@ -99,7 +102,7 @@ func (widget *Widget) displayMyReviewRequests(repo *GithubRepo, username string)
 
 	str := ""
 	for idx, pr := range prs {
-		str += fmt.Sprintf(`[green]["%d"]%4d[""][white] %s`, idx, *pr.Number, *pr.Title)
+		str += fmt.Sprintf(` [green]["%d"]%4d[""][white] %s`, idx, *pr.Number, *pr.Title)
 		str += "\n"
 	}
 

--- a/modules/github/display.go
+++ b/modules/github/display.go
@@ -12,6 +12,8 @@ func (widget *Widget) display() {
 
 func (widget *Widget) content() (string, string, bool) {
 	repo := widget.currentGithubRepo()
+	widget.Unselect()
+
 	title := fmt.Sprintf("%s - %s", widget.CommonSettings().Title, widget.title(repo))
 	if repo == nil {
 		return title, " GitHub repo data is unavailable ", false

--- a/modules/github/display.go
+++ b/modules/github/display.go
@@ -2,6 +2,8 @@ package github
 
 import (
 	"fmt"
+	"strconv"
+	"net/url"
 
 	"github.com/google/go-github/v26/github"
 )
@@ -36,20 +38,31 @@ func (widget *Widget) content() (string, string, bool) {
 func (widget *Widget) displayMyPullRequests(repo *GithubRepo, username string) string {
 	prs := repo.myPullRequests(username, widget.settings.enableStatus)
 
+	u, _ := url.Parse(*repo.RemoteRepo.HTMLURL + "/pull/")
+	numSelections := widget.GetSelected()
+
 	if len(prs) == 0 {
 		return " [grey]none[white]\n"
 	}
 
 	str := ""
 	for _, pr := range prs {
-		str += fmt.Sprintf(" %s[green]%4d[white] %s\n", widget.mergeString(pr), *pr.Number, *pr.Title)
+		// str += fmt.Sprintf(` %s[green]%4d[white] %s\n`, widget.mergeString(pr), *pr.Number, *pr.Title)
+		str += fmt.Sprintf(`["%d"]%s[""]`, numSelections, u.String() + strconv.Itoa(*pr.Number))
+		str += "\n"
+		numSelections++
 	}
+
 
 	return str
 }
 
 func (widget *Widget) displayCustomQuery(repo *GithubRepo, filter string, perPage int) string {
 	res := repo.customIssueQuery(filter, perPage)
+	
+	u, _ := url.Parse(*repo.RemoteRepo.HTMLURL + "/pull/")
+	numSelections := widget.GetSelected()
+	
 	if res == nil {
 		return " [grey]Invalid Query[white]\n"
 	}
@@ -60,8 +73,14 @@ func (widget *Widget) displayCustomQuery(repo *GithubRepo, filter string, perPag
 
 	str := ""
 	for _, issue := range res.Issues {
-		str += fmt.Sprintf(" [green]%4d[white] %s\n", *issue.Number, *issue.Title)
+		// str += fmt.Sprintf(" [green]%4d[white] %s\n", *issue.Number, *issue.Title)
+		str += fmt.Sprintf(`["%d"]%s[""]`, numSelections, u.String() + strconv.Itoa(*issue.Number))
+		str += "\n"
+		numSelections++
 	}
+
+	widget.SetItemCount(numSelections)
+
 	return str
 }
 

--- a/modules/github/display.go
+++ b/modules/github/display.go
@@ -2,8 +2,6 @@ package github
 
 import (
 	"fmt"
-	"strconv"
-	"net/url"
 
 	"github.com/google/go-github/v26/github"
 )
@@ -38,7 +36,6 @@ func (widget *Widget) content() (string, string, bool) {
 func (widget *Widget) displayMyPullRequests(repo *GithubRepo, username string) string {
 	prs := repo.myPullRequests(username, widget.settings.enableStatus)
 
-	u, _ := url.Parse(*repo.RemoteRepo.HTMLURL + "/pull/")
 	numSelections := widget.GetSelected()
 
 	if len(prs) == 0 {
@@ -47,12 +44,12 @@ func (widget *Widget) displayMyPullRequests(repo *GithubRepo, username string) s
 
 	str := ""
 	for _, pr := range prs {
-		// str += fmt.Sprintf(` %s[green]%4d[white] %s\n`, widget.mergeString(pr), *pr.Number, *pr.Title)
-		str += fmt.Sprintf(`["%d"]%s[""]`, numSelections, u.String() + strconv.Itoa(*pr.Number))
+		str += fmt.Sprintf(`[green]["%d"]%4d[""][white] %s`, numSelections, *pr.Number, *pr.Title)
 		str += "\n"
 		numSelections++
 	}
 
+	widget.SetItemCount(numSelections)
 
 	return str
 }
@@ -60,7 +57,6 @@ func (widget *Widget) displayMyPullRequests(repo *GithubRepo, username string) s
 func (widget *Widget) displayCustomQuery(repo *GithubRepo, filter string, perPage int) string {
 	res := repo.customIssueQuery(filter, perPage)
 	
-	u, _ := url.Parse(*repo.RemoteRepo.HTMLURL + "/pull/")
 	numSelections := widget.GetSelected()
 	
 	if res == nil {
@@ -73,8 +69,7 @@ func (widget *Widget) displayCustomQuery(repo *GithubRepo, filter string, perPag
 
 	str := ""
 	for _, issue := range res.Issues {
-		// str += fmt.Sprintf(" [green]%4d[white] %s\n", *issue.Number, *issue.Title)
-		str += fmt.Sprintf(`["%d"]%s[""]`, numSelections, u.String() + strconv.Itoa(*issue.Number))
+		str += fmt.Sprintf(`[green]["%d"]%4d[""][white] %s`, numSelections, *issue.Number, *issue.Title)
 		str += "\n"
 		numSelections++
 	}
@@ -84,8 +79,10 @@ func (widget *Widget) displayCustomQuery(repo *GithubRepo, filter string, perPag
 	return str
 }
 
-func (widget *Widget) displayMyReviewRequests(repo *GithubRepo, username string) string {
+func (widget *Widget) displayMyReviewRequests(repo*GithubRepo, username string) string {
 	prs := repo.myReviewRequests(username)
+
+	numSelections := widget.GetSelected()
 
 	if len(prs) == 0 {
 		return " [grey]none[white]\n"
@@ -93,8 +90,12 @@ func (widget *Widget) displayMyReviewRequests(repo *GithubRepo, username string)
 
 	str := ""
 	for _, pr := range prs {
-		str += fmt.Sprintf(" [green]%4d[white] %s\n", *pr.Number, *pr.Title)
+		str += fmt.Sprintf(`[green]["%d"]%4d[""][white] %s`, numSelections, *pr.Number, *pr.Title)
+		str += "\n"
+		numSelections++
 	}
+
+	widget.SetItemCount(numSelections)
 
 	return str
 }

--- a/modules/github/display.go
+++ b/modules/github/display.go
@@ -36,12 +36,14 @@ func (widget *Widget) content() (string, string, bool) {
 
 func (widget *Widget) displayMyPullRequests(repo *GithubRepo, username string) string {
 	prs := repo.myPullRequests(username, widget.settings.enableStatus)
+	
+	prLength := len(prs)
 
-	if len(prs) == 0 {
+	if prLength == 0 {
 		return " [grey]none[white]\n"
 	}
 
-	widget.SetItemCount(len(prs))
+	widget.SetItemCount(prLength)
 
 	str := ""
 	for idx, pr := range prs {
@@ -55,23 +57,25 @@ func (widget *Widget) displayMyPullRequests(repo *GithubRepo, username string) s
 func (widget *Widget) displayCustomQuery(repo *GithubRepo, filter string, perPage int) string {
 	res := repo.customIssueQuery(filter, perPage)
 	
-	maxItems := widget.GetItemCount()
-	
 	if res == nil {
 		return " [grey]Invalid Query[white]\n"
 	}
 
-	if len(res.Issues) == 0 {
+	issuesLength := len(res.Issues)
+	
+	if issuesLength == 0 {
 		return " [grey]none[white]\n"
 	}
+	
+	maxItems := widget.GetItemCount()
 
 	str := ""
 	for idx, issue := range res.Issues {
-		str += fmt.Sprintf(`[green]["%d"]%4d[""][white] %s`, maxItems + idx, *issue.Number, *issue.Title)
+		str += fmt.Sprintf(`[green]["%d"]%4d[""][white] %s`, maxItems + idx , *issue.Number, *issue.Title)
 		str += "\n"
 	}
 
-	widget.SetItemCount(maxItems + len(res.Issues))
+	widget.SetItemCount(maxItems + issuesLength)
 
 	return str
 }
@@ -79,11 +83,13 @@ func (widget *Widget) displayCustomQuery(repo *GithubRepo, filter string, perPag
 func (widget *Widget) displayMyReviewRequests(repo *GithubRepo, username string) string {
 	prs := repo.myReviewRequests(username)
 
-	maxItems := widget.GetItemCount()
+	prLength := len(prs)
 
-	if len(prs) == 0 {
+	if prLength == 0 {
 		return " [grey]none[white]\n"
 	}
+
+	maxItems := widget.GetItemCount()
 
 	str := ""
 	for idx, pr := range prs {
@@ -91,7 +97,7 @@ func (widget *Widget) displayMyReviewRequests(repo *GithubRepo, username string)
 		str += "\n"
 	}
 
-	widget.SetItemCount(maxItems + len(prs))
+	widget.SetItemCount(maxItems + prLength)
 
 	return str
 }

--- a/modules/github/display.go
+++ b/modules/github/display.go
@@ -22,6 +22,7 @@ func (widget *Widget) content() (string, string, bool) {
 	}
 
 	// initial maxItems count
+	widget.Items = make([]int, 0)
 	widget.SetItemCount(len(repo.myReviewRequests((username))))
 
 	title := fmt.Sprintf("%s - %s", widget.CommonSettings().Title, widget.title(repo))
@@ -60,6 +61,7 @@ func (widget *Widget) displayMyPullRequests(repo *GithubRepo, username string) s
 	for idx, pr := range prs {
 		str += fmt.Sprintf(` %s[green]["%d"]%4d[""][white] %s`, widget.mergeString(pr), maxItems + idx, *pr.Number, *pr.Title)
 		str += "\n"
+		widget.Items = append(widget.Items, *pr.Number)
 	}
 
 	widget.SetItemCount(maxItems + prLength)
@@ -86,6 +88,7 @@ func (widget *Widget) displayCustomQuery(repo *GithubRepo, filter string, perPag
 	for idx, issue := range res.Issues {
 		str += fmt.Sprintf(` [green]["%d"]%4d[""][white] %s`, maxItems + idx , *issue.Number, *issue.Title)
 		str += "\n"
+		widget.Items = append(widget.Items, *issue.Number)
 	}
 
 	widget.SetItemCount(maxItems + issuesLength)
@@ -104,6 +107,7 @@ func (widget *Widget) displayMyReviewRequests(repo *GithubRepo, username string)
 	for idx, pr := range prs {
 		str += fmt.Sprintf(` [green]["%d"]%4d[""][white] %s`, idx, *pr.Number, *pr.Title)
 		str += "\n"
+		widget.Items = append(widget.Items, *pr.Number)
 	}
 
 	return str

--- a/modules/github/keyboard.go
+++ b/modules/github/keyboard.go
@@ -7,13 +7,16 @@ import (
 func (widget *Widget) initializeKeyboardControls() {
 	widget.InitializeCommonControls(widget.Refresh)
 
+	widget.SetKeyboardChar("j", widget.Next, "Select next item")
+	widget.SetKeyboardChar("k", widget.Prev, "Select previous item")
 	widget.SetKeyboardChar("l", widget.NextSource, "Select next source")
 	widget.SetKeyboardChar("h", widget.PrevSource, "Select previous source")
 	widget.SetKeyboardChar("o", widget.openRepo, "Open item in browser")
 
-	widget.SetKeyboardKey(tcell.KeyDown, widget.Next, "Select next source")
-	widget.SetKeyboardKey(tcell.KeyUp, widget.Prev, "Select next source")
+	widget.SetKeyboardKey(tcell.KeyDown, widget.Next, "Select next item")
+	widget.SetKeyboardKey(tcell.KeyUp, widget.Prev, "Select previous item")
 	widget.SetKeyboardKey(tcell.KeyRight, widget.NextSource, "Select next source")
 	widget.SetKeyboardKey(tcell.KeyLeft, widget.PrevSource, "Select previous source")
 	widget.SetKeyboardKey(tcell.KeyEnter, widget.openPr, "Open item in browser")
+	widget.SetKeyboardKey(tcell.KeyBackspace, widget.openRepo, "Open item in browser")
 }

--- a/modules/github/keyboard.go
+++ b/modules/github/keyboard.go
@@ -17,6 +17,6 @@ func (widget *Widget) initializeKeyboardControls() {
 	widget.SetKeyboardKey(tcell.KeyUp, widget.Prev, "Select previous item")
 	widget.SetKeyboardKey(tcell.KeyRight, widget.NextSource, "Select next source")
 	widget.SetKeyboardKey(tcell.KeyLeft, widget.PrevSource, "Select previous source")
-	widget.SetKeyboardKey(tcell.KeyEnter, widget.openPr, "Open item in browser")
+	widget.SetKeyboardKey(tcell.KeyEnter, widget.openPr, "Open PR in browser")
 	widget.SetKeyboardKey(tcell.KeyInsert, widget.openRepo, "Open item in browser")
 }

--- a/modules/github/keyboard.go
+++ b/modules/github/keyboard.go
@@ -11,7 +11,9 @@ func (widget *Widget) initializeKeyboardControls() {
 	widget.SetKeyboardChar("h", widget.PrevSource, "Select previous source")
 	widget.SetKeyboardChar("o", widget.openRepo, "Open item in browser")
 
+	widget.SetKeyboardKey(tcell.KeyDown, widget.Next, "Select next source")
+	widget.SetKeyboardKey(tcell.KeyUp, widget.Prev, "Select next source")
 	widget.SetKeyboardKey(tcell.KeyRight, widget.NextSource, "Select next source")
 	widget.SetKeyboardKey(tcell.KeyLeft, widget.PrevSource, "Select previous source")
-	widget.SetKeyboardKey(tcell.KeyEnter, widget.openRepo, "Open item in browser")
+	widget.SetKeyboardKey(tcell.KeyEnter, widget.openPr, "Open item in browser")
 }

--- a/modules/github/keyboard.go
+++ b/modules/github/keyboard.go
@@ -19,4 +19,5 @@ func (widget *Widget) initializeKeyboardControls() {
 	widget.SetKeyboardKey(tcell.KeyLeft, widget.PrevSource, "Select previous source")
 	widget.SetKeyboardKey(tcell.KeyEnter, widget.openPr, "Open PR in browser")
 	widget.SetKeyboardKey(tcell.KeyInsert, widget.openRepo, "Open item in browser")
+	widget.SetKeyboardKey(tcell.KeyEsc, widget.Unselect, "Clear selection")
 }

--- a/modules/github/keyboard.go
+++ b/modules/github/keyboard.go
@@ -18,5 +18,5 @@ func (widget *Widget) initializeKeyboardControls() {
 	widget.SetKeyboardKey(tcell.KeyRight, widget.NextSource, "Select next source")
 	widget.SetKeyboardKey(tcell.KeyLeft, widget.PrevSource, "Select previous source")
 	widget.SetKeyboardKey(tcell.KeyEnter, widget.openPr, "Open item in browser")
-	widget.SetKeyboardKey(tcell.KeyBackspace, widget.openRepo, "Open item in browser")
+	widget.SetKeyboardKey(tcell.KeyInsert, widget.openRepo, "Open item in browser")
 }

--- a/modules/github/widget.go
+++ b/modules/github/widget.go
@@ -80,7 +80,7 @@ func (widget *Widget) Prev() {
 
 func (widget *Widget) Unselect() {
 	widget.Selected = -1
-	widget.View.Highlight(strconv.Itoa(widget.Selected)).ScrollToHighlight()
+	widget.View.ScrollToBeginning()
 }
 
 func (widget *Widget) Refresh() {

--- a/modules/github/widget.go
+++ b/modules/github/widget.go
@@ -81,6 +81,7 @@ func (widget *Widget) Prev() {
 
 func (widget *Widget) Unselect() {
 	widget.Selected = -1
+	widget.View.Highlight()
 	widget.View.ScrollToBeginning()
 }
 

--- a/modules/github/widget.go
+++ b/modules/github/widget.go
@@ -76,9 +76,6 @@ func (widget *Widget) Prev() {
 
 func (widget *Widget) Unselect() {
 	widget.Selected = -1
-	if widget.DisplayFunction != nil {
-		widget.SetDisplayFunction(widget.display)
-	}
 }
 
 func (widget *Widget) Refresh() {

--- a/modules/github/widget.go
+++ b/modules/github/widget.go
@@ -130,7 +130,8 @@ func (widget *Widget) currentGithubRepo() *GithubRepo {
 func (widget *Widget) openPr() {
 	currentSelection := widget.View.GetHighlights()
 	if widget.Selected >= 0 && currentSelection[0] != "" {
-		utils.OpenFile(widget.View.GetRegionText(currentSelection[0]))
+		url := (*widget.currentGithubRepo().RemoteRepo.HTMLURL + "/pull/" +  widget.View.GetRegionText(currentSelection[0]))
+		utils.OpenFile(url)
 	}
 }
 

--- a/modules/github/widget.go
+++ b/modules/github/widget.go
@@ -88,7 +88,6 @@ func (widget *Widget) Refresh() {
 		repo.Refresh()
 	}
 
-	widget.SetItemCount(0)
 	widget.display()
 }
 

--- a/modules/github/widget.go
+++ b/modules/github/widget.go
@@ -51,6 +51,10 @@ func (widget *Widget) SetItemCount(items int) {
 	widget.maxItems = items
 }
 
+func (widget *Widget) GetItemCount() int {
+	return widget.maxItems
+}
+
 func (widget *Widget) GetSelected() int {
 	if widget.Selected < 0 {
 		return 0
@@ -76,6 +80,7 @@ func (widget *Widget) Prev() {
 
 func (widget *Widget) Unselect() {
 	widget.Selected = -1
+	widget.View.Highlight(strconv.Itoa(widget.Selected)).ScrollToHighlight()
 }
 
 func (widget *Widget) Refresh() {
@@ -83,6 +88,7 @@ func (widget *Widget) Refresh() {
 		repo.Refresh()
 	}
 
+	widget.SetItemCount(0)
 	widget.display()
 }
 

--- a/modules/github/widget.go
+++ b/modules/github/widget.go
@@ -31,7 +31,7 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 	}
 
 	widget.GithubRepos = widget.buildRepoCollection(widget.settings.repositories)
-	
+
 	widget.initializeKeyboardControls()
 	widget.View.SetRegions(true)
 	widget.View.SetInputCapture(widget.InputCapture)

--- a/modules/github/widget.go
+++ b/modules/github/widget.go
@@ -19,6 +19,7 @@ type Widget struct {
 	settings *Settings
 	Selected int
 	maxItems int
+	Items	[]int
 }
 
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
@@ -132,7 +133,7 @@ func (widget *Widget) currentGithubRepo() *GithubRepo {
 func (widget *Widget) openPr() {
 	currentSelection := widget.View.GetHighlights()
 	if widget.Selected >= 0 && currentSelection[0] != "" {
-		url := (*widget.currentGithubRepo().RemoteRepo.HTMLURL + "/pull/" +  widget.View.GetRegionText(currentSelection[0]))
+		url := (*widget.currentGithubRepo().RemoteRepo.HTMLURL + "/pull/" + strconv.Itoa(widget.Items[widget.Selected]))
 		utils.OpenFile(url)
 	}
 }


### PR DESCRIPTION
This closes #547

using the up or down arrow / j or k keys it will select the PR/issue. Once selected you can hit return to open that specific PR in a browser. It also retains opening of the repo by pressing insert. Insert probably isn't the best key for this and am open to change that.

Currently it isn't using a ScrollableWidget but rather uses highlighting of text through the TextWidget. when hitting enter the PR number will be sent used in conjunction with the current repo to determine what url to open.

This could be done through a ScrollableWidget as I'm aware I've used most of the functionality from there. DRY isn't exactly followed here and would be open to turning it into a ScrollableWidget but would need some guidance. 