### PR TITLE
Add colors.eventTime to gcal

### DIFF
--- a/modules/gcal/display.go
+++ b/modules/gcal/display.go
@@ -48,7 +48,7 @@ func (widget *Widget) content() (string, string, bool) {
 	}
 
 	for _, calEvent := range calEvents {
-		timestamp := fmt.Sprintf("[%s]%s", widget.descriptionColor(calEvent), calEvent.Timestamp())
+		timestamp := fmt.Sprintf("[%s]%s", widget.eventTimeColor(calEvent), calEvent.Timestamp())
 		if calEvent.AllDay() {
 			timestamp = ""
 		}
@@ -114,6 +114,10 @@ func (widget *Widget) descriptionColor(calEvent *CalEvent) string {
 	}
 
 	return widget.settings.colors.description
+}
+
+func (widget *Widget) eventTimeColor(calEvent *CalEvent) string {
+	return widget.settings.colors.eventTime
 }
 
 func (widget *Widget) eventSummary(calEvent *CalEvent, conflict bool) string {

--- a/modules/gcal/settings.go
+++ b/modules/gcal/settings.go
@@ -10,6 +10,7 @@ const defaultTitle = "Calendar"
 type colors struct {
 	day         string
 	description string `help:"The default color for calendar event descriptions." values:"Any X11 color name." optional:"true"`
+	eventTime   string `help:"The default color for calendar event times." values:"Any X11 color name." optional:"true"`
 	past        string `help:"The color for calendar events that have passed." values:"Any X11 color name." optional:"true"`
 	title       string `help:"The default colour for calendar event titles." values:"Any X11 color name." optional:"true"`
 
@@ -55,6 +56,14 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 
 	settings.colors.day = ymlConfig.UString("colors.day", "forestgreen")
 	settings.colors.description = ymlConfig.UString("colors.description", "white")
+	// settings.colors.eventTime is a new feature introduced via issue #638. Prior to this, the color of the event
+	// time was (unintentionally) customized via settings.colors.description. To maintain backwards compatibility
+	// for users who might be already using this to set the color of the event time, we try to determine the default
+	// from settings.colors.description. If it is not set, then the default value of "white" is used.  Finally, if a
+	// user sets a value for colors.eventTime, it overrides the defaults.
+	//
+	// PS: We should have a deprecation plan for supporting this backwards compatibility feature.
+	settings.colors.eventTime = ymlConfig.UString("colors.eventTime", settings.colors.description)
 	settings.colors.highlights = ymlConfig.UList("colors.highlights")
 	settings.colors.past = ymlConfig.UString("colors.past", "gray")
 	settings.colors.title = ymlConfig.UString("colors.title", "white")


### PR DESCRIPTION
Fixes #638 

**Default setting:**
![s_2019-09-18_011615](https://user-images.githubusercontent.com/2682729/65076462-a8284f00-d9b6-11e9-8112-064583173cba.png)

**Custom setting:**
```
      colors:
        title: "orange"
        eventTime: "pink"
        description: "lightgrey"  
        highlights:
        - ['Engineering team daily', 'lightblue']
```

![s_2019-09-18_011551](https://user-images.githubusercontent.com/2682729/65076466-aa8aa900-d9b6-11e9-9b4a-039636b8eecb.png)
