### PR TITLE
Remove pull request count from issue count

### DIFF
--- a/modules/github/github_repo.go
+++ b/modules/github/github_repo.go
@@ -63,7 +63,9 @@ func (repo *GithubRepo) IssueCount() int {
 		return 0
 	}
 
-	return *repo.RemoteRepo.OpenIssuesCount
+	issuesLessPulls := *repo.RemoteRepo.OpenIssuesCount - len(repo.PullRequests)
+
+	return issuesLessPulls
 }
 
 // PullRequestCount returns the total amount of pull requests as an int


### PR DESCRIPTION
Closes #693 

From the [GitHub API Docs](https://developer.github.com/v3/issues/)

> **Note**: GitHub's REST API v3 considers every pull request an issue, but not every issue is a pull request. For this reason, "Issues" endpoints may return both issues and pull requests in the response. You can identify pull requests by the `pull_request` key.
>
>Be aware that the `id` of a pull request returned from "Issues" endpoints will be an issue id. To find out the pull request id, use the "List pull requests" endpoint.

I assume that we want the Stats for the GitHub module to show an Issue count that matches only Issues, not Issues + Pull requests. This patch subtracts Pull requests from the count of issues.

#hacktoberfest