### PR TITLE
feat(newrelic): Display deploy information from multiple apps

### DIFF
--- a/app/widget_maker.go
+++ b/app/widget_maker.go
@@ -163,7 +163,7 @@ func MakeWidget(
 		widget = nbascore.NewWidget(app, pages, settings)
 	case "newrelic":
 		settings := newrelic.NewSettingsFromYAML(moduleName, moduleConfig, config)
-		widget = newrelic.NewWidget(app, settings)
+		widget = newrelic.NewWidget(app, pages, settings)
 	case "opsgenie":
 		settings := opsgenie.NewSettingsFromYAML(moduleName, moduleConfig, config)
 		widget = opsgenie.NewWidget(app, settings)

--- a/modules/newrelic/display.go
+++ b/modules/newrelic/display.go
@@ -3,15 +3,15 @@ package newrelic
 import (
 	"fmt"
 
+	"github.com/wtfutil/wtf/utils"
 	"github.com/wtfutil/wtf/wtf"
 	nr "github.com/yfronto/newrelic"
 )
 
-func (widget *Widget) display() {
+func (widget *Widget) content() (string, string, bool) {
 	client := widget.currentData()
 	if client == nil {
-		widget.Redraw(widget.CommonSettings.Title, " NewRelic data unavailable ", false)
-		return
+		return widget.CommonSettings().Title, " NewRelic data unavailable ", false
 	}
 	app, appErr := client.Application()
 	deploys, depErr := client.Deployments()
@@ -22,7 +22,7 @@ func (widget *Widget) display() {
 	}
 
 	var content string
-	title := fmt.Sprintf("%s - [green]%s[white]", widget.CommonSettings.Title, appName)
+	title := fmt.Sprintf("%s - [green]%s[white]", widget.CommonSettings().Title, appName)
 	wrap := false
 	if depErr != nil {
 		wrap = true
@@ -31,7 +31,7 @@ func (widget *Widget) display() {
 		content = widget.contentFrom(deploys)
 	}
 
-	widget.Redraw(title, content, wrap)
+	return title, content, wrap
 }
 
 func (widget *Widget) contentFrom(deploys []nr.ApplicationDeployment) string {
@@ -43,7 +43,7 @@ func (widget *Widget) contentFrom(deploys []nr.ApplicationDeployment) string {
 	revisions := []string{}
 
 	for _, deploy := range deploys {
-		if (deploy.Revision != "") && wtf.Exclude(revisions, deploy.Revision) {
+		if (deploy.Revision != "") && utils.DoesNotInclude(revisions, deploy.Revision) {
 			lineColor := "white"
 			if wtf.IsToday(deploy.Timestamp) {
 				lineColor = "lightblue"
@@ -59,7 +59,7 @@ func (widget *Widget) contentFrom(deploys []nr.ApplicationDeployment) string {
 				deploy.Revision[0:revLen],
 				lineColor,
 				deploy.Timestamp.Format("Jan 02 15:04 MST"),
-				wtf.NameFromEmail(deploy.User),
+				utils.NameFromEmail(deploy.User),
 			)
 
 			revisions = append(revisions, deploy.Revision)

--- a/modules/newrelic/display.go
+++ b/modules/newrelic/display.go
@@ -1,0 +1,74 @@
+package newrelic
+
+import (
+	"fmt"
+
+	"github.com/wtfutil/wtf/wtf"
+	nr "github.com/yfronto/newrelic"
+)
+
+func (widget *Widget) display() {
+	client := widget.currentData()
+	if client == nil {
+		widget.Redraw(widget.CommonSettings.Title, " NewRelic data unavailable ", false)
+		return
+	}
+	app, appErr := client.Application()
+	deploys, depErr := client.Deployments()
+
+	appName := "error"
+	if appErr == nil {
+		appName = app.Name
+	}
+
+	var content string
+	title := fmt.Sprintf("%s - [green]%s[white]", widget.CommonSettings.Title, appName)
+	wrap := false
+	if depErr != nil {
+		wrap = true
+		content = depErr.Error()
+	} else {
+		content = widget.contentFrom(deploys)
+	}
+
+	widget.Redraw(title, content, wrap)
+}
+
+func (widget *Widget) contentFrom(deploys []nr.ApplicationDeployment) string {
+	str := fmt.Sprintf(
+		" %s\n",
+		"[red]Latest Deploys[white]",
+	)
+
+	revisions := []string{}
+
+	for _, deploy := range deploys {
+		if (deploy.Revision != "") && wtf.Exclude(revisions, deploy.Revision) {
+			lineColor := "white"
+			if wtf.IsToday(deploy.Timestamp) {
+				lineColor = "lightblue"
+			}
+
+			revLen := 8
+			if revLen > len(deploy.Revision) {
+				revLen = len(deploy.Revision)
+			}
+
+			str += fmt.Sprintf(
+				" [green]%s[%s] %s %-.16s[white]\n",
+				deploy.Revision[0:revLen],
+				lineColor,
+				deploy.Timestamp.Format("Jan 02 15:04 MST"),
+				wtf.NameFromEmail(deploy.User),
+			)
+
+			revisions = append(revisions, deploy.Revision)
+
+			if len(revisions) == widget.settings.deployCount {
+				break
+			}
+		}
+	}
+
+	return str
+}

--- a/modules/newrelic/keyboard.go
+++ b/modules/newrelic/keyboard.go
@@ -1,0 +1,9 @@
+package newrelic
+
+import "github.com/gdamore/tcell"
+
+func (widget *Widget) initializeKeyboardControls() {
+	widget.SetKeyboardChar("/", widget.ShowHelp, "Show/hide this help window")
+	widget.SetKeyboardKey(tcell.KeyLeft, widget.PrevSource, "Select previous application")
+	widget.SetKeyboardKey(tcell.KeyRight, widget.NextSource, "Select next application")
+}

--- a/modules/newrelic/settings.go
+++ b/modules/newrelic/settings.go
@@ -12,9 +12,9 @@ const defaultTitle = "NewRelic"
 type Settings struct {
 	common *cfg.Common
 
-	apiKey        string `help:"Your New Relic API token."`
-	applicationID int    `help:"The integer ID of the New Relic application you wish to report on."`
-	deployCount   int    `help:"The number of past deploys to display on screen." optional:"true"`
+	apiKey         string        `help:"Your New Relic API token."`
+	deployCount    int           `help:"The number of past deploys to display on screen." optional:"true"`
+	applicationIDs []interface{} `help:"The integer ID of the New Relic application you wish to report on."`
 }
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
@@ -22,9 +22,9 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	settings := Settings{
 		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
 
-		apiKey:        ymlConfig.UString("apiKey", ymlConfig.UString("apikey", os.Getenv("WTF_NEW_RELIC_API_KEY"))),
-		applicationID: ymlConfig.UInt("applicationID"),
-		deployCount:   ymlConfig.UInt("deployCount", 5),
+		apiKey:         ymlConfig.UString("apiKey", os.Getenv("WTF_NEW_RELIC_API_KEY")),
+		deployCount:    ymlConfig.UInt("deployCount", 5),
+		applicationIDs: ymlConfig.UList("applicationIDs"),
 	}
 
 	return &settings


### PR DESCRIPTION
This is a rebased/minimally fixed version of #472

Changes are:
Move client config to widget setup. This means clients are initialized once, and if config is updated, we are recreating widgets, so this is should be 'fine'.
Standard keyboard config
Should still support `applicationID` vs `applicationIDs`