### PR TITLE
Expose the widget dimensions in cmdrunner

### DIFF
--- a/modules/cmdrunner/settings.go
+++ b/modules/cmdrunner/settings.go
@@ -19,6 +19,10 @@ type Settings struct {
 	cmd      string   `help:"The terminal command to be run, withouth the arguments. Ie: ping, whoami, curl."`
 	tail     bool     `help:"Automatically scroll to the end of the command output."`
 	maxLines int      `help:"Maximum number of lines kept in the buffer."`
+
+	// The dimensions of the module
+	width  int
+	height int
 }
 
 // NewSettingsFromYAML loads the cmdrunner portion of the WTF config
@@ -32,6 +36,8 @@ func NewSettingsFromYAML(name string, moduleConfig *config.Config, globalConfig 
 		tail:     moduleConfig.UBool("tail"),
 		maxLines: moduleConfig.UInt("maxLines", 256),
 	}
+
+	settings.width, settings.height = utils.CalculateDimensions(moduleConfig, globalConfig)
 
 	return &settings
 }

--- a/modules/cmdrunner/widget.go
+++ b/modules/cmdrunner/widget.go
@@ -3,6 +3,7 @@ package cmdrunner
 import (
 	"bytes"
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 	"sync"
@@ -108,6 +109,7 @@ func (widget *Widget) execute() {
 	// Setup the command to run
 	cmd := exec.Command(widget.settings.cmd, widget.settings.args...)
 	cmd.Stdout = widget
+	cmd.Env = widget.environment()
 
 	// Run the command and wait for it to exit in another Go-routine
 	go func() {
@@ -133,4 +135,14 @@ func (widget *Widget) drainLines(n int) {
 	for i := 0; i < n; i++ {
 		widget.buffer.ReadBytes('\n')
 	}
+}
+
+func (widget *Widget) environment() []string {
+	envs := os.Environ()
+	envs = append(
+		envs,
+		fmt.Sprintf("WTF_WIDGET_WIDTH=%d", widget.settings.width),
+		fmt.Sprintf("WTF_WIDGET_HEIGHT=%d", widget.settings.height),
+	)
+	return envs
 }


### PR DESCRIPTION
This PR contains two changes:
- Added the utils.CalculateDimensions function to calculate the widget dimensions
- The cmdrunner widget now sets the WTF_WIDGET_WIDTH and WTF_WIDGET_HEIGHT environment variables to allow called commands/scripts to fill the widget
