### PR TITLE
Sort Buildkite pipelines and branches alphabetically

### DIFF
--- a/modules/buildkite/pipelines_display_data.go
+++ b/modules/buildkite/pipelines_display_data.go
@@ -1,0 +1,120 @@
+package buildkite
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+type pipelinesDisplayData struct {
+	buildsForPipeline map[string][]Build
+	orderedPipelines  []string
+}
+
+func (data *pipelinesDisplayData) Content() string {
+	maxPipelineLength := getLongestLength(data.orderedPipelines)
+
+	str := ""
+	for _, pipeline := range data.orderedPipelines {
+		str += fmt.Sprintf("[white]%s", padRight(pipeline, maxPipelineLength))
+		for _, build := range data.buildsForPipeline[pipeline] {
+			str += fmt.Sprintf("  [%s]%s[white]", buildColor(build.State), build.Branch)
+		}
+		str += "\n"
+	}
+
+	return str
+}
+
+func NewPipelinesDisplayData(builds []Build) pipelinesDisplayData {
+	grouped := make(map[string][]Build)
+
+	for _, build := range builds {
+		if _, ok := grouped[build.Pipeline.Slug]; ok {
+			grouped[build.Pipeline.Slug] = append(grouped[build.Pipeline.Slug], build)
+		} else {
+			grouped[build.Pipeline.Slug] = []Build{}
+			grouped[build.Pipeline.Slug] = append(grouped[build.Pipeline.Slug], build)
+		}
+	}
+
+	orderedPipelines := make([]string, len(grouped))
+	i := 0
+	for pipeline := range grouped {
+		orderedPipelines[i] = pipeline
+		i++
+	}
+	sort.Strings(orderedPipelines)
+
+	name := func(b1, b2 *Build) bool {
+		return b1.Branch < b2.Branch
+	}
+	for _, builds := range grouped {
+		ByBuild(name).Sort(builds)
+	}
+
+	return pipelinesDisplayData{
+		buildsForPipeline: grouped,
+		orderedPipelines:  orderedPipelines,
+	}
+}
+
+type ByBuild func(b1, b2 *Build) bool
+
+func (by ByBuild) Sort(builds []Build) {
+	sorter := &buildSorter{
+		builds: builds,
+		by:     by,
+	}
+	sort.Sort(sorter)
+}
+
+type buildSorter struct {
+	builds []Build
+	by     func(b1, b2 *Build) bool
+}
+
+func (bs *buildSorter) Len() int {
+	return len(bs.builds)
+}
+
+func (bs *buildSorter) Swap(i, j int) {
+	bs.builds[i], bs.builds[j] = bs.builds[j], bs.builds[i]
+}
+
+func (bs *buildSorter) Less(i, j int) bool {
+	return bs.by(&bs.builds[i], &bs.builds[j])
+}
+
+func getLongestLength(strs []string) int {
+	longest := 0
+
+	for _, str := range strs {
+		if len(str) > longest {
+			longest = len(str)
+		}
+	}
+
+	return longest
+}
+
+func padRight(text string, length int) string {
+	padLength := length - len(text)
+
+	if padLength <= 0 {
+		return text[:length]
+	}
+
+	return text + strings.Repeat(" ", padLength)
+}
+
+func buildColor(state string) string {
+	switch state {
+	case "passed":
+		return "green"
+	case "failed":
+		return "red"
+	default:
+		return "yellow"
+	}
+}

--- a/modules/buildkite/widget.go
+++ b/modules/buildkite/widget.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"github.com/rivo/tview"
 	"github.com/wtfutil/wtf/view"
-	"strings"
 )
 
 const HelpText = `
@@ -65,65 +64,7 @@ func (widget *Widget) content() (string, string, bool) {
 		return title, widget.err.Error(), true
 	}
 
-	pipelineData := groupByPipeline(widget.builds)
-	maxPipelineLength := getLongestPipelineLength(widget.builds)
+	displayData := NewPipelinesDisplayData(widget.builds)
 
-	str := ""
-	for pipeline, builds := range pipelineData {
-		str += fmt.Sprintf("[white]%s", padRight(pipeline, maxPipelineLength))
-		for _, build := range builds {
-			str += fmt.Sprintf("  [%s]%s[white]", buildColor(build.State), build.Branch)
-		}
-		str += "\n"
-	}
-
-	return title, str, false
-}
-
-func groupByPipeline(builds []Build) map[string][]Build {
-	grouped := make(map[string][]Build)
-
-	for _, build := range builds {
-		if _, ok := grouped[build.Pipeline.Slug]; ok {
-			grouped[build.Pipeline.Slug] = append(grouped[build.Pipeline.Slug], build)
-		} else {
-			grouped[build.Pipeline.Slug] = []Build{}
-			grouped[build.Pipeline.Slug] = append(grouped[build.Pipeline.Slug], build)
-		}
-	}
-
-	return grouped
-}
-
-func getLongestPipelineLength(builds []Build) int {
-	maxPipelineLength := 0
-
-	for _, build := range builds {
-		if len(build.Pipeline.Slug) > maxPipelineLength {
-			maxPipelineLength = len(build.Pipeline.Slug)
-		}
-	}
-
-	return maxPipelineLength
-}
-
-func padRight(text string, length int) string {
-	padLength := length - len(text)
-
-	if padLength <= 0 {
-		return text[:length]
-	}
-
-	return text + strings.Repeat(" ", padLength)
-}
-
-func buildColor(state string) string {
-	switch state {
-	case "passed":
-		return "green"
-	case "failed":
-		return "red"
-	default:
-		return "yellow"
-	}
+	return title, displayData.Content(), false
 }


### PR DESCRIPTION
I noticed that the order of my Pipelines would shuffle between refreshes.
The display data was just looping over a map, which is not ordered in Go.

I introduced a struct to hold the data and display order. I followed the docs on how to sort the `[]Build`s. Since it required introducing a few new types/funcs, I pulled all the display logic to its own type and file.