### PR TITLE
Support theming for Spotify widget

### DIFF
--- a/modules/spotify/settings.go
+++ b/modules/spotify/settings.go
@@ -10,7 +10,13 @@ const (
 	defaultTitle     = "Spotify"
 )
 
+type colors struct {
+	label string
+	text  string
+}
+
 type Settings struct {
+	colors
 	common *cfg.Common
 }
 
@@ -18,6 +24,9 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	settings := Settings{
 		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 	}
+
+	settings.colors.label = ymlConfig.UString("colors.label", "green")
+	settings.colors.text = ymlConfig.UString("colors.text", "white")
 
 	return &settings
 }

--- a/modules/spotify/widget.go
+++ b/modules/spotify/widget.go
@@ -64,10 +64,13 @@ func (w *Widget) createOutput() (string, string, bool) {
 	if err != nil {
 		content = err.Error()
 	} else {
-		content = utils.CenterText(fmt.Sprintf("[green]Now %v [white]\n", w.Info.Status), w.CommonSettings().Width)
-		content += utils.CenterText(fmt.Sprintf("[green]Title:[white] %v\n ", w.Info.Title), w.CommonSettings().Width)
-		content += utils.CenterText(fmt.Sprintf("[green]Artist:[white] %v\n", w.Info.Artist), w.CommonSettings().Width)
-		content += utils.CenterText(fmt.Sprintf("[green]%v:[white] %v\n", w.Info.TrackNumber, w.Info.Album), w.CommonSettings().Width)
+		labelColor := w.settings.colors.label
+		textColor := w.settings.colors.text
+
+		content = utils.CenterText(fmt.Sprintf("[%s]Now %v [%s]\n", labelColor, w.Info.Status, textColor), w.CommonSettings().Width)
+		content += utils.CenterText(fmt.Sprintf("[%s]Title:[%s] %v\n ", labelColor, textColor, w.Info.Title), w.CommonSettings().Width)
+		content += utils.CenterText(fmt.Sprintf("[%s]Artist:[%s] %v\n", labelColor, textColor, w.Info.Artist), w.CommonSettings().Width)
+		content += utils.CenterText(fmt.Sprintf("[%s]%v:[%s] %v\n", labelColor, w.Info.TrackNumber, textColor, w.Info.Album), w.CommonSettings().Width)
 	}
 	return w.CommonSettings().Title, content, true
 }


### PR DESCRIPTION
Solves #659. The changes made here allow users to set custom colors for labels and normal text in the widget.