### PR TITLE
Remove blank line from default config.

### DIFF
--- a/cfg/default_config_file.go
+++ b/cfg/default_config_file.go
@@ -1,7 +1,6 @@
 package cfg
 
-const defaultConfigFile = `
-wtf:
+const defaultConfigFile = `wtf:
   colors:
     border:
       focusable: darkslateblue


### PR DESCRIPTION
When using backticks in Go, the string starts right there and then. The current behavior causes the default wtfutil config that is created to start with a blank line.

This PR removes that blank line (the invisible `\n` character).