### PR TITLE
Removed Go 1.11 from the tested versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: go
 go:
-  - "1.11.x"
   - "1.12.x"
   - "1.13.x"
 sudo: false

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ make install
 make run
 ```
 
-**Note:** WTF is _only_ compatible with Go versions **1.11.0** or later (due to the use of Go modules). If you would like to use `gccgo` to compile, you _must_ use `gccgo-9` or later which introduces support for Go modules.
+**Note:** WTF is _only_ compatible with Go versions **1.12.0** or later (due to the use of Go modules and newer standard library functions). If you would like to use `gccgo` to compile, you _must_ use `gccgo-9` or later which introduces support for Go modules.
 
 ## Communication
 


### PR DESCRIPTION
In order to use newer Go features we need to cut support for older versions.

See https://github.com/wtfutil/wtf/pull/695#issuecomment-541257512