### PR TITLE
added modules cmdrunner2 and resourceusage2

### DIFF
--- a/app/widget_maker.go
+++ b/app/widget_maker.go
@@ -8,6 +8,7 @@ import (
 	"github.com/wtfutil/wtf/modules/circleci"
 	"github.com/wtfutil/wtf/modules/clocks"
 	"github.com/wtfutil/wtf/modules/cmdrunner"
+	"github.com/wtfutil/wtf/modules/cmdrunner2"
 	"github.com/wtfutil/wtf/modules/cryptoexchanges/bittrex"
 	"github.com/wtfutil/wtf/modules/cryptoexchanges/blockfolio"
 	"github.com/wtfutil/wtf/modules/cryptoexchanges/cryptolive"
@@ -38,6 +39,7 @@ import (
 	"github.com/wtfutil/wtf/modules/pagerduty"
 	"github.com/wtfutil/wtf/modules/power"
 	"github.com/wtfutil/wtf/modules/resourceusage"
+	"github.com/wtfutil/wtf/modules/resourceusage2"
 	"github.com/wtfutil/wtf/modules/rollbar"
 	"github.com/wtfutil/wtf/modules/security"
 	"github.com/wtfutil/wtf/modules/spotify"
@@ -103,6 +105,33 @@ func MakeWidget(
 	case "cmdrunner":
 		settings := cmdrunner.NewSettingsFromYAML(moduleName, moduleConfig, config)
 		widget = cmdrunner.NewWidget(app, settings)
+	case "cmdrunner2":
+		settings := cmdrunner2.NewSettingsFromYAML(2, moduleName, moduleConfig, config)
+		widget = cmdrunner2.NewWidget(app, settings)
+	case "cmdrunner3":
+		settings := cmdrunner2.NewSettingsFromYAML(3, moduleName, moduleConfig, config)
+		widget = cmdrunner2.NewWidget(app, settings)
+	case "cmdrunner4":
+		settings := cmdrunner2.NewSettingsFromYAML(4, moduleName, moduleConfig, config)
+		widget = cmdrunner2.NewWidget(app, settings)
+	case "cmdrunner5":
+		settings := cmdrunner2.NewSettingsFromYAML(5, moduleName, moduleConfig, config)
+		widget = cmdrunner2.NewWidget(app, settings)
+	case "cmdrunner6":
+		settings := cmdrunner2.NewSettingsFromYAML(6, moduleName, moduleConfig, config)
+		widget = cmdrunner2.NewWidget(app, settings)
+	case "cmdrunner7":
+		settings := cmdrunner2.NewSettingsFromYAML(7, moduleName, moduleConfig, config)
+		widget = cmdrunner2.NewWidget(app, settings)
+	case "cmdrunner8":
+		settings := cmdrunner2.NewSettingsFromYAML(8, moduleName, moduleConfig, config)
+		widget = cmdrunner2.NewWidget(app, settings)
+	case "cmdrunner9":
+		settings := cmdrunner2.NewSettingsFromYAML(9, moduleName, moduleConfig, config)
+		widget = cmdrunner2.NewWidget(app, settings)
+	case "cmdrunner0":
+		settings := cmdrunner2.NewSettingsFromYAML(0, moduleName, moduleConfig, config)
+		widget = cmdrunner2.NewWidget(app, settings)
 	case "cryptolive":
 		settings := cryptolive.NewSettingsFromYAML(moduleName, moduleConfig, config)
 		widget = cryptolive.NewWidget(app, settings)
@@ -187,6 +216,9 @@ func MakeWidget(
 	case "resourceusage":
 		settings := resourceusage.NewSettingsFromYAML(moduleName, moduleConfig, config)
 		widget = resourceusage.NewWidget(app, settings)
+	case "resourceusage2":
+		settings := resourceusage2.NewSettingsFromYAML(moduleName, moduleConfig, config)
+		widget = resourceusage2.NewWidget(app, settings)
 	case "rollbar":
 		settings := rollbar.NewSettingsFromYAML(moduleName, moduleConfig, config)
 		widget = rollbar.NewWidget(app, pages, settings)

--- a/modules/cmdrunner2/settings.go
+++ b/modules/cmdrunner2/settings.go
@@ -1,0 +1,29 @@
+package cmdrunner2
+
+import (
+	"github.com/olebedev/config"
+	"github.com/wtfutil/wtf/cfg"
+	"github.com/wtfutil/wtf/utils"
+)
+
+const defaultTitle = "CmdRunner"
+
+type Settings struct {
+	common *cfg.Common
+
+	args []string `help:"The arguments to the command, with each item as an element in an array. Example: for curl -I cisco.com, the arguments array would be ['-I', 'cisco.com']."`
+	cmd  string   `help:"The terminal command to be run, withouth the arguments. Ie: ping, whoami, curl."`
+	num	 int	  `help:"The index of terminal to run, each terminal must have unique index."`	
+}
+
+func NewSettingsFromYAML(num int, name string, moduleConfig *config.Config, globalConfig *config.Config) *Settings {
+	settings := Settings{
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, moduleConfig, globalConfig),
+
+		args: utils.ToStrs(moduleConfig.UList("args")),
+		cmd:  moduleConfig.UString("cmd"),
+		num:  num,
+	}
+
+	return &settings
+}

--- a/modules/cmdrunner2/widget.go
+++ b/modules/cmdrunner2/widget.go
@@ -1,0 +1,69 @@
+package cmdrunner2
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/rivo/tview"
+	"github.com/wtfutil/wtf/utils"
+	"github.com/wtfutil/wtf/view"
+)
+
+type Widget struct {
+	view.TextWidget
+
+	args     []string
+	cmd      string
+	settings *Settings
+}
+
+// NewWidget creates a new instance of the widget
+func NewWidget(app *tview.Application, settings *Settings) *Widget {
+	widget := Widget{
+		TextWidget: view.NewTextWidget(app, settings.common, false),
+
+		args:     settings.args,
+		cmd:      settings.cmd,
+		settings: settings,
+	}
+
+	widget.View.SetWrap(true)
+
+	return &widget
+}
+
+func (widget *Widget) content() (string, string, bool) {
+	result := widget.execute()
+
+	ansiTitle := tview.TranslateANSI(widget.CommonSettings().Title)
+	if ansiTitle == defaultTitle {
+		ansiTitle = tview.TranslateANSI(widget.String())
+	}
+	ansiResult := tview.TranslateANSI(result)
+
+	return ansiTitle, ansiResult, false
+}
+
+// Refresh executes the command and updates the view with the results
+func (widget *Widget) Refresh() {
+	widget.Redraw(widget.content)
+}
+
+// String returns the string representation of the widget
+func (widget *Widget) String() string {
+	args := strings.Join(widget.args, " ")
+
+	if args != "" {
+		return fmt.Sprintf(" %s %s ", widget.cmd, args)
+	}
+
+	return fmt.Sprintf(" %s ", widget.cmd)
+}
+
+/* -------------------- Unexported Functions -------------------- */
+
+func (widget *Widget) execute() string {
+	cmd := exec.Command(widget.cmd, widget.args...)
+	return utils.ExecuteCommand(cmd)
+}

--- a/modules/resourceusage2/settings.go
+++ b/modules/resourceusage2/settings.go
@@ -1,0 +1,20 @@
+package resourceusage2
+
+import (
+	"github.com/olebedev/config"
+	"github.com/wtfutil/wtf/cfg"
+)
+
+const defaultTitle = "ResourceUsage"
+
+type Settings struct {
+	common *cfg.Common
+}
+
+func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
+	settings := Settings{
+		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, ymlConfig, globalConfig),
+	}
+
+	return &settings
+}

