### PR TITLE
Secrets file for API Keys

### DIFF
--- a/app/wtf_app.go
+++ b/app/wtf_app.go
@@ -17,23 +17,25 @@ import (
 // WtfApp is the container for a collection of widgets that are all constructed from a single
 // configuration file and displayed together
 type WtfApp struct {
-	app            *tview.Application
-	config         *config.Config
-	configFilePath string
-	display        *Display
-	focusTracker   FocusTracker
-	pages          *tview.Pages
-	validator      *ModuleValidator
-	widgets        []wtf.Wtfable
+	app             *tview.Application
+	config          *config.Config
+	configFilePath  string
+	secretsFilePath string
+	display         *Display
+	focusTracker    FocusTracker
+	pages           *tview.Pages
+	validator       *ModuleValidator
+	widgets         []wtf.Wtfable
 }
 
 // NewWtfApp creates and returns an instance of WtfApp
-func NewWtfApp(app *tview.Application, config *config.Config, configFilePath string) *WtfApp {
+func NewWtfApp(app *tview.Application, config *config.Config, configFilePath string, secretsFilePath string) *WtfApp {
 	wtfApp := WtfApp{
-		app:            app,
-		config:         config,
-		configFilePath: configFilePath,
-		pages:          tview.NewPages(),
+		app:             app,
+		config:          config,
+		configFilePath:  configFilePath,
+		secretsFilePath: secretsFilePath,
+		pages:           tview.NewPages(),
 	}
 
 	wtfApp.app.SetBeforeDrawFunc(func(s tcell.Screen) bool {
@@ -139,7 +141,8 @@ func (wtfApp *WtfApp) watchForConfigChanges() {
 				wtfApp.Stop()
 
 				config := cfg.LoadWtfConfigFile(wtfApp.configFilePath)
-				newApp := NewWtfApp(wtfApp.app, config, wtfApp.configFilePath)
+				secrets := cfg.LoadWtfSecretsFile(wtfApp.secretsFilePath)
+				newApp := NewWtfApp(wtfApp.app, config, wtfApp.configFilePath, wtfApp.secretsFilePath)
 
 				newApp.Start()
 			case err := <-watch.Error:

--- a/cfg/default_config_file.go
+++ b/cfg/default_config_file.go
@@ -103,3 +103,10 @@ wtf:
       refreshInterval: 30
       type: cmdrunner
 `
+const defaultSecretsFile = `
+wtf:
+  keys:
+  # API keys and other secrets are listed below. For example:
+  #WTF_GITHUB_TOKEN: AVERYLONGSECRET
+
+`

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/gogo/protobuf v1.3.0 // indirect
 	github.com/golang/glog v0.0.0-20170312005925-543a34c32e4d // indirect
 	github.com/golang/groupcache v0.0.0-20191002201903-404acd9df4cc // indirect
+	github.com/google/btree v1.0.0 // indirect
 	github.com/google/go-cmp v0.3.1 // indirect
 	github.com/google/go-github/v26 v26.1.3+incompatible
 	github.com/googleapis/gnostic v0.3.1 // indirect


### PR DESCRIPTION
This is still very much a work in progress. I'm attempting to help resolve #517 by creating a single file to store API keys (as discussed [here](https://github.com/wtfutil/wtf/issues/517#issuecomment-526019827)), which can then be excluded from config backup and management systems like RCM and the like. 

A solution like this seems better to me than loading these keys as environment variables in the shell, where they could be read in memory by other programs.

I've made the default file and added it to the config, and now my build tests return:

```
app/wtf_app.go:144:5: secrets declared and not used
```

This is where my limited knowledge of Go ends. What I do not yet know how to do is take the contents of the secrets file and load them as environment variables. Anyone who wants to contribute to this branch is welcome to do so. Likewise, any documentation of tutorials you think would be useful in finishing this would be much appreciated.

#hacktoberfest