### PR TITLE
Pass through github client errors to display

### DIFF
--- a/modules/github/display.go
+++ b/modules/github/display.go
@@ -15,6 +15,8 @@ func (widget *Widget) content() (string, string, bool) {
 	title := fmt.Sprintf("%s - %s", widget.CommonSettings().Title, widget.title(repo))
 	if repo == nil {
 		return title, " GitHub repo data is unavailable ", false
+	} else if repo.Err != nil {
+		return title, repo.Err.Error(), true
 	}
 
 	_, _, width, _ := widget.View.GetRect()

--- a/modules/github/github_repo.go
+++ b/modules/github/github_repo.go
@@ -19,6 +19,7 @@ type GithubRepo struct {
 	Owner        string
 	PullRequests []*ghb.PullRequest
 	RemoteRepo   *ghb.Repository
+	Err          error
 }
 
 func NewGithubRepo(name, owner, apiKey, baseURL, uploadURL string) *GithubRepo {
@@ -40,8 +41,15 @@ func (repo *GithubRepo) Open() {
 
 // Refresh reloads the github data via the Github API
 func (repo *GithubRepo) Refresh() {
-	repo.PullRequests, _ = repo.loadPullRequests()
-	repo.RemoteRepo, _ = repo.loadRemoteRepository()
+	prs, err := repo.loadPullRequests()
+	repo.Err = err
+	repo.PullRequests = prs
+	if err != nil {
+		return
+	}
+	remote, err := repo.loadRemoteRepository()
+	repo.Err = err
+	repo.RemoteRepo = remote
 }
 
 /* -------------------- Counts -------------------- */


### PR DESCRIPTION
Per #598, we crash on occasion.
We are swallowing errors incorrectly, and should catch/render