### PR TITLE
Clean up cfg error handling a bit

### DIFF
--- a/app/wtf_app.go
+++ b/app/wtf_app.go
@@ -22,19 +22,17 @@ type WtfApp struct {
 	configFilePath string
 	display        *Display
 	focusTracker   FocusTracker
-	isCustomConfig bool
 	pages          *tview.Pages
 	validator      *ModuleValidator
 	widgets        []wtf.Wtfable
 }
 
 // NewWtfApp creates and returns an instance of WtfApp
-func NewWtfApp(app *tview.Application, config *config.Config, configFilePath string, isCustom bool) *WtfApp {
+func NewWtfApp(app *tview.Application, config *config.Config, configFilePath string) *WtfApp {
 	wtfApp := WtfApp{
 		app:            app,
 		config:         config,
 		configFilePath: configFilePath,
-		isCustomConfig: isCustom,
 		pages:          tview.NewPages(),
 	}
 
@@ -140,8 +138,8 @@ func (wtfApp *WtfApp) watchForConfigChanges() {
 			case <-watch.Event:
 				wtfApp.Stop()
 
-				config := cfg.LoadWtfConfigFile(wtfApp.configFilePath, wtfApp.isCustomConfig)
-				newApp := NewWtfApp(wtfApp.app, config, wtfApp.configFilePath, wtfApp.isCustomConfig)
+				config := cfg.LoadWtfConfigFile(wtfApp.configFilePath)
+				newApp := NewWtfApp(wtfApp.app, config, wtfApp.configFilePath)
 
 				newApp.Start()
 			case err := <-watch.Error:

--- a/cfg/config_files.go
+++ b/cfg/config_files.go
@@ -84,17 +84,12 @@ func WtfConfigDir() (string, error) {
 }
 
 // LoadWtfConfigFile loads the specified config file
-func LoadWtfConfigFile(filePath string, isCustomConfig bool) *config.Config {
+func LoadWtfConfigFile(filePath string) *config.Config {
 	absPath, _ := expandHomeDir(filePath)
 
 	cfg, err := config.ParseYamlFile(absPath)
 	if err != nil {
-		if isCustomConfig {
-			displayWtfCustomConfigFileLoadError(err)
-		} else {
-			displayWtfConfigFileLoadError(err)
-		}
-
+		displayWtfConfigFileLoadError(absPath, err)
 		os.Exit(1)
 	}
 

--- a/cfg/error_messages.go
+++ b/cfg/error_messages.go
@@ -42,19 +42,8 @@ func displayWtfConfigDirCreateError(err error) {
 	displayError(err)
 }
 
-func displayWtfConfigFileLoadError(err error) {
-	fmt.Printf("\n%s Could not load '%s'.\n", aurora.Red("ERROR"), aurora.Yellow(WtfConfigFile))
-	fmt.Println()
-	fmt.Println("This could mean one of two things:")
-	fmt.Println()
-	fmt.Printf("    1. Your %s file is missing. Check in %s to see if %s is there.\n", aurora.Yellow(WtfConfigFile), aurora.Yellow("~/.config/wtf/"), aurora.Yellow(WtfConfigFile))
-	fmt.Printf("    2. Your %s file has a syntax error. Try running it through http://www.yamllint.com to check for errors.\n", aurora.Yellow(WtfConfigFile))
-	fmt.Println()
-	displayError(err)
-}
-
-func displayWtfCustomConfigFileLoadError(err error) {
-	fmt.Printf("\n%s Could not load '%s'.\n", aurora.Red("ERROR"), aurora.Yellow(WtfConfigFile))
+func displayWtfConfigFileLoadError(path string, err error) {
+	fmt.Printf("\n%s Could not load '%s'.\n", aurora.Red("ERROR"), aurora.Yellow(path))
 	fmt.Println()
 	fmt.Println("This could mean one of two things:")
 	fmt.Println()

--- a/main.go
+++ b/main.go
@@ -55,7 +55,7 @@ func main() {
 	cfg.Initialize(hasCustom)
 
 	// Load the configuration file
-	config := cfg.LoadWtfConfigFile(flags.ConfigFilePath(), hasCustom)
+	config := cfg.LoadWtfConfigFile(flags.ConfigFilePath())
 	flags.RenderIf(version, config)
 
 	if flags.Profile {
@@ -68,7 +68,7 @@ func main() {
 
 	// Build the application
 	tviewApp = tview.NewApplication()
-	wtfApp := app.NewWtfApp(tviewApp, config, flags.Config, hasCustom)
+	wtfApp := app.NewWtfApp(tviewApp, config, flags.Config)
 	wtfApp.Start()
 
 	if err := tviewApp.Run(); err != nil {


### PR DESCRIPTION
Pass in the actual file being used, rather than hardcoded `config.yaml`
Differences between two error messages are not that distinct
Centralize on one and clean up all the `isCustomConfig` tracking