### PR TITLE
Add a focusable over-ride setting for modules

### DIFF
--- a/cfg/common_settings.go
+++ b/cfg/common_settings.go
@@ -57,7 +57,7 @@ type Common struct {
 	focusChar int `help:"Define one of the number keys as a short cut key to access the widget." optional:"true"`
 }
 
-func NewCommonSettingsFromModule(name, defaultTitle string, moduleConfig *config.Config, globalSettings *config.Config) *Common {
+func NewCommonSettingsFromModule(name, defaultTitle string, defaultFocusable bool, moduleConfig *config.Config, globalSettings *config.Config) *Common {
 	colorsConfig, _ := globalSettings.Get("wtf.colors")
 	sigilsPath := "wtf.sigils"
 
@@ -84,7 +84,7 @@ func NewCommonSettingsFromModule(name, defaultTitle string, moduleConfig *config
 
 		Bordered:        moduleConfig.UBool("border", true),
 		Enabled:         moduleConfig.UBool("enabled", false),
-		Focusable:       moduleConfig.UBool("focusable", false),
+		Focusable:       moduleConfig.UBool("focusable", defaultFocusable),
 		RefreshInterval: moduleConfig.UInt("refreshInterval", 300),
 		Title:           moduleConfig.UString("title", defaultTitle),
 		Config:          moduleConfig,

--- a/cfg/common_settings.go
+++ b/cfg/common_settings.go
@@ -49,6 +49,7 @@ type Common struct {
 
 	Bordered        bool   `help:"Whether or not the module should be displayed with a border." values:"true, false" optional:"true" default:"true"`
 	Enabled         bool   `help:"Whether or not this module is executed and if its data displayed onscreen." values:"true, false" optional:"true" default:"false"`
+	Focusable       bool   `help:"Whether or  not this module is focusable." values:"true, false" optional:"true" default:"false"`
 	RefreshInterval int    `help:"How often, in seconds, this module will update its data." values:"A positive integer, 0..n." optional:"true"`
 	Title           string `help:"The title string to show when displaying this module" optional:"true"`
 	Config          *config.Config
@@ -83,6 +84,7 @@ func NewCommonSettingsFromModule(name, defaultTitle string, moduleConfig *config
 
 		Bordered:        moduleConfig.UBool("border", true),
 		Enabled:         moduleConfig.UBool("enabled", false),
+		Focusable:       moduleConfig.UBool("focusable", false),
 		RefreshInterval: moduleConfig.UInt("refreshInterval", 300),
 		Title:           moduleConfig.UString("title", defaultTitle),
 		Config:          moduleConfig,

--- a/modules/azuredevops/settings.go
+++ b/modules/azuredevops/settings.go
@@ -7,7 +7,10 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const defaultTitle = "azuredevops"
+const (
+	defaultFocus = false
+	defaultTitle = "azuredevops"
+)
 
 // Settings defines the configuration options for this module
 type Settings struct {
@@ -23,7 +26,7 @@ type Settings struct {
 // NewSettingsFromYAML creates and returns an instance of Settings with configuration options populated
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocus, ymlConfig, globalConfig),
 
 		labelColor:  ymlConfig.UString("labelColor", "white"),
 		apiToken:    ymlConfig.UString("apiToken", os.Getenv("WTF_AZURE DEVOPS_API_TOKEN")),

--- a/modules/azuredevops/widget.go
+++ b/modules/azuredevops/widget.go
@@ -21,7 +21,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, settings.common, false),
+		TextWidget: view.NewTextWidget(app, settings.common),
 		settings:   settings,
 	}
 

--- a/modules/bamboohr/settings.go
+++ b/modules/bamboohr/settings.go
@@ -7,7 +7,10 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const defaultTitle = "BambooHR"
+const (
+	defaultFocusable = false
+	defaultTitle     = "BambooHR"
+)
 
 type Settings struct {
 	common *cfg.Common
@@ -18,7 +21,7 @@ type Settings struct {
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		apiKey:    ymlConfig.UString("apiKey", ymlConfig.UString("apikey", os.Getenv("WTF_BAMBOO_HR_TOKEN"))),
 		subdomain: ymlConfig.UString("subdomain", os.Getenv("WTF_BAMBOO_HR_SUBDOMAIN")),

--- a/modules/bamboohr/widget.go
+++ b/modules/bamboohr/widget.go
@@ -10,7 +10,7 @@ import (
 	"github.com/wtfutil/wtf/wtf"
 )
 
-const APIURI = "https://api.bamboohr.com/api/gateway.php"
+const apiURI = "https://api.bamboohr.com/api/gateway.php"
 
 type Widget struct {
 	view.TextWidget
@@ -21,7 +21,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, settings.common, false),
+		TextWidget: view.NewTextWidget(app, settings.common),
 
 		settings: settings,
 	}
@@ -33,7 +33,7 @@ func NewWidget(app *tview.Application, settings *Settings) *Widget {
 
 func (widget *Widget) Refresh() {
 	client := NewClient(
-		APIURI,
+		apiURI,
 		widget.settings.apiKey,
 		widget.settings.subdomain,
 	)

--- a/modules/bargraph/settings.go
+++ b/modules/bargraph/settings.go
@@ -5,7 +5,10 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const defaultTitle = "Bargraph"
+const (
+	defaultFocusable = false
+	defaultTitle     = "Bargraph"
+)
 
 type Settings struct {
 	common *cfg.Common
@@ -13,7 +16,7 @@ type Settings struct {
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 	}
 
 	return &settings

--- a/modules/bargraph/widget.go
+++ b/modules/bargraph/widget.go
@@ -12,8 +12,10 @@ import (
 	"github.com/wtfutil/wtf/view"
 )
 
-var started = false
-var ok = true
+var (
+	ok      = true
+	started = false
+)
 
 // Widget define wtf widget to register widget later
 type Widget struct {
@@ -25,7 +27,7 @@ type Widget struct {
 // NewWidget Make new instance of widget
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		BarGraph: view.NewBarGraph(app, "Sample Bar Graph", settings.common, false),
+		BarGraph: view.NewBarGraph(app, "Sample Bar Graph", settings.common),
 
 		app: app,
 	}

--- a/modules/circleci/settings.go
+++ b/modules/circleci/settings.go
@@ -7,7 +7,10 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const defaultTitle = "CircleCI"
+const (
+	defaultFocusable = false
+	defaultTitle     = "CircleCI"
+)
 
 type Settings struct {
 	common *cfg.Common
@@ -18,7 +21,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		apiKey: ymlConfig.UString("apiKey", ymlConfig.UString("apikey", os.Getenv("WTF_CIRCLE_API_KEY"))),
 	}

--- a/modules/circleci/widget.go
+++ b/modules/circleci/widget.go
@@ -16,7 +16,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, settings.common, false),
+		TextWidget: view.NewTextWidget(app, settings.common),
 		Client:     NewClient(settings.apiKey),
 
 		settings: settings,

--- a/modules/clocks/settings.go
+++ b/modules/clocks/settings.go
@@ -6,7 +6,10 @@ import (
 	"github.com/wtfutil/wtf/utils"
 )
 
-const defaultTitle = "Clocks"
+const (
+	defaultFocusable = false
+	defaultTitle     = "Clocks"
+)
 
 type colors struct {
 	rows struct {
@@ -26,9 +29,8 @@ type Settings struct {
 }
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
-
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		dateFormat: ymlConfig.UString("dateFormat", utils.SimpleDateFormat),
 		timeFormat: ymlConfig.UString("timeFormat", utils.SimpleTimeFormat),

--- a/modules/clocks/widget.go
+++ b/modules/clocks/widget.go
@@ -20,7 +20,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, settings.common, false),
+		TextWidget: view.NewTextWidget(app, settings.common),
 
 		app:        app,
 		settings:   settings,

--- a/modules/cmdrunner/settings.go
+++ b/modules/cmdrunner/settings.go
@@ -6,7 +6,10 @@ import (
 	"github.com/wtfutil/wtf/utils"
 )
 
-const defaultTitle = "CmdRunner"
+const (
+	defaultFocusable = false
+	defaultTitle     = "CmdRunner"
+)
 
 type Settings struct {
 	common *cfg.Common
@@ -18,7 +21,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, moduleConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, moduleConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, moduleConfig, globalConfig),
 
 		args: utils.ToStrs(moduleConfig.UList("args")),
 		cmd:  moduleConfig.UString("cmd"),

--- a/modules/cmdrunner/widget.go
+++ b/modules/cmdrunner/widget.go
@@ -21,7 +21,7 @@ type Widget struct {
 // NewWidget creates a new instance of the widget
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, settings.common, false),
+		TextWidget: view.NewTextWidget(app, settings.common),
 
 		args:     settings.args,
 		cmd:      settings.cmd,

--- a/modules/cryptoexchanges/bittrex/settings.go
+++ b/modules/cryptoexchanges/bittrex/settings.go
@@ -5,7 +5,10 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const defaultTitle = "Bittrex"
+const (
+	defaultFocusable = false
+	defaultTitle     = "Bittrex"
+)
 
 type colors struct {
 	base struct {
@@ -37,7 +40,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 	}
 
 	settings.colors.base.name = ymlConfig.UString("colors.base.name")

--- a/modules/cryptoexchanges/bittrex/widget.go
+++ b/modules/cryptoexchanges/bittrex/widget.go
@@ -11,10 +11,14 @@ import (
 	"github.com/wtfutil/wtf/view"
 )
 
-var ok = true
-var errorText = ""
+const (
+	baseURL = "https://bittrex.com/api/v1.1/public/getmarketsummary"
+)
 
-const baseURL = "https://bittrex.com/api/v1.1/public/getmarketsummary"
+var (
+	errorText = ""
+	ok        = true
+)
 
 // Widget define wtf widget to register widget later
 type Widget struct {
@@ -27,7 +31,7 @@ type Widget struct {
 // NewWidget Make new instance of widget
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, settings.common, false),
+		TextWidget: view.NewTextWidget(app, settings.common),
 
 		settings:    settings,
 		summaryList: summaryList{},

--- a/modules/cryptoexchanges/blockfolio/settings.go
+++ b/modules/cryptoexchanges/blockfolio/settings.go
@@ -5,7 +5,10 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const defaultTitle = "Blockfolio"
+const (
+	defaultFocusable = false
+	defaultTitle     = "Blockfolio"
+)
 
 type colors struct {
 	name  string
@@ -24,7 +27,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		deviceToken:     ymlConfig.UString("device_token"),
 		displayHoldings: ymlConfig.UBool("displayHoldings", true),

--- a/modules/cryptoexchanges/blockfolio/widget.go
+++ b/modules/cryptoexchanges/blockfolio/widget.go
@@ -20,7 +20,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, settings.common, false),
+		TextWidget: view.NewTextWidget(app, settings.common),
 
 		device_token: settings.deviceToken,
 		settings:     settings,

--- a/modules/cryptoexchanges/cryptolive/price/settings.go
+++ b/modules/cryptoexchanges/cryptolive/price/settings.go
@@ -5,7 +5,10 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const defaultTitle = "CryptoLive"
+const (
+	defaultFocusable = false
+	defaultTitle     = "CryptoLive"
+)
 
 type colors struct {
 	from struct {
@@ -43,7 +46,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 	}
 
 	settings.colors.from.name = ymlConfig.UString("colors.from.name")

--- a/modules/cryptoexchanges/cryptolive/settings.go
+++ b/modules/cryptoexchanges/cryptolive/settings.go
@@ -7,7 +7,10 @@ import (
 	"github.com/wtfutil/wtf/modules/cryptoexchanges/cryptolive/toplist"
 )
 
-const defaultTitle = "CryptolLive"
+const (
+	defaultFocusable = false
+	defaultTitle     = "CryptolLive"
+)
 
 type colors struct {
 	from struct {
@@ -43,12 +46,11 @@ type Settings struct {
 }
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
-
 	currencies, _ := ymlConfig.Map("currencies")
 	top, _ := ymlConfig.Map("top")
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		currencies: currencies,
 		top:        top,

--- a/modules/cryptoexchanges/cryptolive/toplist/settings.go
+++ b/modules/cryptoexchanges/cryptolive/toplist/settings.go
@@ -5,7 +5,10 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const defaultTitle = "CryptoLive"
+const (
+	defaultFocusable = false
+	defaultTitle     = "CryptoLive"
+)
 
 type colors struct {
 	from struct {
@@ -44,7 +47,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 	}
 
 	settings.colors.from.name = ymlConfig.UString("colors.from.name")

--- a/modules/cryptoexchanges/cryptolive/widget.go
+++ b/modules/cryptoexchanges/cryptolive/widget.go
@@ -22,7 +22,7 @@ type Widget struct {
 // NewWidget Make new instance of widget
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, settings.common, false),
+		TextWidget: view.NewTextWidget(app, settings.common),
 
 		priceWidget:   price.NewWidget(settings.priceSettings),
 		toplistWidget: toplist.NewWidget(settings.toplistSettings),

--- a/modules/datadog/settings.go
+++ b/modules/datadog/settings.go
@@ -7,7 +7,10 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const defaultTitle = "DataDog"
+const (
+	defaultFocusable = true
+	defaultTitle     = "DataDog"
+)
 
 type Settings struct {
 	common *cfg.Common
@@ -20,7 +23,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		apiKey:         ymlConfig.UString("apiKey", ymlConfig.UString("apikey", os.Getenv("WTF_DATADOG_API_KEY"))),
 		applicationKey: ymlConfig.UString("applicationKey", os.Getenv("WTF_DATADOG_APPLICATION_KEY")),

--- a/modules/datadog/widget.go
+++ b/modules/datadog/widget.go
@@ -21,7 +21,7 @@ type Widget struct {
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
 		KeyboardWidget:   view.NewKeyboardWidget(app, pages, settings.common),
-		ScrollableWidget: view.NewScrollableWidget(app, settings.common, true),
+		ScrollableWidget: view.NewScrollableWidget(app, settings.common),
 
 		settings: settings,
 	}

--- a/modules/devto/settings.go
+++ b/modules/devto/settings.go
@@ -6,7 +6,10 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const defaultTitle = "dev.to | News Feed"
+const (
+	defaultFocusable = true
+	defaultTitle     = "dev.to | News Feed"
+)
 
 // Settings defines the configuration options for this module
 type Settings struct {
@@ -21,7 +24,7 @@ type Settings struct {
 // NewSettingsFromYAML creates and returns an instance of Settings with configuration options populated
 func NewSettingsFromYAML(name string, yamlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := Settings{
-		common:           cfg.NewCommonSettingsFromModule(name, defaultTitle, yamlConfig, globalConfig),
+		common:           cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, yamlConfig, globalConfig),
 		numberOfArticles: yamlConfig.UInt("numberOfArticles", 10),
 		contentTag:       yamlConfig.UString("contentTag", ""),
 		contentUsername:  yamlConfig.UString("contentUsername", ""),

--- a/modules/devto/widget.go
+++ b/modules/devto/widget.go
@@ -22,7 +22,7 @@ type Widget struct {
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := &Widget{
 		KeyboardWidget:   view.NewKeyboardWidget(app, pages, settings.common),
-		ScrollableWidget: view.NewScrollableWidget(app, settings.common, true),
+		ScrollableWidget: view.NewScrollableWidget(app, settings.common),
 
 		settings: settings,
 	}

--- a/modules/digitalclock/settings.go
+++ b/modules/digitalclock/settings.go
@@ -5,7 +5,10 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const defaultTitle = "Clocks"
+const (
+	defaultFocusable = false
+	defaultTitle     = "Clocks"
+)
 
 // Settings struct to define settings got digital clock
 type Settings struct {
@@ -21,7 +24,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common:     cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
+		common:     cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 		color:      ymlConfig.UString("color"),
 		font:       ymlConfig.UString("font"),
 		hourFormat: ymlConfig.UString("hourFormat"),

--- a/modules/digitalclock/widget.go
+++ b/modules/digitalclock/widget.go
@@ -17,7 +17,7 @@ type Widget struct {
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, settings.common, false),
+		TextWidget: view.NewTextWidget(app, settings.common),
 
 		app:      app,
 		settings: settings,

--- a/modules/docker/settings.go
+++ b/modules/docker/settings.go
@@ -5,7 +5,10 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const defaultTitle = "docker"
+const (
+	defaultFocusable = false
+	defaultTitle     = "docker"
+)
 
 // Settings defines the configuration options for this module
 type Settings struct {
@@ -16,7 +19,7 @@ type Settings struct {
 // NewSettingsFromYAML creates and returns an instance of Settings with configuration options populated
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := Settings{
-		common:     cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
+		common:     cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 		labelColor: ymlConfig.UString("labelColor", "white"),
 	}
 

--- a/modules/docker/widget.go
+++ b/modules/docker/widget.go
@@ -16,7 +16,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, settings.common, false),
+		TextWidget: view.NewTextWidget(app, settings.common),
 		settings:   settings,
 	}
 

--- a/modules/feedreader/settings.go
+++ b/modules/feedreader/settings.go
@@ -7,7 +7,8 @@ import (
 )
 
 const (
-	defaultTitle = "Feed Reader"
+	defaultFocusable = true
+	defaultTitle     = "Feed Reader"
 )
 
 // Settings defines the configuration properties for this module
@@ -21,7 +22,7 @@ type Settings struct {
 // NewSettingsFromYAML creates a new settings instance from a YAML config block
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := &Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		feeds:     utils.ToStrs(ymlConfig.UList("feeds")),
 		feedLimit: ymlConfig.UInt("feedLimit", -1),

--- a/modules/feedreader/widget.go
+++ b/modules/feedreader/widget.go
@@ -36,7 +36,7 @@ type Widget struct {
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := &Widget{
 		KeyboardWidget:   view.NewKeyboardWidget(app, pages, settings.common),
-		ScrollableWidget: view.NewScrollableWidget(app, settings.common, true),
+		ScrollableWidget: view.NewScrollableWidget(app, settings.common),
 
 		parser:   gofeed.NewParser(),
 		settings: settings,

--- a/modules/gcal/settings.go
+++ b/modules/gcal/settings.go
@@ -5,7 +5,10 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const defaultTitle = "Calendar"
+const (
+	defaultFocusable = true
+	defaultTitle     = "Calendar"
+)
 
 type colors struct {
 	day         string
@@ -37,9 +40,8 @@ type Settings struct {
 
 // NewSettingsFromYAML creates and returns an instance of Settings with configuration options populated
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
-
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		conflictIcon:          ymlConfig.UString("conflictIcon", "🚨"),
 		currentIcon:           ymlConfig.UString("currentIcon", "🔸"),

--- a/modules/gcal/widget.go
+++ b/modules/gcal/widget.go
@@ -16,7 +16,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, settings.common, true),
+		TextWidget: view.NewTextWidget(app, settings.common),
 
 		app:      app,
 		settings: settings,

--- a/modules/gerrit/settings.go
+++ b/modules/gerrit/settings.go
@@ -7,14 +7,17 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
+const (
+	defaultFocusable = true
+	defaultTitle     = "Gerrit"
+)
+
 type colors struct {
 	rows struct {
 		even string `help:"Define the foreground color for even-numbered rows." values:"Any X11 color name." optional:"true"`
 		odd  string `help:"Define the foreground color for odd-numbered rows." values:"Any X11 color name." optional:"true"`
 	}
 }
-
-const defaultTitle = "Gerrit"
 
 type Settings struct {
 	colors
@@ -28,9 +31,8 @@ type Settings struct {
 }
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
-
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		domain:                  ymlConfig.UString("domain", ""),
 		password:                ymlConfig.UString("password", os.Getenv("WTF_GERRIT_PASSWORD")),

--- a/modules/gerrit/widget.go
+++ b/modules/gerrit/widget.go
@@ -33,7 +33,7 @@ var (
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
 		KeyboardWidget: view.NewKeyboardWidget(app, pages, settings.common),
-		TextWidget:     view.NewTextWidget(app, settings.common, true),
+		TextWidget:     view.NewTextWidget(app, settings.common),
 
 		Idx: 0,
 

--- a/modules/git/settings.go
+++ b/modules/git/settings.go
@@ -6,7 +6,10 @@ import (
 	"github.com/wtfutil/wtf/utils"
 )
 
-const defaultTitle = "Git"
+const (
+	defaultFocusable = true
+	defaultTitle     = "Git"
+)
 
 type Settings struct {
 	common *cfg.Common
@@ -18,9 +21,8 @@ type Settings struct {
 }
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
-
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		commitCount:  ymlConfig.UInt("commitCount", 10),
 		commitFormat: ymlConfig.UString("commitFormat", "[forestgreen]%h [white]%s [grey]%an on %cd[white]"),

--- a/modules/git/widget.go
+++ b/modules/git/widget.go
@@ -11,9 +11,11 @@ import (
 	"github.com/wtfutil/wtf/view"
 )
 
-const offscreen = -1000
-const modalWidth = 80
-const modalHeight = 7
+const (
+	modalHeight = 7
+	modalWidth  = 80
+	offscreen   = -1000
+)
 
 type Widget struct {
 	view.KeyboardWidget
@@ -31,7 +33,7 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 	widget := Widget{
 		KeyboardWidget:    view.NewKeyboardWidget(app, pages, settings.common),
 		MultiSourceWidget: view.NewMultiSourceWidget(settings.common, "repository", "repositories"),
-		TextWidget:        view.NewTextWidget(app, settings.common, true),
+		TextWidget:        view.NewTextWidget(app, settings.common),
 
 		app:      app,
 		pages:    pages,

--- a/modules/github/settings.go
+++ b/modules/github/settings.go
@@ -7,7 +7,10 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const defaultTitle = "GitHub"
+const (
+	defaultFocusable = true
+	defaultTitle     = "GitHub"
+)
 
 // Settings defines the configuration properties for this module
 type Settings struct {
@@ -30,9 +33,8 @@ type customQuery struct {
 
 // NewSettingsFromYAML creates a new settings instance from a YAML config block
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
-
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		apiKey:       ymlConfig.UString("apiKey", ymlConfig.UString("apikey", os.Getenv("WTF_GITHUB_TOKEN"))),
 		baseURL:      ymlConfig.UString("baseURL", os.Getenv("WTF_GITHUB_BASE_URL")),

--- a/modules/github/widget.go
+++ b/modules/github/widget.go
@@ -28,7 +28,7 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 	widget := Widget{
 		KeyboardWidget:    view.NewKeyboardWidget(app, pages, settings.common),
 		MultiSourceWidget: view.NewMultiSourceWidget(settings.common, "repository", "repositories"),
-		TextWidget:        view.NewTextWidget(app, settings.common, true),
+		TextWidget:        view.NewTextWidget(app, settings.common),
 
 		settings: settings,
 	}

--- a/modules/gitlab/settings.go
+++ b/modules/gitlab/settings.go
@@ -7,7 +7,10 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const defaultTitle = "GitLab"
+const (
+	defaultFocusable = true
+	defaultTitle     = "GitLab"
+)
 
 // Settings defines the configuration properties for this module
 type Settings struct {
@@ -22,7 +25,7 @@ type Settings struct {
 // NewSettingsFromYAML creates a new settings instance from a YAML config block
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		apiKey:   ymlConfig.UString("apiKey", ymlConfig.UString("apikey", os.Getenv("WTF_GITLAB_TOKEN"))),
 		domain:   ymlConfig.UString("domain"),

--- a/modules/gitlab/widget.go
+++ b/modules/gitlab/widget.go
@@ -28,7 +28,7 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 	widget := Widget{
 		KeyboardWidget:    view.NewKeyboardWidget(app, pages, settings.common),
 		MultiSourceWidget: view.NewMultiSourceWidget(settings.common, "repository", "repositories"),
-		TextWidget:        view.NewTextWidget(app, settings.common, true),
+		TextWidget:        view.NewTextWidget(app, settings.common),
 
 		gitlab:   gitlab,
 		settings: settings,

--- a/modules/gitter/settings.go
+++ b/modules/gitter/settings.go
@@ -7,7 +7,10 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const defaultTitle = "Gitter"
+const (
+	defaultFocusable = true
+	defaultTitle     = "Gitter"
+)
 
 type Settings struct {
 	common *cfg.Common
@@ -20,7 +23,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		apiToken:         ymlConfig.UString("apiToken", os.Getenv("WTF_GITTER_API_TOKEN")),
 		numberOfMessages: ymlConfig.UInt("numberOfMessages", 10),

--- a/modules/gitter/widget.go
+++ b/modules/gitter/widget.go
@@ -21,7 +21,7 @@ type Widget struct {
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
 		KeyboardWidget:   view.NewKeyboardWidget(app, pages, settings.common),
-		ScrollableWidget: view.NewScrollableWidget(app, settings.common, true),
+		ScrollableWidget: view.NewScrollableWidget(app, settings.common),
 
 		settings: settings,
 	}

--- a/modules/googleanalytics/settings.go
+++ b/modules/googleanalytics/settings.go
@@ -5,7 +5,10 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const defaultTitle = "Google Analytics"
+const (
+	defaultFocusable = false
+	defaultTitle     = "Google Analytics"
+)
 
 type Settings struct {
 	common *cfg.Common
@@ -19,7 +22,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		months:         ymlConfig.UInt("months"),
 		secretFile:     ymlConfig.UString("secretFile"),

--- a/modules/googleanalytics/widget.go
+++ b/modules/googleanalytics/widget.go
@@ -13,7 +13,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, settings.common, false),
+		TextWidget: view.NewTextWidget(app, settings.common),
 
 		settings: settings,
 	}

--- a/modules/gspreadsheets/settings.go
+++ b/modules/gspreadsheets/settings.go
@@ -5,7 +5,10 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const defaultTitle = "Google Spreadsheets"
+const (
+	defaultFocusable = false
+	defaultTitle     = "Google Spreadsheets"
+)
 
 type colors struct {
 	values string
@@ -24,7 +27,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		cellNames:  ymlConfig.UList("cells.names"),
 		secretFile: ymlConfig.UString("secretFile"),

--- a/modules/gspreadsheets/widget.go
+++ b/modules/gspreadsheets/widget.go
@@ -19,7 +19,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, settings.common, false),
+		TextWidget: view.NewTextWidget(app, settings.common),
 
 		settings: settings,
 	}

--- a/modules/hackernews/settings.go
+++ b/modules/hackernews/settings.go
@@ -5,7 +5,10 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const defaultTitle = "HackerNews"
+const (
+	defaultFocusable = true
+	defaultTitle     = "HackerNews"
+)
 
 type Settings struct {
 	common *cfg.Common
@@ -17,7 +20,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		numberOfStories: ymlConfig.UInt("numberOfStories", 10),
 		storyType:       ymlConfig.UString("storyType", "top"),

--- a/modules/hackernews/widget.go
+++ b/modules/hackernews/widget.go
@@ -22,7 +22,7 @@ type Widget struct {
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := &Widget{
 		KeyboardWidget:   view.NewKeyboardWidget(app, pages, settings.common),
-		ScrollableWidget: view.NewScrollableWidget(app, settings.common, true),
+		ScrollableWidget: view.NewScrollableWidget(app, settings.common),
 
 		settings: settings,
 	}

--- a/modules/hibp/settings.go
+++ b/modules/hibp/settings.go
@@ -10,6 +10,7 @@ import (
 )
 
 const (
+	defaultFocusable   = false
 	defaultTitle       = "HIBP"
 	minRefreshInterval = 21600 // Six hours
 )
@@ -32,7 +33,7 @@ type Settings struct {
 // NewSettingsFromYAML creates a new settings instance from a YAML config block
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := &Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		apiKey:   ymlConfig.UString("apiKey", ymlConfig.UString("apikey", os.Getenv("WTF_HIBP_TOKEN"))),
 		accounts: utils.ToStrs(ymlConfig.UList("accounts")),

--- a/modules/hibp/widget.go
+++ b/modules/hibp/widget.go
@@ -19,7 +19,7 @@ type Widget struct {
 // NewWidget creates a new instance of a widget
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := &Widget{
-		TextWidget: view.NewTextWidget(app, settings.common, false),
+		TextWidget: view.NewTextWidget(app, settings.common),
 
 		settings: settings,
 	}

--- a/modules/ipaddresses/ipapi/settings.go
+++ b/modules/ipaddresses/ipapi/settings.go
@@ -5,7 +5,10 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const defaultTitle = "IP API"
+const (
+	defaultFocusable = false
+	defaultTitle     = "IP API"
+)
 
 type colors struct {
 	name  string
@@ -20,7 +23,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 	}
 
 	settings.colors.name = ymlConfig.UString("colors.name", "red")

--- a/modules/ipaddresses/ipapi/widget.go
+++ b/modules/ipaddresses/ipapi/widget.go
@@ -38,7 +38,7 @@ type ipinfo struct {
 // NewWidget constructor
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, settings.common, false),
+		TextWidget: view.NewTextWidget(app, settings.common),
 
 		settings: settings,
 	}

--- a/modules/ipaddresses/ipinfo/settings.go
+++ b/modules/ipaddresses/ipinfo/settings.go
@@ -5,7 +5,10 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const defaultTitle = "IPInfo"
+const (
+	defaultFocusable = false
+	defaultTitle     = "IPInfo"
+)
 
 type colors struct {
 	name  string
@@ -20,7 +23,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 	}
 
 	settings.colors.name = ymlConfig.UString("colors.name", "red")

--- a/modules/ipaddresses/ipinfo/widget.go
+++ b/modules/ipaddresses/ipinfo/widget.go
@@ -31,7 +31,7 @@ type ipinfo struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, settings.common, false),
+		TextWidget: view.NewTextWidget(app, settings.common),
 
 		settings: settings,
 	}

--- a/modules/jenkins/settings.go
+++ b/modules/jenkins/settings.go
@@ -7,7 +7,10 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const defaultTitle = "Jenkins"
+const (
+	defaultFocusable = true
+	defaultTitle     = "Jenkins"
+)
 
 type Settings struct {
 	common *cfg.Common
@@ -23,7 +26,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		apiKey:                  ymlConfig.UString("apiKey", ymlConfig.UString("apikey", os.Getenv("WTF_JENKINS_API_KEY"))),
 		jobNameRegex:            ymlConfig.UString("jobNameRegex", ".*"),

--- a/modules/jenkins/widget.go
+++ b/modules/jenkins/widget.go
@@ -20,7 +20,7 @@ type Widget struct {
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
 		KeyboardWidget:   view.NewKeyboardWidget(app, pages, settings.common),
-		ScrollableWidget: view.NewScrollableWidget(app, settings.common, true),
+		ScrollableWidget: view.NewScrollableWidget(app, settings.common),
 
 		settings: settings,
 	}

--- a/modules/jira/settings.go
+++ b/modules/jira/settings.go
@@ -7,7 +7,10 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const defaultTitle = "Jira"
+const (
+	defaultFocusable = true
+	defaultTitle     = "Jira"
+)
 
 type colors struct {
 	rows struct {
@@ -32,7 +35,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		apiKey:                  ymlConfig.UString("apiKey", ymlConfig.UString("apikey", os.Getenv("WTF_JIRA_API_KEY"))),
 		domain:                  ymlConfig.UString("domain"),

--- a/modules/jira/widget.go
+++ b/modules/jira/widget.go
@@ -19,7 +19,7 @@ type Widget struct {
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
 		KeyboardWidget:   view.NewKeyboardWidget(app, pages, settings.common),
-		ScrollableWidget: view.NewScrollableWidget(app, settings.common, true),
+		ScrollableWidget: view.NewScrollableWidget(app, settings.common),
 
 		settings: settings,
 	}

--- a/modules/kubernetes/settings.go
+++ b/modules/kubernetes/settings.go
@@ -6,7 +6,10 @@ import (
 	"github.com/wtfutil/wtf/utils"
 )
 
-const defaultTitle = "Kubernetes"
+const (
+	defaultFocusable = false
+	defaultTitle     = "Kubernetes"
+)
 
 type Settings struct {
 	common *cfg.Common
@@ -20,7 +23,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, moduleConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, moduleConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, moduleConfig, globalConfig),
 
 		objects:    utils.ToStrs(moduleConfig.UList("objects")),
 		title:      moduleConfig.UString("title"),

--- a/modules/kubernetes/widget.go
+++ b/modules/kubernetes/widget.go
@@ -24,7 +24,7 @@ type Widget struct {
 // NewWidget creates a new instance of the widget
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, settings.common, false),
+		TextWidget: view.NewTextWidget(app, settings.common),
 
 		objects:    settings.objects,
 		title:      settings.title,

--- a/modules/logger/settings.go
+++ b/modules/logger/settings.go
@@ -5,7 +5,10 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const defaultTitle = "Logger"
+const (
+	defaultFocusable = true
+	defaultTitle     = "Logger"
+)
 
 type Settings struct {
 	common *cfg.Common
@@ -13,7 +16,7 @@ type Settings struct {
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 	}
 
 	return &settings

--- a/modules/logger/widget.go
+++ b/modules/logger/widget.go
@@ -10,7 +10,9 @@ import (
 	"github.com/wtfutil/wtf/view"
 )
 
-const maxBufferSize int64 = 1024
+const (
+	maxBufferSize int64 = 1024
+)
 
 type Widget struct {
 	view.TextWidget
@@ -22,7 +24,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, settings.common, true),
+		TextWidget: view.NewTextWidget(app, settings.common),
 
 		app:      app,
 		filePath: log.LogFilePath(),

--- a/modules/mercurial/settings.go
+++ b/modules/mercurial/settings.go
@@ -5,7 +5,10 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const defaultTitle = "Mercurial"
+const (
+	defaultFocusable = true
+	defaultTitle     = "Mercurial"
+)
 
 type Settings struct {
 	common *cfg.Common
@@ -18,7 +21,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		commitCount:  ymlConfig.UInt("commitCount", 10),
 		commitFormat: ymlConfig.UString("commitFormat", "[forestgreen]{rev}:{phase} [white]{desc|firstline|strip} [grey]{author|person} {date|age}[white]"),

--- a/modules/mercurial/widget.go
+++ b/modules/mercurial/widget.go
@@ -7,9 +7,11 @@ import (
 	"github.com/wtfutil/wtf/view"
 )
 
-const offscreen = -1000
-const modalWidth = 80
-const modalHeight = 7
+const (
+	modalHeight = 7
+	modalWidth  = 80
+	offscreen   = -1000
+)
 
 // A Widget represents a Mercurial widget
 type Widget struct {
@@ -28,7 +30,7 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 	widget := Widget{
 		KeyboardWidget:    view.NewKeyboardWidget(app, pages, settings.common),
 		MultiSourceWidget: view.NewMultiSourceWidget(settings.common, "repository", "repositories"),
-		TextWidget:        view.NewTextWidget(app, settings.common, true),
+		TextWidget:        view.NewTextWidget(app, settings.common),
 
 		app:      app,
 		pages:    pages,

--- a/modules/nbascore/settings.go
+++ b/modules/nbascore/settings.go
@@ -5,7 +5,10 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const defaultTitle = "NBA Score"
+const (
+	defaultFocusable = true
+	defaultTitle     = "NBA Score"
+)
 
 type Settings struct {
 	common *cfg.Common
@@ -13,7 +16,7 @@ type Settings struct {
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 	}
 
 	return &settings

--- a/modules/nbascore/widget.go
+++ b/modules/nbascore/widget.go
@@ -13,6 +13,8 @@ import (
 	"github.com/wtfutil/wtf/view"
 )
 
+var offset = 0
+
 // A Widget represents an NBA Score  widget
 type Widget struct {
 	view.KeyboardWidget
@@ -23,13 +25,11 @@ type Widget struct {
 	settings *Settings
 }
 
-var offset = 0
-
 // NewWidget creates a new instance of a widget
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
 		KeyboardWidget: view.NewKeyboardWidget(app, pages, settings.common),
-		TextWidget:     view.NewTextWidget(app, settings.common, true),
+		TextWidget:     view.NewTextWidget(app, settings.common),
 
 		settings: settings,
 	}

--- a/modules/newrelic/settings.go
+++ b/modules/newrelic/settings.go
@@ -7,7 +7,10 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const defaultTitle = "NewRelic"
+const (
+	defaultFocusable = true
+	defaultTitle     = "NewRelic"
+)
 
 type Settings struct {
 	common *cfg.Common
@@ -20,7 +23,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		apiKey:         ymlConfig.UString("apiKey", os.Getenv("WTF_NEW_RELIC_API_KEY")),
 		deployCount:    ymlConfig.UInt("deployCount", 5),

--- a/modules/newrelic/widget.go
+++ b/modules/newrelic/widget.go
@@ -22,7 +22,7 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 	widget := Widget{
 		KeyboardWidget:    view.NewKeyboardWidget(app, pages, settings.common),
 		MultiSourceWidget: view.NewMultiSourceWidget(settings.common, "applicationID", "applicationIDs"),
-		TextWidget:        view.NewTextWidget(app, settings.common, true),
+		TextWidget:        view.NewTextWidget(app, settings.common),
 
 		settings: settings,
 	}

--- a/modules/opsgenie/settings.go
+++ b/modules/opsgenie/settings.go
@@ -7,7 +7,10 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const defaultTitle = "OpsGenie"
+const (
+	defaultFocusable = false
+	defaultTitle     = "OpsGenie"
+)
 
 type Settings struct {
 	common *cfg.Common
@@ -22,7 +25,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		apiKey:                 ymlConfig.UString("apiKey", ymlConfig.UString("apikey", os.Getenv("WTF_OPS_GENIE_API_KEY"))),
 		region:                 ymlConfig.UString("region", "us"),

--- a/modules/opsgenie/widget.go
+++ b/modules/opsgenie/widget.go
@@ -17,7 +17,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, settings.common, false),
+		TextWidget: view.NewTextWidget(app, settings.common),
 
 		settings: settings,
 	}

--- a/modules/pagerduty/settings.go
+++ b/modules/pagerduty/settings.go
@@ -7,7 +7,10 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const defaultTitle = "PagerDuty"
+const (
+	defaultFocusable = false
+	defaultTitle     = "PagerDuty"
+)
 
 type Settings struct {
 	common *cfg.Common
@@ -22,7 +25,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		apiKey:           ymlConfig.UString("apiKey", ymlConfig.UString("apikey", os.Getenv("WTF_PAGERDUTY_API_KEY"))),
 		escalationFilter: ymlConfig.UList("escalationFilter"),

--- a/modules/pagerduty/widget.go
+++ b/modules/pagerduty/widget.go
@@ -18,7 +18,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, settings.common, false),
+		TextWidget: view.NewTextWidget(app, settings.common),
 
 		settings: settings,
 	}

--- a/modules/power/settings.go
+++ b/modules/power/settings.go
@@ -5,7 +5,10 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const defaultTitle = "Power"
+const (
+	defaultFocusable = false
+	defaultTitle     = "Power"
+)
 
 type Settings struct {
 	common *cfg.Common
@@ -13,7 +16,7 @@ type Settings struct {
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 	}
 
 	return &settings

--- a/modules/power/widget.go
+++ b/modules/power/widget.go
@@ -17,7 +17,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, settings.common, false),
+		TextWidget: view.NewTextWidget(app, settings.common),
 
 		Battery: NewBattery(),
 

--- a/modules/resourceusage/settings.go
+++ b/modules/resourceusage/settings.go
@@ -5,7 +5,10 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const defaultTitle = "ResourceUsage"
+const (
+	defaultFocusable = false
+	defaultTitle     = "ResourceUsage"
+)
 
 type Settings struct {
 	common *cfg.Common
@@ -13,7 +16,7 @@ type Settings struct {
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 	}
 
 	return &settings

--- a/modules/resourceusage/widget.go
+++ b/modules/resourceusage/widget.go
@@ -12,8 +12,10 @@ import (
 	"github.com/wtfutil/wtf/view"
 )
 
-var started = false
-var ok = true
+var (
+	ok      = true
+	started = false
+)
 
 // Widget define wtf widget to register widget later
 type Widget struct {
@@ -26,7 +28,7 @@ type Widget struct {
 // NewWidget Make new instance of widget
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		BarGraph: view.NewBarGraph(app, settings.common.Name, settings.common, false),
+		BarGraph: view.NewBarGraph(app, settings.common.Name, settings.common),
 
 		app:      app,
 		settings: settings,

--- a/modules/rollbar/settings.go
+++ b/modules/rollbar/settings.go
@@ -5,7 +5,10 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const defaultTitle = "Rollbar"
+const (
+	defaultFocusable = true
+	defaultTitle     = "Rollbar"
+)
 
 type Settings struct {
 	common *cfg.Common
@@ -21,7 +24,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		accessToken:    ymlConfig.UString("accessToken"),
 		activeOnly:     ymlConfig.UBool("activeOnly", false),

--- a/modules/rollbar/widget.go
+++ b/modules/rollbar/widget.go
@@ -22,7 +22,7 @@ type Widget struct {
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
 		KeyboardWidget:   view.NewKeyboardWidget(app, pages, settings.common),
-		ScrollableWidget: view.NewScrollableWidget(app, settings.common, true),
+		ScrollableWidget: view.NewScrollableWidget(app, settings.common),
 
 		settings: settings,
 	}

--- a/modules/security/settings.go
+++ b/modules/security/settings.go
@@ -5,7 +5,10 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const defaultTitle = "Security"
+const (
+	defaultFocusable = false
+	defaultTitle     = "Security"
+)
 
 type Settings struct {
 	common *cfg.Common
@@ -13,7 +16,7 @@ type Settings struct {
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 	}
 
 	return &settings

--- a/modules/security/widget.go
+++ b/modules/security/widget.go
@@ -16,7 +16,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, settings.common, false),
+		TextWidget: view.NewTextWidget(app, settings.common),
 
 		settings: settings,
 	}

--- a/modules/spotify/settings.go
+++ b/modules/spotify/settings.go
@@ -5,7 +5,10 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const defaultTitle = "Spotify"
+const (
+	defaultFocusable = true
+	defaultTitle     = "Spotify"
+)
 
 type Settings struct {
 	common *cfg.Common
@@ -13,7 +16,7 @@ type Settings struct {
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 	}
 
 	return &settings

--- a/modules/spotify/widget.go
+++ b/modules/spotify/widget.go
@@ -23,7 +23,7 @@ type Widget struct {
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
 		KeyboardWidget: view.NewKeyboardWidget(app, pages, settings.common),
-		TextWidget:     view.NewTextWidget(app, settings.common, true),
+		TextWidget:     view.NewTextWidget(app, settings.common),
 
 		Info:   spotigopher.Info{},
 		client: spotigopher.NewClient(),

--- a/modules/spotifyweb/settings.go
+++ b/modules/spotifyweb/settings.go
@@ -7,7 +7,10 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const defaultTitle = "Spotify Web"
+const (
+	defaultFocusable = true
+	defaultTitle     = "Spotify Web"
+)
 
 type Settings struct {
 	common *cfg.Common
@@ -20,7 +23,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		callbackPort: ymlConfig.UString("callbackPort", "8080"),
 		clientID:     ymlConfig.UString("clientID", os.Getenv("SPOTIFY_ID")),

--- a/modules/spotifyweb/widget.go
+++ b/modules/spotifyweb/widget.go
@@ -12,6 +12,15 @@ import (
 	"github.com/zmb3/spotify"
 )
 
+var (
+	auth           spotify.Authenticator
+	tempClientChan = make(chan *spotify.Client)
+	state          = "wtfSpotifyWebStateString"
+	authURL        string
+	callbackPort   string
+	redirectURI    string
+)
+
 // Info is the struct that contains all the information the Spotify player displays to the user
 type Info struct {
 	Artists     string
@@ -33,15 +42,6 @@ type Widget struct {
 	playerState *spotify.PlayerState
 	settings    *Settings
 }
-
-var (
-	auth           spotify.Authenticator
-	tempClientChan = make(chan *spotify.Client)
-	state          = "wtfSpotifyWebStateString"
-	authURL        string
-	callbackPort   string
-	redirectURI    string
-)
 
 func authHandler(w http.ResponseWriter, r *http.Request) {
 	tok, err := auth.Token(state, r)
@@ -70,7 +70,7 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 
 	widget := Widget{
 		KeyboardWidget: view.NewKeyboardWidget(app, pages, settings.common),
-		TextWidget:     view.NewTextWidget(app, settings.common, true),
+		TextWidget:     view.NewTextWidget(app, settings.common),
 
 		Info: Info{},
 

--- a/modules/status/settings.go
+++ b/modules/status/settings.go
@@ -5,7 +5,10 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const defaultTitle = "Status"
+const (
+	defaultFocusable = false
+	defaultTitle     = "Status"
+)
 
 type Settings struct {
 	common *cfg.Common
@@ -13,7 +16,7 @@ type Settings struct {
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 	}
 
 	return &settings

--- a/modules/status/widget.go
+++ b/modules/status/widget.go
@@ -15,7 +15,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, settings.common, false),
+		TextWidget: view.NewTextWidget(app, settings.common),
 
 		CurrentIcon: 0,
 

--- a/modules/system/settings.go
+++ b/modules/system/settings.go
@@ -5,7 +5,10 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const defaultTitle = "System"
+const (
+	defaultFocusable = false
+	defaultTitle     = "System"
+)
 
 type Settings struct {
 	common *cfg.Common
@@ -13,7 +16,7 @@ type Settings struct {
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 	}
 
 	return &settings

--- a/modules/system/widget.go
+++ b/modules/system/widget.go
@@ -21,7 +21,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, date, version string, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, settings.common, false),
+		TextWidget: view.NewTextWidget(app, settings.common),
 
 		Date: date,
 

--- a/modules/textfile/settings.go
+++ b/modules/textfile/settings.go
@@ -5,7 +5,10 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const defaultTitle = "Textfile"
+const (
+	defaultFocusable = true
+	defaultTitle     = "Textfile"
+)
 
 // Settings defines the configuration properties for this module
 type Settings struct {
@@ -21,7 +24,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		filePaths:   ymlConfig.UList("filePaths"),
 		format:      ymlConfig.UBool("format", false),

--- a/modules/textfile/widget.go
+++ b/modules/textfile/widget.go
@@ -34,7 +34,7 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 	widget := Widget{
 		KeyboardWidget:    view.NewKeyboardWidget(app, pages, settings.common),
 		MultiSourceWidget: view.NewMultiSourceWidget(settings.common, "filePath", "filePaths"),
-		TextWidget:        view.NewTextWidget(app, settings.common, true),
+		TextWidget:        view.NewTextWidget(app, settings.common),
 
 		settings: settings,
 	}

--- a/modules/todo/settings.go
+++ b/modules/todo/settings.go
@@ -5,7 +5,10 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const defaultTitle = "Todo"
+const (
+	defaultFocusable = true
+	defaultTitle     = "Todo"
+)
 
 type Settings struct {
 	common *cfg.Common
@@ -16,7 +19,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		filePath: ymlConfig.UString("filename"),
 	}

--- a/modules/todo/widget.go
+++ b/modules/todo/widget.go
@@ -15,9 +15,9 @@ import (
 )
 
 const (
-	offscreen   = -1000
-	modalWidth  = 80
 	modalHeight = 7
+	modalWidth  = 80
+	offscreen   = -1000
 )
 
 // A Widget represents a Todo widget
@@ -36,7 +36,7 @@ type Widget struct {
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
 		KeyboardWidget: view.NewKeyboardWidget(app, pages, settings.common),
-		TextWidget:     view.NewTextWidget(app, settings.common, true),
+		TextWidget:     view.NewTextWidget(app, settings.common),
 
 		app:      app,
 		settings: settings,

--- a/modules/todoist/settings.go
+++ b/modules/todoist/settings.go
@@ -7,7 +7,10 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const defaultTitle = "Todoist"
+const (
+	defaultFocusable = true
+	defaultTitle     = "Todoist"
+)
 
 type Settings struct {
 	common *cfg.Common
@@ -19,7 +22,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		apiKey:   ymlConfig.UString("apiKey", ymlConfig.UString("apikey", os.Getenv("WTF_TODOIST_TOKEN"))),
 		projects: ymlConfig.UList("projects"),

--- a/modules/todoist/widget.go
+++ b/modules/todoist/widget.go
@@ -21,7 +21,7 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 	widget := Widget{
 		KeyboardWidget:    view.NewKeyboardWidget(app, pages, settings.common),
 		MultiSourceWidget: view.NewMultiSourceWidget(settings.common, "project", "projects"),
-		ScrollableWidget:  view.NewScrollableWidget(app, settings.common, true),
+		ScrollableWidget:  view.NewScrollableWidget(app, settings.common),
 
 		settings: settings,
 	}

--- a/modules/transmission/settings.go
+++ b/modules/transmission/settings.go
@@ -5,6 +5,11 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
+const (
+	defaultFocusable = true
+	defaultTitle     = "Transmission"
+)
+
 // Settings defines the configuration properties for this module
 type Settings struct {
 	common *cfg.Common
@@ -17,14 +22,10 @@ type Settings struct {
 	username string `help:"The username of the Transmission user"`
 }
 
-const (
-	defaultTitle = "Transmission"
-)
-
 // NewSettingsFromYAML creates a new settings instance from a YAML config block
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		host:     ymlConfig.UString("host"),
 		https:    ymlConfig.UBool("https", false),

--- a/modules/transmission/widget.go
+++ b/modules/transmission/widget.go
@@ -23,7 +23,7 @@ type Widget struct {
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
 		KeyboardWidget:   view.NewKeyboardWidget(app, pages, settings.common),
-		ScrollableWidget: view.NewScrollableWidget(app, settings.common, true),
+		ScrollableWidget: view.NewScrollableWidget(app, settings.common),
 
 		settings: settings,
 	}

--- a/modules/travisci/settings.go
+++ b/modules/travisci/settings.go
@@ -7,7 +7,10 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const defaultTitle = "TravisCI"
+const (
+	defaultFocusable = true
+	defaultTitle     = "TravisCI"
+)
 
 type Settings struct {
 	common *cfg.Common
@@ -20,9 +23,8 @@ type Settings struct {
 }
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
-
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		apiKey:  ymlConfig.UString("apiKey", ymlConfig.UString("apikey", os.Getenv("WTF_TRAVIS_API_TOKEN"))),
 		pro:     ymlConfig.UBool("pro", false),

--- a/modules/travisci/widget.go
+++ b/modules/travisci/widget.go
@@ -21,7 +21,7 @@ type Widget struct {
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
 		KeyboardWidget:   view.NewKeyboardWidget(app, pages, settings.common),
-		ScrollableWidget: view.NewScrollableWidget(app, settings.common, true),
+		ScrollableWidget: view.NewScrollableWidget(app, settings.common),
 
 		settings: settings,
 	}

--- a/modules/trello/settings.go
+++ b/modules/trello/settings.go
@@ -7,7 +7,10 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const defaultTitle = "Trello"
+const (
+	defaultFocusable = false
+	defaultTitle     = "Trello"
+)
 
 type Settings struct {
 	common *cfg.Common
@@ -20,9 +23,8 @@ type Settings struct {
 }
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
-
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		accessToken: ymlConfig.UString("accessToken", ymlConfig.UString("apikey", os.Getenv("WTF_TRELLO_ACCESS_TOKEN"))),
 		apiKey:      ymlConfig.UString("apiKey", os.Getenv("WTF_TRELLO_APP_KEY")),

--- a/modules/trello/widget.go
+++ b/modules/trello/widget.go
@@ -16,7 +16,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, settings.common, false),
+		TextWidget: view.NewTextWidget(app, settings.common),
 
 		settings: settings,
 	}

--- a/modules/twitter/settings.go
+++ b/modules/twitter/settings.go
@@ -7,7 +7,10 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const defaultTitle = "Twitter"
+const (
+	defaultFocusable = true
+	defaultTitle     = "Twitter"
+)
 
 type Settings struct {
 	common *cfg.Common
@@ -18,9 +21,8 @@ type Settings struct {
 }
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
-
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		bearerToken: ymlConfig.UString("bearerToken", os.Getenv("WTF_TWITTER_BEARER_TOKEN")),
 		count:       ymlConfig.UInt("count", 5),

--- a/modules/twitter/widget.go
+++ b/modules/twitter/widget.go
@@ -26,7 +26,7 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 	widget := Widget{
 		KeyboardWidget:    view.NewKeyboardWidget(app, pages, settings.common),
 		MultiSourceWidget: view.NewMultiSourceWidget(settings.common, "screenName", "screenNames"),
-		TextWidget:        view.NewTextWidget(app, settings.common, true),
+		TextWidget:        view.NewTextWidget(app, settings.common),
 
 		idx:      0,
 		settings: settings,

--- a/modules/unknown/settings.go
+++ b/modules/unknown/settings.go
@@ -5,7 +5,10 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const defaultTitle = "Unknown"
+const (
+	defaultFocusable = false
+	defaultTitle     = "Unknown"
+)
 
 type Settings struct {
 	common *cfg.Common
@@ -13,7 +16,7 @@ type Settings struct {
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 	}
 
 	return &settings

--- a/modules/unknown/widget.go
+++ b/modules/unknown/widget.go
@@ -15,7 +15,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, settings.common, false),
+		TextWidget: view.NewTextWidget(app, settings.common),
 
 		settings: settings,
 	}

--- a/modules/victorops/settings.go
+++ b/modules/victorops/settings.go
@@ -7,7 +7,10 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const defaultTitle = "VictorOps"
+const (
+	defaultFocusable = true
+	defaultTitle     = "VictorOps"
+)
 
 type Settings struct {
 	common *cfg.Common
@@ -18,9 +21,8 @@ type Settings struct {
 }
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
-
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		apiID:  ymlConfig.UString("apiID", os.Getenv("WTF_VICTOROPS_API_ID")),
 		apiKey: ymlConfig.UString("apiKey", ymlConfig.UString("apikey", os.Getenv("WTF_VICTOROPS_API_KEY"))),

--- a/modules/victorops/widget.go
+++ b/modules/victorops/widget.go
@@ -19,7 +19,7 @@ type Widget struct {
 // NewWidget creates a new widget
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, settings.common, true),
+		TextWidget: view.NewTextWidget(app, settings.common),
 	}
 
 	widget.View.SetScrollable(true)

--- a/modules/weatherservices/arpansagovau/settings.go
+++ b/modules/weatherservices/arpansagovau/settings.go
@@ -5,17 +5,20 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const defaultTitle = "ARPANSA UV Data"
+const (
+	defaultFocusable = false
+	defaultTitle     = "ARPANSA UV Data"
+)
 
 type Settings struct {
 	common *cfg.Common
-	city string;
+	city   string
 }
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
-		city: ymlConfig.UString("locationid"),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+		city:   ymlConfig.UString("locationid"),
 	}
 
 	return &settings

--- a/modules/weatherservices/arpansagovau/widget.go
+++ b/modules/weatherservices/arpansagovau/widget.go
@@ -8,18 +8,18 @@ import (
 
 type Widget struct {
 	view.TextWidget
-	location *location
+	location  *location
 	lastError error
-	settings *Settings
+	settings  *Settings
 }
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	locationData, err := GetLocationData(settings.city)
-	widget := Widget {
-		TextWidget: view.NewTextWidget(app, settings.common, false),
-		location: locationData,
-		lastError: err,
-		settings: settings,
+	widget := Widget{
+		TextWidget: view.NewTextWidget(app, settings.common),
+		location:   locationData,
+		lastError:  err,
+		settings:   settings,
 	}
 
 	widget.View.SetWrap(true)
@@ -50,32 +50,32 @@ func formatLocationData(location *location) string {
 	var color string
 	var content string
 
-	if(location.name == "") {
+	if location.name == "" {
 		return "[red]No data?"
 	}
 
-	if(location.status != "ok") {
+	if location.status != "ok" {
 		content = "[red]Data unavailable for "
 		content += location.name
 		return content
 	}
 
 	switch {
-		case location.index < 2.5:
-			color = "[green]"
-			level = " (LOW)"
-		case location.index >= 2.5 && location.index < 5.5:
-			color = "[yellow]"
-			level = " (MODERATE)"
-		case location.index >= 5.5 && location.index < 7.5:
-			color = "[orange]"
-			level = " (HIGH)"
-		case location.index >= 7.5 && location.index < 10.5:
-			color = "[red]"
-			level = " (VERY HIGH)"
-		case location.index >= 10.5:
-			color = "[fuchsia]"
-			level = " (EXTREME)"
+	case location.index < 2.5:
+		color = "[green]"
+		level = " (LOW)"
+	case location.index >= 2.5 && location.index < 5.5:
+		color = "[yellow]"
+		level = " (MODERATE)"
+	case location.index >= 5.5 && location.index < 7.5:
+		color = "[orange]"
+		level = " (HIGH)"
+	case location.index >= 7.5 && location.index < 10.5:
+		color = "[red]"
+		level = " (VERY HIGH)"
+	case location.index >= 10.5:
+		color = "[fuchsia]"
+		level = " (EXTREME)"
 	}
 
 	content = "Location: "

--- a/modules/weatherservices/prettyweather/settings.go
+++ b/modules/weatherservices/prettyweather/settings.go
@@ -5,7 +5,10 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const defaultTitle = "Pretty Weather"
+const (
+	defaultFocusable = false
+	defaultTitle     = "Pretty Weather"
+)
 
 type Settings struct {
 	common *cfg.Common
@@ -17,9 +20,8 @@ type Settings struct {
 }
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
-
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		city:     ymlConfig.UString("city", "Barcelona"),
 		language: ymlConfig.UString("language", "en"),

--- a/modules/weatherservices/prettyweather/widget.go
+++ b/modules/weatherservices/prettyweather/widget.go
@@ -19,7 +19,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, settings.common, false),
+		TextWidget: view.NewTextWidget(app, settings.common),
 
 		settings: settings,
 	}

--- a/modules/weatherservices/weather/settings.go
+++ b/modules/weatherservices/weather/settings.go
@@ -7,7 +7,10 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const defaultTitle = "Weather"
+const (
+	defaultFocusable = true
+	defaultTitle     = "Weather"
+)
 
 type colors struct {
 	current string
@@ -24,9 +27,8 @@ type Settings struct {
 }
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
-
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		apiKey:   ymlConfig.UString("apiKey", ymlConfig.UString("apikey", os.Getenv("WTF_OWM_API_KEY"))),
 		cityIDs:  ymlConfig.UList("cityids"),

--- a/modules/weatherservices/weather/widget.go
+++ b/modules/weatherservices/weather/widget.go
@@ -25,7 +25,7 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 	widget := Widget{
 		KeyboardWidget:    view.NewKeyboardWidget(app, pages, settings.common),
 		MultiSourceWidget: view.NewMultiSourceWidget(settings.common, "cityid", "cityids"),
-		TextWidget:        view.NewTextWidget(app, settings.common, true),
+		TextWidget:        view.NewTextWidget(app, settings.common),
 
 		pages:    pages,
 		settings: settings,

--- a/modules/zendesk/settings.go
+++ b/modules/zendesk/settings.go
@@ -7,7 +7,10 @@ import (
 	"github.com/wtfutil/wtf/cfg"
 )
 
-const defaultTitle = "Zendesk"
+const (
+	defaultFocusable = true
+	defaultTitle     = "Zendesk"
+)
 
 type Settings struct {
 	common *cfg.Common
@@ -19,9 +22,8 @@ type Settings struct {
 }
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
-
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		apiKey:    ymlConfig.UString("apiKey", ymlConfig.UString("apikey", os.Getenv("ZENDESK_API"))),
 		status:    ymlConfig.UString("status"),

--- a/modules/zendesk/widget.go
+++ b/modules/zendesk/widget.go
@@ -22,7 +22,7 @@ type Widget struct {
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
 		KeyboardWidget:   view.NewKeyboardWidget(app, pages, settings.common),
-		ScrollableWidget: view.NewScrollableWidget(app, settings.common, true),
+		ScrollableWidget: view.NewScrollableWidget(app, settings.common),
 
 		settings: settings,
 	}

--- a/view/bargraph.go
+++ b/view/bargraph.go
@@ -28,9 +28,9 @@ type Bar struct {
 }
 
 // NewBarGraph creates and returns an instance of BarGraph
-func NewBarGraph(app *tview.Application, name string, commonSettings *cfg.Common, focusable bool) BarGraph {
+func NewBarGraph(app *tview.Application, name string, commonSettings *cfg.Common) BarGraph {
 	widget := BarGraph{
-		Base: NewBase(app, commonSettings, focusable),
+		Base: NewBase(app, commonSettings),
 
 		maxStars: commonSettings.Config.UInt("graphStars", 20),
 		starChar: commonSettings.Config.UString("graphIcon", "|"),

--- a/view/base.go
+++ b/view/base.go
@@ -23,16 +23,14 @@ type Base struct {
 	enabledMutex    *sync.Mutex
 }
 
-func NewBase(app *tview.Application, commonSettings *cfg.Common, defaultFocusable bool) Base {
-	focusable := commonSettings.Focusable || defaultFocusable
-
+func NewBase(app *tview.Application, commonSettings *cfg.Common) Base {
 	base := Base{
 		commonSettings:  commonSettings,
 		app:             app,
 		bordered:        commonSettings.Bordered,
 		enabled:         commonSettings.Enabled,
 		focusChar:       commonSettings.FocusChar(),
-		focusable:       focusable,
+		focusable:       commonSettings.Focusable,
 		name:            commonSettings.Name,
 		quitChan:        make(chan bool),
 		refreshInterval: commonSettings.RefreshInterval,

--- a/view/base.go
+++ b/view/base.go
@@ -23,7 +23,9 @@ type Base struct {
 	enabledMutex    *sync.Mutex
 }
 
-func NewBase(app *tview.Application, commonSettings *cfg.Common, focusable bool) Base {
+func NewBase(app *tview.Application, commonSettings *cfg.Common, defaultFocusable bool) Base {
+	focusable := commonSettings.Focusable || defaultFocusable
+
 	base := Base{
 		commonSettings:  commonSettings,
 		app:             app,

--- a/view/scrollable_widget.go
+++ b/view/scrollable_widget.go
@@ -15,9 +15,9 @@ type ScrollableWidget struct {
 	RenderFunction func()
 }
 
-func NewScrollableWidget(app *tview.Application, commonSettings *cfg.Common, focusable bool) ScrollableWidget {
+func NewScrollableWidget(app *tview.Application, commonSettings *cfg.Common) ScrollableWidget {
 	widget := ScrollableWidget{
-		TextWidget: NewTextWidget(app, commonSettings, focusable),
+		TextWidget: NewTextWidget(app, commonSettings),
 	}
 
 	widget.Unselect()

--- a/view/text_widget.go
+++ b/view/text_widget.go
@@ -13,9 +13,9 @@ type TextWidget struct {
 }
 
 // NewTextWidget creates and returns an instance of TextWidget
-func NewTextWidget(app *tview.Application, commonSettings *cfg.Common, focusable bool) TextWidget {
+func NewTextWidget(app *tview.Application, commonSettings *cfg.Common, defaultFocusable bool) TextWidget {
 	widget := TextWidget{
-		Base: NewBase(app, commonSettings, focusable),
+		Base: NewBase(app, commonSettings, defaultFocusable),
 	}
 
 	widget.View = widget.createView(widget.bordered)

--- a/view/text_widget.go
+++ b/view/text_widget.go
@@ -13,9 +13,9 @@ type TextWidget struct {
 }
 
 // NewTextWidget creates and returns an instance of TextWidget
-func NewTextWidget(app *tview.Application, commonSettings *cfg.Common, defaultFocusable bool) TextWidget {
+func NewTextWidget(app *tview.Application, commonSettings *cfg.Common) TextWidget {
 	widget := TextWidget{
-		Base: NewBase(app, commonSettings, defaultFocusable),
+		Base: NewBase(app, commonSettings),
 	}
 
 	widget.View = widget.createView(widget.bordered)

--- a/view/text_widget_test.go
+++ b/view/text_widget_test.go
@@ -15,7 +15,6 @@ func testTextWidget() TextWidget {
 				Name: "test widget",
 			},
 		},
-		true,
 	)
 	return txtWid
 }


### PR DESCRIPTION
Widgets can now override a module's `defaultFocusable` value in the module config using a `focusable` key:

```
    focusable: true || false
```
