### PR TITLE
Optimizations in ./utils/

### DIFF
--- a/utils/conversions.go
+++ b/utils/conversions.go
@@ -8,7 +8,7 @@ import (
 
 // MapToStrs takes a map of interfaces and returns a map of strings
 func MapToStrs(aMap map[string]interface{}) map[string]string {
-	results := make(map[string]string)
+	results := make(map[string]string, len(aMap))
 
 	for key, val := range aMap {
 		results[key] = val.(string)
@@ -21,10 +21,10 @@ func MapToStrs(aMap map[string]interface{}) map[string]string {
 
 // ToInts takes a slice of interfaces and returns a slice of ints
 func ToInts(slice []interface{}) []int {
-	results := []int{}
+	results := make([]int, len(slice))
 
-	for _, val := range slice {
-		results = append(results, val.(int))
+	for i, val := range slice {
+		results[i] = val.(int)
 	}
 
 	return results
@@ -32,14 +32,14 @@ func ToInts(slice []interface{}) []int {
 
 // ToStrs takes a slice of interfaces and returns a slice of strings
 func ToStrs(slice []interface{}) []string {
-	results := []string{}
+	results := make([]string, len(slice))
 
-	for _, val := range slice {
-		switch val.(type) {
+	for i, val := range slice {
+		switch t := val.(type) {
 		case int:
-			results = append(results, strconv.Itoa(val.(int)))
+			results[i] = strconv.Itoa(t)
 		case string:
-			results = append(results, val.(string))
+			results[i] = t
 		}
 	}
 

--- a/utils/email_addresses.go
+++ b/utils/email_addresses.go
@@ -25,10 +25,10 @@ func NameFromEmail(email string) string {
 //    > []string{"Test_user", "Other_user"}
 //
 func NamesFromEmails(emails []string) []string {
-	names := []string{}
+	names := make([]string, len(emails))
 
-	for _, email := range emails {
-		names = append(names, NameFromEmail(email))
+	for i, email := range emails {
+		names[i] = NameFromEmail(email)
 	}
 
 	return names

--- a/utils/homedir.go
+++ b/utils/homedir.go
@@ -6,7 +6,7 @@ package utils
 
 import (
 	"errors"
-	"os/user"
+	"os"
 	"path/filepath"
 )
 
@@ -37,14 +37,5 @@ func ExpandHomeDir(path string) (string, error) {
 // Home returns the home directory for the executing user.
 // An error is returned if a home directory cannot be detected.
 func Home() (string, error) {
-	currentUser, err := user.Current()
-	if err != nil {
-		return "", err
-	}
-
-	if currentUser.HomeDir == "" {
-		return "", errors.New("cannot find user-specific home dir")
-	}
-
-	return currentUser.HomeDir, nil
+	return os.UserHomeDir()
 }

--- a/utils/homedir.go
+++ b/utils/homedir.go
@@ -6,7 +6,7 @@ package utils
 
 import (
 	"errors"
-	"os"
+	"os/user"
 	"path/filepath"
 )
 
@@ -37,5 +37,14 @@ func ExpandHomeDir(path string) (string, error) {
 // Home returns the home directory for the executing user.
 // An error is returned if a home directory cannot be detected.
 func Home() (string, error) {
-	return os.UserHomeDir()
+	currentUser, err := user.Current()
+	if err != nil {
+		return "", err
+	}
+
+	if currentUser.HomeDir == "" {
+		return "", errors.New("cannot find user-specific home dir")
+	}
+
+	return currentUser.HomeDir, nil
 }


### PR DESCRIPTION
This PR optimizes a few function in the utils package. Specially the `ToInts` and `ToStrs` functions did not pre-allocate slices and produced unnecessary temporary slices while converting.

- In `conversions.go` the slices are preallocated and the map is created with a size hint. Also the type switch now uses the result of the switch rather than type asserting again.
- In `email_addresses.go` the email slice is preallocated.
- ~In `homedir.go` the `Home` function now just calls `os.UserHomeDir()` which does the exact same thing.~
- In `utils.go` the `ExecuteCommand` function directly writes into a buffer instead of having an intermediate `ioutil.ReadAll` call. Also the `ParseJson` function now decodes directly from the stream (but just one object instead of multiple which may replace the previous ones).
