### PR TITLE
fix: reducing the size of the cross

### DIFF
--- a/modules/github/display.go
+++ b/modules/github/display.go
@@ -133,8 +133,8 @@ func (widget *Widget) title(repo *GithubRepo) string {
 var mergeIcons = map[string]string{
 	"dirty":    "[red]\u0021[white] ",
 	"clean":    "[green]\u2713[white] ",
-	"unstable": "[red]\u274C[white] ",
-	"blocked":  "[red]\u274C[white] ",
+	"unstable": "[red]\u2717[white] ",
+	"blocked":  "[red]\u2717[white] ",
 }
 
 func (widget *Widget) mergeString(pr *github.PullRequest) string {


### PR DESCRIPTION
My bad, after having a dirty PR I noticed the size of the cross was way out of wack, chose a different unicode that is a clean size, also tested the exclamation mark too