### PR TITLE
WTF-566 Support GitLab projects as list

### DIFF
--- a/cfg/parsers.go
+++ b/cfg/parsers.go
@@ -1,0 +1,28 @@
+package cfg
+
+import (
+	"fmt"
+
+	"github.com/olebedev/config"
+)
+
+// ParseAsMapOrList takes a configuration key and attempts to parse it first as a map
+// and then as a list. Map entries are concatenated as "key/value"
+func ParseAsMapOrList(ymlConfig *config.Config, configKey string) []string {
+	result := []string{}
+
+	mapItems, err := ymlConfig.Map(configKey)
+	if err == nil {
+		for key, value := range mapItems {
+			result = append(result, fmt.Sprintf("%s/%s", value, key))
+		}
+		return result
+	}
+
+	listItems := ymlConfig.UList(configKey)
+	for _, listItem := range listItems {
+		result = append(result, listItem.(string))
+	}
+
+	return result
+}

--- a/cfg/parsers_test.go
+++ b/cfg/parsers_test.go
@@ -1,0 +1,50 @@
+package cfg
+
+import (
+	"testing"
+
+	"github.com/olebedev/config"
+)
+
+func Test_ParseAsMapOrList(t *testing.T) {
+	tests := []struct {
+		name          string
+		configKey     string
+		yaml          string
+		expectedCount int
+	}{
+		{
+			name:          "as empty set",
+			configKey:     "data",
+			yaml:          "",
+			expectedCount: 0,
+		},
+		{
+			name:          "as map",
+			configKey:     "data",
+			yaml:          "data:\n  a: cat\n  b: dog",
+			expectedCount: 2,
+		},
+		{
+			name:          "as list",
+			configKey:     "data",
+			yaml:          "data:\n  - cat\n  - dog\n  - rat\n",
+			expectedCount: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ymlConfig, err := config.ParseYaml(tt.yaml)
+			if err != nil {
+				t.Errorf("\nexpected: no error\n     got: %v", err)
+			}
+
+			actual := ParseAsMapOrList(ymlConfig, tt.configKey)
+
+			if tt.expectedCount != len(actual) {
+				t.Errorf("\nexpected: %d\n     got: %d", tt.expectedCount, len(actual))
+			}
+		})
+	}
+}

--- a/modules/github/settings.go
+++ b/modules/github/settings.go
@@ -1,12 +1,10 @@
 package github
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/olebedev/config"
 	"github.com/wtfutil/wtf/cfg"
-	"github.com/wtfutil/wtf/utils"
 )
 
 const defaultTitle = "GitHub"
@@ -42,26 +40,13 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 		uploadURL:    ymlConfig.UString("uploadURL", os.Getenv("WTF_GITHUB_UPLOAD_URL")),
 		username:     ymlConfig.UString("username"),
 	}
-	settings.repositories = parseRepositories(ymlConfig)
+	settings.repositories = cfg.ParseAsMapOrList(ymlConfig, "repositories")
 	settings.customQueries = parseCustomQueries(ymlConfig)
 
 	return &settings
 }
 