--- a/modules/resourceusage2/widget.go
+++ b/modules/resourceusage2/widget.go
@@ -1,0 +1,127 @@
+package resourceusage2
+
+import (
+	"fmt"
+	"math"
+	"time"
+
+	"code.cloudfoundry.org/bytefmt"
+	"github.com/rivo/tview"
+	"github.com/shirou/gopsutil/cpu"
+	"github.com/shirou/gopsutil/mem"
+	"github.com/wtfutil/wtf/view"
+)
+
+var started = false
+var ok = true
+
+// Widget define wtf widget to register widget later
+type Widget struct {
+	view.BarGraph
+
+	app      *tview.Application
+	settings *Settings
+}
+
+// NewWidget Make new instance of widget
+func NewWidget(app *tview.Application, settings *Settings) *Widget {
+	widget := Widget{
+		BarGraph: view.NewBarGraph(app, settings.common.Name, settings.common, false),
+
+		app:      app,
+		settings: settings,
+	}
+
+	widget.View.SetWrap(false)
+	widget.View.SetWordWrap(false)
+
+	return &widget
+}
+
+/* -------------------- Exported Functions -------------------- */
+
+// MakeGraph - Load the dead drop stats
+func MakeGraph(widget *Widget) {
+	cpuStats, err := cpu.Percent(time.Duration(0), false)
+	if err != nil {
+		return
+	}
+
+	var stats = make([]view.Bar, len(cpuStats)+2)
+
+	for i, stat := range cpuStats {
+		// Stats sometimes jump outside the 0-100 range, possibly due to timing
+		stat = math.Min(100, stat)
+		stat = math.Max(0, stat)
+
+		bar := view.Bar{
+			Label:      "CPU",
+			Percent:    int(stat),
+			ValueLabel: fmt.Sprintf("%d%%", int(stat)),
+		}
+
+		stats[i] = bar
+	}
+
+	memInfo, err := mem.VirtualMemory()
+	if err != nil {
+		return
+	}
+
+	memIndex := len(cpuStats)
+
+	usedMemLabel := bytefmt.ByteSize(memInfo.Used)
+	totalMemLabel := bytefmt.ByteSize(memInfo.Total)
+
+	if usedMemLabel[len(usedMemLabel)-1] == totalMemLabel[len(totalMemLabel)-1] {
+		usedMemLabel = usedMemLabel[:len(usedMemLabel)-1]
+	}
+
+	stats[memIndex] = view.Bar{
+		Label:      "Mem",
+		Percent:    int(memInfo.UsedPercent),
+		ValueLabel: fmt.Sprintf("%s/%s", usedMemLabel, totalMemLabel),
+	}
+
+	swapIndex := len(cpuStats) + 1
+	swapUsed := memInfo.SwapTotal - memInfo.SwapFree
+	var swapPercent float64
+	if memInfo.SwapTotal > 0 {
+		swapPercent = float64(swapUsed) / float64(memInfo.SwapTotal)
+	}
+
+	usedSwapLabel := bytefmt.ByteSize(swapUsed)
+	totalSwapLabel := bytefmt.ByteSize(memInfo.SwapTotal)
+
+	if usedSwapLabel[len(usedSwapLabel)-1] == totalMemLabel[len(totalSwapLabel)-1] {
+		usedSwapLabel = usedSwapLabel[:len(usedSwapLabel)-1]
+	}
+
+	stats[swapIndex] = view.Bar{
+		Label:      "Swp",
+		Percent:    int(swapPercent * 100),
+		ValueLabel: fmt.Sprintf("%s/%s", usedSwapLabel, totalSwapLabel),
+	}
+
+	widget.BarGraph.BuildBars(stats[:])
+}
+
+// Refresh & update after interval time
+func (widget *Widget) Refresh() {
+
+	if widget.Disabled() {
+		return
+	}
+
+	widget.View.Clear()
+
+	widget.app.QueueUpdateDraw(func() {
+		display(widget)
+	})
+}
+
+/* -------------------- Unexported Functions -------------------- */
+
+func display(widget *Widget) {
+	MakeGraph(widget)
+}

