### PR TITLE
Fix delete/close of todoist

### DIFF
--- a/modules/todoist/widget.go
+++ b/modules/todoist/widget.go
@@ -104,25 +104,26 @@ func (widget *Widget) Unselect() {
 // Close closes the currently-selected task in the currently-selected project
 func (w *Widget) Close() {
 	w.CurrentProject().closeSelectedTask()
+	w.SetItemCount(len(w.CurrentProject().tasks))
 
 	if w.CurrentProject().isLast() {
 		w.Prev()
 		return
 	}
-
-	w.Next()
+	w.CurrentProject().index = w.Selected
+	w.RenderFunction()
 }
 
 // Delete deletes the currently-selected task in the currently-selected project
 func (w *Widget) Delete() {
 	w.CurrentProject().deleteSelectedTask()
+	w.SetItemCount(len(w.CurrentProject().tasks))
 
 	if w.CurrentProject().isLast() {
 		w.Prev()
-		return
 	}
-
-	w.Next()
+	w.CurrentProject().index = w.Selected
+	w.RenderFunction()
 }
 
 /* -------------------- Unexported Functions -------------------- */

--- a/view/scrollable_widget.go
+++ b/view/scrollable_widget.go
@@ -35,6 +35,9 @@ func (widget *ScrollableWidget) SetRenderFunction(displayFunc func()) {
 
 func (widget *ScrollableWidget) SetItemCount(items int) {
 	widget.maxItems = items
+	if items == 0 {
+		widget.Selected = -1
+	}
 }
 
 func (widget *ScrollableWidget) GetSelected() int {
@@ -54,6 +57,9 @@ func (widget *ScrollableWidget) Next() {
 	if widget.Selected >= widget.maxItems {
 		widget.Selected = 0
 	}
+	if widget.maxItems == 0 {
+		widget.Selected = -1
+	}
 	widget.RenderFunction()
 }
 
@@ -61,6 +67,9 @@ func (widget *ScrollableWidget) Prev() {
 	widget.Selected--
 	if widget.Selected < 0 {
 		widget.Selected = widget.maxItems - 1
+	}
+	if widget.maxItems == 0 {
+		widget.Selected = -1
 	}
 	widget.RenderFunction()
 }


### PR DESCRIPTION
Currently, when deleting, we jump 2 positions, since we are calling next.
However, the next item becomes the current selected position, so handle better
Properly set selected in some edge cases where we may go from a list to 0