### PR TITLE
Disable the GOSUMDB in the compilation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,9 @@ If you want to run the build command from within your `$GOPATH`:
 # Set the Go proxy variable to GoCenter
 export GOPROXY="https://gocenter.io"
 
+# Disable the Go checksum database
+export GOSUMDB=off
+
 # Enable Go modules
 export GO111MODULE=on
 


### PR DESCRIPTION
With Go 1.13 the current instructions result in an error message

```
verifying github.com/golang/glog@v0.0.0-20170312005925-543a34c32e4d/go.mod: github.com/golang/glog@v0.0.0-20170312005925-543a34c32e4d/go.mod: reading https://sum.golang.org/lookup/github.com/golang/glog@v0.0.0-20170312005925-543a34c32e4d: 410 Gone
```

because Go tries to verify the module hashes against the public hash database.