### PR TITLE
WTF-575: URL-Decode Jenkins branch names

### DIFF
--- a/modules/jenkins/widget.go
+++ b/modules/jenkins/widget.go
@@ -5,6 +5,7 @@ import (
 	"github.com/rivo/tview"
 	"github.com/wtfutil/wtf/utils"
 	"github.com/wtfutil/wtf/view"
+	"net/url"
 )
 
 type Widget struct {
@@ -75,12 +76,13 @@ func (widget *Widget) content() (string, string, bool) {
 	var str string
 	jobs := widget.view.Jobs
 	for idx, job := range jobs {
+		jobName, _ := url.QueryUnescape(job.Name)
 
 		row := fmt.Sprintf(
 			`[%s] [%s]%-6s[white]`,
 			widget.RowColor(idx),
 			widget.jobColor(&job),
-			job.Name,
+			jobName,
 		)
 
 		str += utils.HighlightableHelper(widget.View, row, idx, len(job.Name))


### PR DESCRIPTION
Bugfix for https://github.com/wtfutil/wtf/issues/575.