### PR TITLE
fix: lint GitHub module, fix visual icon bug 

### DIFF
--- a/modules/github/display.go
+++ b/modules/github/display.go
@@ -131,7 +131,7 @@ func (widget *Widget) title(repo *GithubRepo) string {
 }
 
 var mergeIcons = map[string]string{
-	"dirty":    "[red]![white] ",
+	"dirty":    "[red]\u0021[white] ",
 	"clean":    "[green]\u2713[white] ",
 	"unstable": "[red]\u274C[white] ",
 	"blocked":  "[red]\u274C[white] ",

--- a/modules/github/display.go
+++ b/modules/github/display.go
@@ -61,7 +61,7 @@ func (widget *Widget) displayMyPullRequests(repo *GithubRepo, username string) s
 
 	str := ""
 	for idx, pr := range prs {
-		str += fmt.Sprintf(` %s[green]["%d"]%4d[""][white] %s`, widget.mergeString(pr), maxItems + idx, *pr.Number, *pr.Title)
+		str += fmt.Sprintf(` %s[green]["%d"]%4d[""][white] %s`, widget.mergeString(pr), maxItems+idx, *pr.Number, *pr.Title)
 		str += "\n"
 		widget.Items = append(widget.Items, *pr.Number)
 	}
@@ -73,22 +73,22 @@ func (widget *Widget) displayMyPullRequests(repo *GithubRepo, username string) s
 
 func (widget *Widget) displayCustomQuery(repo *GithubRepo, filter string, perPage int) string {
 	res := repo.customIssueQuery(filter, perPage)
-	
+
 	if res == nil {
 		return " [grey]Invalid Query[white]\n"
 	}
 
 	issuesLength := len(res.Issues)
-	
+
 	if issuesLength == 0 {
 		return " [grey]none[white]\n"
 	}
-	
+
 	maxItems := widget.GetItemCount()
 
 	str := ""
 	for idx, issue := range res.Issues {
-		str += fmt.Sprintf(` [green]["%d"]%4d[""][white] %s`, maxItems + idx , *issue.Number, *issue.Title)
+		str += fmt.Sprintf(` [green]["%d"]%4d[""][white] %s`, maxItems+idx, *issue.Number, *issue.Title)
 		str += "\n"
 		widget.Items = append(widget.Items, *issue.Number)
 	}
@@ -132,9 +132,9 @@ func (widget *Widget) title(repo *GithubRepo) string {
 
 var mergeIcons = map[string]string{
 	"dirty":    "[red]![white] ",
-	"clean":    "[green]✔[white] ",
-	"unstable": "[red]✖[white] ",
-	"blocked":  "[red]✖[white] ",
+	"clean":    "[green]\u2713[white] ",
+	"unstable": "[red]\u274C[white] ",
+	"blocked":  "[red]\u274C[white] ",
 }
 
 func (widget *Widget) mergeString(pr *github.PullRequest) string {

--- a/modules/github/github_repo.go
+++ b/modules/github/github_repo.go
@@ -10,6 +10,7 @@ import (
 	"golang.org/x/oauth2"
 )
 
+// GithubRepo defines a new GithubRepo structure
 type GithubRepo struct {
 	apiKey    string
 	baseURL   string
@@ -22,6 +23,7 @@ type GithubRepo struct {
 	Err          error
 }
 
+// NewGithubRepo returns a new Github Repo with a name, owner, apiKey, baseURL and uploadURL
 func NewGithubRepo(name, owner, apiKey, baseURL, uploadURL string) *GithubRepo {
 	repo := GithubRepo{
 		Name:  name,
@@ -35,6 +37,7 @@ func NewGithubRepo(name, owner, apiKey, baseURL, uploadURL string) *GithubRepo {
 	return &repo
 }
 
+// Open will open the GitHub Repo URL using the utils helper
 func (repo *GithubRepo) Open() {
 	utils.OpenFile(*repo.RemoteRepo.HTMLURL)
 }
@@ -54,6 +57,7 @@ func (repo *GithubRepo) Refresh() {
 
 /* -------------------- Counts -------------------- */
 
+// IssueCount return the total amount of issues as an int
 func (repo *GithubRepo) IssueCount() int {
 	if repo.RemoteRepo == nil {
 		return 0
@@ -62,10 +66,12 @@ func (repo *GithubRepo) IssueCount() int {
 	return *repo.RemoteRepo.OpenIssuesCount
 }
 
+// PullRequestCount returns the total amount of pull requests as an int
 func (repo *GithubRepo) PullRequestCount() int {
 	return len(repo.PullRequests)
 }
 
+// StarCount returns the total amount of stars this repo has gained as an int
 func (repo *GithubRepo) StarCount() int {
 	if repo.RemoteRepo == nil {
 		return 0

--- a/modules/github/settings.go
+++ b/modules/github/settings.go
@@ -11,6 +11,7 @@ import (
 
 const defaultTitle = "GitHub"
 
+// Settings defines the configuration properties for this module
 type Settings struct {
 	common *cfg.Common
 
@@ -29,6 +30,7 @@ type customQuery struct {
 	perPage int    `help:"Number of issues to show"`
 }
 
+// NewSettingsFromYAML creates a new settings instance from a YAML config block
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{

--- a/modules/github/widget.go
+++ b/modules/github/widget.go
@@ -1,14 +1,15 @@
 package github
 
 import (
-	"strings"
 	"strconv"
+	"strings"
 
 	"github.com/rivo/tview"
 	"github.com/wtfutil/wtf/utils"
 	"github.com/wtfutil/wtf/view"
 )
 
+// Widget define wtf widget to register widget later
 type Widget struct {
 	view.MultiSourceWidget
 	view.KeyboardWidget
@@ -19,9 +20,10 @@ type Widget struct {
 	settings *Settings
 	Selected int
 	maxItems int
-	Items	[]int
+	Items    []int
 }
 
+// NewWidget creates a new instance of the widget
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
 		KeyboardWidget:    view.NewKeyboardWidget(app, pages, settings.common),
@@ -48,14 +50,18 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 }
 
 /* -------------------- Exported Functions -------------------- */
+
+// SetItemCount sets the amount of PRs RRs and other PRs throughout the widgets display creation
 func (widget *Widget) SetItemCount(items int) {
 	widget.maxItems = items
 }
 
+// GetItemCount returns the amount of PRs RRs and other PRs calculated so far as an int
 func (widget *Widget) GetItemCount() int {
 	return widget.maxItems
 }
 
+// GetSelected returns the index of the currently highlighted item as an int
 func (widget *Widget) GetSelected() int {
 	if widget.Selected < 0 {
 		return 0
@@ -63,6 +69,7 @@ func (widget *Widget) GetSelected() int {
 	return widget.Selected
 }
 
+// Next cycles the currently highlighted text down
 func (widget *Widget) Next() {
 	widget.Selected++
 	if widget.Selected >= widget.maxItems {
@@ -71,6 +78,7 @@ func (widget *Widget) Next() {
 	widget.View.Highlight(strconv.Itoa(widget.Selected)).ScrollToHighlight()
 }
 
+// Prev cycles the currently highlighted text up
 func (widget *Widget) Prev() {
 	widget.Selected--
 	if widget.Selected < 0 {
@@ -79,12 +87,14 @@ func (widget *Widget) Prev() {
 	widget.View.Highlight(strconv.Itoa(widget.Selected)).ScrollToHighlight()
 }
 
+// Unselect stops highlighting the text and jumps the scroll position to the top
 func (widget *Widget) Unselect() {
 	widget.Selected = -1
 	widget.View.Highlight()
 	widget.View.ScrollToBeginning()
 }
 
+// Refresh reloads the github data via the Github API and reruns the display
 func (widget *Widget) Refresh() {
 	for _, repo := range widget.GithubRepos {
 		repo.Refresh()
@@ -93,6 +103,7 @@ func (widget *Widget) Refresh() {
 	widget.display()
 }
 
+// HelpText displays the widgets controls
 func (widget *Widget) HelpText() string {
 	return widget.KeyboardWidget.HelpText()
 }


### PR DESCRIPTION
This PR has linted the GitHub module and fixed an issue where the icons representing the mergeable status of a PR would sometimes show random characters. This was mainly down to the way the icon was references, now referencing with unicode. I don't think terminals/go/tview likes the unicode icon \u2314 so am using \u2313 to represent a tick.

Also let me know if this is the correct kind of comments to put above exported functions