### PR TITLE
WTF-665 Add time format setting for gCal module

### DIFF
--- a/modules/digitalclock/settings.go
+++ b/modules/digitalclock/settings.go
@@ -24,10 +24,11 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common:     cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+
 		color:      ymlConfig.UString("color"),
 		font:       ymlConfig.UString("font"),
-		hourFormat: ymlConfig.UString("hourFormat"),
+		hourFormat: ymlConfig.UString("hourFormat", "24"),
 	}
 
 	return &settings

--- a/modules/gcal/cal_event.go
+++ b/modules/gcal/cal_event.go
@@ -97,12 +97,17 @@ func (calEvent *CalEvent) Start() time.Time {
 	return start
 }
 
-func (calEvent *CalEvent) Timestamp() string {
+func (calEvent *CalEvent) Timestamp(hourFormat string) string {
 	if calEvent.AllDay() {
 		startTime, _ := time.ParseInLocation("2006-01-02", calEvent.event.Start.Date, time.Local)
 		return startTime.Format(utils.FriendlyDateFormat)
 	}
 
 	startTime, _ := time.Parse(time.RFC3339, calEvent.event.Start.DateTime)
-	return startTime.Format(utils.MinimumTimeFormat)
+
+	timeFormat := utils.MinimumTimeFormat24
+	if hourFormat == "12" {
+		timeFormat = utils.MinimumTimeFormat12
+	}
+	return startTime.Format(timeFormat)
 }

--- a/modules/gcal/display.go
+++ b/modules/gcal/display.go
@@ -48,7 +48,7 @@ func (widget *Widget) content() (string, string, bool) {
 	}
 
 	for _, calEvent := range calEvents {
-		timestamp := fmt.Sprintf("[%s]%s", widget.eventTimeColor(calEvent), calEvent.Timestamp())
+		timestamp := fmt.Sprintf("[%s]%s", widget.eventTimeColor(calEvent), calEvent.Timestamp(widget.settings.hourFormat))
 		if calEvent.AllDay() {
 			timestamp = ""
 		}

--- a/modules/gcal/settings.go
+++ b/modules/gcal/settings.go
@@ -30,6 +30,7 @@ type Settings struct {
 	displayResponseStatus bool   `help:"Whether or not to display your response status to the calendar event." values:"true or false" optional:"true"`
 	email                 string `help:"The email address associated with your Google account. Necessary for determining 'responseStatus'." values:"A valid email address string."`
 	eventCount            int    `help:"The number of calendar events to display." values:"A positive integer, 0..n." optional:"true"`
+	hourFormat            string `help:"The format of the clock." values:"12 or 24"`
 	multiCalendar         bool   `help:"Whether or not to display your primary calendar or all calendars you have access to." values:"true or false" optional:"true"`
 	secretFile            string `help:"Your Google client secret JSON file." values:"A string representing a file path to the JSON secret file."`
 	showDeclined          bool   `help:"Whether or not to display events you’ve declined to attend." values:"true or false" optional:"true"`
@@ -48,6 +49,7 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 		displayResponseStatus: ymlConfig.UBool("displayResponseStatus", true),
 		email:                 ymlConfig.UString("email", ""),
 		eventCount:            ymlConfig.UInt("eventCount", 10),
+		hourFormat:            ymlConfig.UString("hourFormat", "24"),
 		multiCalendar:         ymlConfig.UBool("multiCalendar", false),
 		secretFile:            ymlConfig.UString("secretFile", ""),
 		showDeclined:          ymlConfig.UBool("showDeclined", false),

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -13,9 +13,10 @@ import (
 )
 
 const (
-	SimpleDateFormat  = "Jan 2"
-	SimpleTimeFormat  = "15:04 MST"
-	MinimumTimeFormat = "15:04"
+	SimpleDateFormat    = "Jan 2"
+	SimpleTimeFormat    = "15:04 MST"
+	MinimumTimeFormat12 = "3:04 PM"
+	MinimumTimeFormat24 = "15:04"
 
 	FullDateFormat         = "Monday, Jan 2"
 	FriendlyDateFormat     = "Mon, Jan 2"


### PR DESCRIPTION
Allows the user to specify either "12" or "24" to set whether or not to
display times in AM/PM format or 24-hour format.

Example:

```
      gcal:
        enabled: true
        hourFormat: "12"
        refreshInterval: 360
```

Fixes #665.