-func parseRepositories(ymlConfig *config.Config) []string {
-
-	result := []string{}
-	repositories, err := ymlConfig.Map("repositories")
-	if err == nil {
-		for key, value := range repositories {
-			result = append(result, fmt.Sprintf("%s/%s", value, key))
-		}
-		return result
-	}
-
-	result = utils.ToStrs(ymlConfig.UList("repositories"))
-	return result
-}
+/* -------------------- Unexported Functions -------------------- */
 
 func parseCustomQueries(ymlConfig *config.Config) []customQuery {
 	result := []customQuery{}

--- a/modules/gitlab/display.go
+++ b/modules/gitlab/display.go
@@ -73,5 +73,5 @@ func (widget *Widget) displayStats(project *GitlabProject) string {
 }
 
 func (widget *Widget) title(project *GitlabProject) string {
-	return fmt.Sprintf("[green]%s [white]", project.Path)
+	return fmt.Sprintf("[green]%s [white]", project.path)
 }

--- a/modules/gitlab/gitlab_project.go
+++ b/modules/gitlab/gitlab_project.go
@@ -5,18 +5,17 @@ import (
 )
 
 type GitlabProject struct {
-	gitlab *glb.Client
-	Path   string
+	client *glb.Client
+	path   string
 
 	MergeRequests []*glb.MergeRequest
 	RemoteProject *glb.Project
 }
 
-func NewGitlabProject(name string, namespace string, gitlab *glb.Client) *GitlabProject {
-	path := namespace + "/" + name
+func NewGitlabProject(projectPath string, client *glb.Client) *GitlabProject {
 	project := GitlabProject{
-		gitlab: gitlab,
-		Path:   path,
+		client: client,
+		path:   projectPath,
 	}
 
 	return &project
@@ -73,7 +72,7 @@ func (project *GitlabProject) myApprovalRequests(username string) []*glb.MergeRe
 	mrs := []*glb.MergeRequest{}
 
 	for _, mr := range project.MergeRequests {
-		approvers, _, err := project.gitlab.MergeRequests.GetMergeRequestApprovals(project.Path, mr.IID)
+		approvers, _, err := project.client.MergeRequests.GetMergeRequestApprovals(project.path, mr.IID)
 		if err != nil {
 			continue
 		}
@@ -93,7 +92,7 @@ func (project *GitlabProject) loadMergeRequests() ([]*glb.MergeRequest, error) {
 		State: &state,
 	}
 
-	mrs, _, err := project.gitlab.MergeRequests.ListProjectMergeRequests(project.Path, &opts)
+	mrs, _, err := project.client.MergeRequests.ListProjectMergeRequests(project.path, &opts)
 
 	if err != nil {
 		return nil, err
@@ -103,7 +102,7 @@ func (project *GitlabProject) loadMergeRequests() ([]*glb.MergeRequest, error) {
 }
 
 func (project *GitlabProject) loadRemoteProject() (*glb.Project, error) {
-	projectsitory, _, err := project.gitlab.Projects.GetProject(project.Path, nil)
+	projectsitory, _, err := project.client.Projects.GetProject(project.path, nil)
 
 	if err != nil {
 		return nil, err

--- a/modules/gitlab/settings.go
+++ b/modules/gitlab/settings.go
@@ -9,25 +9,27 @@ import (
 
 const defaultTitle = "GitLab"
 
+// Settings defines the configuration properties for this module
 type Settings struct {
 	common *cfg.Common
 
-	apiKey   string                 `help:"A GitLab personal access token. Requires at least api access."`
-	domain   string                 `help:"Your GitLab corporate domain."`
-	projects map[string]interface{} `help:"A list of key/value pairs each describing a GitLab project to fetch data for." values:"Key: The name of the project. Value: The namespace of the project."`
-	username string                 `help:"Your GitLab username. Used to figure out which requests require your approval"`
+	apiKey   string   `help:"A GitLab personal access token. Requires at least api access."`
+	domain   string   `help:"Your GitLab corporate domain."`
+	projects []string `help:"A list of key/value pairs each describing a GitLab project to fetch data for." values:"Key: The name of the project. Value: The namespace of the project."`
+	username string   `help:"Your GitLab username. Used to figure out which requests require your approval"`
 }
 
+// NewSettingsFromYAML creates a new settings instance from a YAML config block
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
-
 	settings := Settings{
 		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
 
 		apiKey:   ymlConfig.UString("apiKey", ymlConfig.UString("apikey", os.Getenv("WTF_GITLAB_TOKEN"))),
 		domain:   ymlConfig.UString("domain"),
-		projects: ymlConfig.UMap("projects"),
 		username: ymlConfig.UString("username"),
 	}
+
+	settings.projects = cfg.ParseAsMapOrList(ymlConfig, "projects")
 
 	return &settings
 }

--- a/modules/gitlab/widget.go
+++ b/modules/gitlab/widget.go
@@ -61,11 +61,11 @@ func (widget *Widget) HelpText() string {
 
 /* -------------------- Unexported Functions -------------------- */
 
-func (widget *Widget) buildProjectCollection(projectData map[string]interface{}) []*GitlabProject {
+func (widget *Widget) buildProjectCollection(projectData []string) []*GitlabProject {
 	gitlabProjects := []*GitlabProject{}
 
-	for name, namespace := range projectData {
-		project := NewGitlabProject(name, namespace.(string), widget.gitlab)
+	for _, projectPath := range projectData {
+		project := NewGitlabProject(projectPath, widget.gitlab)
 		gitlabProjects = append(gitlabProjects, project)
 	}
 


### PR DESCRIPTION
Fixes #566 

Introduces `cfg.ParseAsMapOrList()` to extract out the common pattern from `github` and `gitlab`.