--- a/modules/resourceusage2/widget.go.orig
+++ b/modules/resourceusage2/widget.go.orig
@@ -1,0 +1,167 @@
+package resourceusage
+
+import (
+	"fmt"
+	"math"
+	"time"
+
+	"code.cloudfoundry.org/bytefmt"
+	"github.com/rivo/tview"
+	"github.com/shirou/gopsutil/cpu"
+	"github.com/shirou/gopsutil/mem"
+	"github.com/wtfutil/wtf/view"
+)
+
+var (
+	ok      = true
+	started = false
+)
+
+// Widget define wtf widget to register widget later
+type Widget struct {
+	view.BarGraph
+
+	app      *tview.Application
+	settings *Settings
+}
+
+// NewWidget Make new instance of widget
+func NewWidget(app *tview.Application, settings *Settings) *Widget {
+	widget := Widget{
+<<<<<<< HEAD:resourceusage/widget.go
+		BarGraph: wtf.NewBarGraph(app, " Resource Usage ", "resourceusage", false),
+=======
+		BarGraph: view.NewBarGraph(app, settings.common.Name, settings.common),
+
+		app:      app,
+		settings: settings,
+>>>>>>> refs/remotes/origin/master:modules/resourceusage/widget.go
+	}
+
+	widget.View.SetWrap(false)
+	widget.View.SetWordWrap(false)
+
+	return &widget
+}
+
+/* -------------------- Exported Functions -------------------- */
+
+// MakeGraph - Load the dead drop stats
+func MakeGraph(widget *Widget) {
+<<<<<<< HEAD:resourceusage/widget.go
+
+	cpuStats, err := cpu.Percent(time.Duration(0), false)
+=======
+	cpuStats, err := cpu.Percent(time.Duration(0), true)
+>>>>>>> refs/remotes/origin/master:modules/resourceusage/widget.go
+	if err != nil {
+		return
+	}
+
+	var stats = make([]view.Bar, len(cpuStats)+2)
+
+	for i, stat := range cpuStats {
+		// Stats sometimes jump outside the 0-100 range, possibly due to timing
+		stat = math.Min(100, stat)
+		stat = math.Max(0, stat)
+
+		bar := view.Bar{
+			Label:      fmt.Sprint(i),
+			Percent:    int(stat),
+			ValueLabel: fmt.Sprintf("%d%%", int(stat)),
+			LabelColor: "red",
+		}
+
+		stats[i] = bar
+	}
+
+	memInfo, err := mem.VirtualMemory()
+	if err != nil {
+		return
+	}
+
+	memIndex := len(cpuStats)
+
+	usedMemLabel := bytefmt.ByteSize(memInfo.Used)
+	totalMemLabel := bytefmt.ByteSize(memInfo.Total)
+
+	if usedMemLabel[len(usedMemLabel)-1] == totalMemLabel[len(totalMemLabel)-1] {
+		usedMemLabel = usedMemLabel[:len(usedMemLabel)-1]
+	}
+
+	stats[memIndex] = view.Bar{
+		Label:      "Mem",
+		Percent:    int(memInfo.UsedPercent),
+		ValueLabel: fmt.Sprintf("%s/%s", usedMemLabel, totalMemLabel),
+		LabelColor: "green",
+	}
+
+	swapIndex := len(cpuStats) + 1
+	swapUsed := memInfo.SwapTotal - memInfo.SwapFree
+	var swapPercent float64
+	if memInfo.SwapTotal > 0 {
+		swapPercent = float64(swapUsed) / float64(memInfo.SwapTotal)
+	}
+
+	usedSwapLabel := bytefmt.ByteSize(swapUsed)
+	totalSwapLabel := bytefmt.ByteSize(memInfo.SwapTotal)
+
+	if usedSwapLabel[len(usedSwapLabel)-1] == totalMemLabel[len(totalSwapLabel)-1] {
+		usedSwapLabel = usedSwapLabel[:len(usedSwapLabel)-1]
+	}
+
+	stats[swapIndex] = view.Bar{
+		Label:      "Swp",
+		Percent:    int(swapPercent * 100),
+		ValueLabel: fmt.Sprintf("%s/%s", usedSwapLabel, totalSwapLabel),
+		LabelColor: "yellow",
+	}
+
+	widget.BarGraph.BuildBars(stats[:])
+
+}
+
+// MakeGraph - Load the dead drop stats
+func Test(widget *Widget) {
+	cpuStats, err := cpu.Percent(time.Duration(0), false)
+	if err != nil {
+		return
+	}
+	
+	var stats = make([]wtf.Bar, 1)
+	
+		stats[0] = wtf.Bar{
+			Label:      fmt.Sprint("CPU"),
+			Percent:    int(cpuStats[0]),
+			ValueLabel: fmt.Sprintf("aaa"),
+		}
+	
+	
+	//widget.View.Clear()
+	widget.BarGraph.BuildBars(stats[:])
+}
+
+// Refresh & update after interval time
+func (widget *Widget) Refresh() {
+
+	if widget.Disabled() {
+		return
+	}
+
+	//widget.View.Clear()
+
+<<<<<<< HEAD:resourceusage/widget.go
+	display(widget)
+	//Test(widget)
+=======
+	widget.app.QueueUpdateDraw(func() {
+		display(widget)
+	})
+>>>>>>> refs/remotes/origin/master:modules/resourceusage/widget.go
+}
+
+/* -------------------- Unexported Functions -------------------- */
+
+func display(widget *Widget) {
+	MakeGraph(widget)
+}


### PR DESCRIPTION
The problem of module cmdrunner is that it can only be used once on the dashboard. I propose a simple extension (could probably be made even simpler, more elegant and with more code reuse) that allows creating cmdrunner2, cmdrunner3, ... and thus multiple cmdrunners.

Second extension (really sorry for making 2 per pull request) is adding an option to not display individual cores in resourceusage plugin. I am working on AMD threadripper, and stats for 32 individual cores are really not interesting to look at. I cloned resourceusage to resourceusage2 and simply changed individual core stats to overall CPU stats. 

The presented solution allows me to stay largely independent of main repo code changes (only widget_maker has to be merged) but I believe the proposed changes could be integrated in a nicer way.