### PR TITLE
Adds football fixtures/standings widget

### DIFF
--- a/app/widget_maker.go
+++ b/app/widget_maker.go
@@ -18,6 +18,7 @@ import (
 	"github.com/wtfutil/wtf/modules/digitalclock"
 	"github.com/wtfutil/wtf/modules/docker"
 	"github.com/wtfutil/wtf/modules/feedreader"
+	"github.com/wtfutil/wtf/modules/football"
 	"github.com/wtfutil/wtf/modules/gcal"
 	"github.com/wtfutil/wtf/modules/gerrit"
 	"github.com/wtfutil/wtf/modules/git"
@@ -128,6 +129,9 @@ func MakeWidget(
 	case "feedreader":
 		settings := feedreader.NewSettingsFromYAML(moduleName, moduleConfig, config)
 		widget = feedreader.NewWidget(app, pages, settings)
+	case "football":
+		settings := football.NewSettingsFromYAML(moduleName, moduleConfig, config)
+		widget = football.NewWidget(app, pages, settings)
 	case "gcal":
 		settings := gcal.NewSettingsFromYAML(moduleName, moduleConfig, config)
 		widget = gcal.NewWidget(app, settings)

--- a/go.mod
+++ b/go.mod
@@ -19,12 +19,10 @@ require (
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.4.0 // indirect
 	github.com/dustin/go-humanize v1.0.0
-	github.com/fatih/color v1.7.0
 	github.com/gdamore/tcell v1.3.0
 	github.com/go-ole/go-ole v1.2.4 // indirect
 	github.com/godbus/dbus v4.1.0+incompatible // indirect
 	github.com/google/go-github/v26 v26.1.3
-	github.com/gookit/color v1.2.0
 	github.com/gophercloud/gophercloud v0.5.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.1 // indirect
 	github.com/hekmon/cunits v2.0.1+incompatible // indirect

--- a/go.mod
+++ b/go.mod
@@ -19,10 +19,12 @@ require (
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.4.0 // indirect
 	github.com/dustin/go-humanize v1.0.0
+	github.com/fatih/color v1.7.0
 	github.com/gdamore/tcell v1.3.0
 	github.com/go-ole/go-ole v1.2.4 // indirect
 	github.com/godbus/dbus v4.1.0+incompatible // indirect
 	github.com/google/go-github/v26 v26.1.3
+	github.com/gookit/color v1.2.0
 	github.com/gophercloud/gophercloud v0.5.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.1 // indirect
 	github.com/hekmon/cunits v2.0.1+incompatible // indirect
@@ -36,7 +38,6 @@ require (
 	github.com/olebedev/config v0.0.0-20190528211619-364964f3a8e4
 	github.com/olekukonko/tablewriter v0.0.1
 	github.com/onsi/ginkgo v1.10.2 // indirect
-	github.com/onsi/gomega v1.7.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
 	github.com/pkg/errors v0.8.1
 	github.com/pkg/profile v1.3.0

--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,9 @@ require (
 	github.com/mmcdole/gofeed v1.0.0-beta2
 	github.com/mmcdole/goxpp v0.0.0-20181012175147-0068e33feabf // indirect
 	github.com/olebedev/config v0.0.0-20190528211619-364964f3a8e4
+	github.com/olekukonko/tablewriter v0.0.1
+	github.com/onsi/ginkgo v1.10.2 // indirect
+	github.com/onsi/gomega v1.7.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
 	github.com/pkg/errors v0.8.1
 	github.com/pkg/profile v1.3.0
@@ -42,7 +45,11 @@ require (
 	github.com/shirou/gopsutil v2.19.9+incompatible
 	github.com/sticreations/spotigopher v0.0.0-20181009182052-98632f6f94b0
 	github.com/stretchr/testify v1.4.0
+<<<<<<< HEAD
 	github.com/wtfutil/todoist v0.0.1
+=======
+	github.com/wtfutil/todoist v0.0.0-20190913231042-97395e581a76
+>>>>>>> 59b8877b... feat: Add new widget for football scores and standings
 	github.com/xanzy/go-gitlab v0.20.1
 	github.com/yfronto/newrelic v0.0.0-00010101000000-000000000000
 	github.com/zmb3/spotify v0.0.0-20191010212056-e12fb981aacb

--- a/go.sum
+++ b/go.sum
@@ -29,8 +29,6 @@ github.com/adlio/trello v1.4.0/go.mod h1:l2068AhUuUuQ9Vsb95ECMueHThYyAj4e85lWPmr
 github.com/akavel/rsrc v0.8.0/go.mod h1:uLoCtb9J+EyAqh+26kdrTgmzRBFPGOolLWKpdxkKq+c=
 github.com/alecthomas/assert v0.0.0-20170929043011-405dbfeb8e38 h1:smF2tmSOzy2Mm+0dGI2AIUHY+w0BUc+4tn40djz7+6U=
 github.com/alecthomas/assert v0.0.0-20170929043011-405dbfeb8e38/go.mod h1:r7bzyVFMNntcxPZXK3/+KdruV1H5KSlyVY0gc+NgInI=
-github.com/alecthomas/chroma v0.6.7 h1:1hKci+AyKOxJrugR9veaocu9DQGR2/GecI72BpaO0Rg=
-github.com/alecthomas/chroma v0.6.7/go.mod h1:zVlgtbRS7BJDrDY9SB238RmpoCBCYFlLmcfZ3durxTk=
 github.com/alecthomas/chroma v0.6.8 h1:TW4JJaIdbAbMyUtGEd6BukFlOKYvVQz3vVhLBEUNwMU=
 github.com/alecthomas/chroma v0.6.8/go.mod h1:o9ohftueRi7H5be3+Q2cQCNa/YnLBFUNx40ZJfGVFKA=
 github.com/alecthomas/colour v0.0.0-20160524082231-60882d9e2721 h1:JHZL0hZKJ1VENNfmXvHbgYlbUOvpzYzvy2aZU5gXVeo=
@@ -75,6 +73,8 @@ github.com/elazarl/goproxy v0.0.0-20170405201442-c4fc26588b6e/go.mod h1:/Zj4wYkg
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/evanphx/json-patch v0.0.0-20190203023257-5858425f7550/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
+github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
+github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/gdamore/encoding v1.0.0 h1:+7OoQ1Bc6eTm5niUzBa0Ctsh6JbMW6Ra+YNuAtDBdko=
@@ -127,6 +127,8 @@ github.com/googleapis/gax-go/v2 v2.0.5 h1:sjZBwGj9Jlw33ImPtvFviGYvseOtDM7hkSKB7+
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d h1:7XGaL1e6bYS1yIonGp9761ExpPPV1ui0SAC59Yube9k=
 github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
+github.com/gookit/color v1.2.0 h1:lHA77Kuyi5JpBnA9ESvwkY+nanLjRZ0mHbWQXRYk2Lk=
+github.com/gookit/color v1.2.0/go.mod h1:AhIE+pS6D4Ql0SQWbBeXPHw7gY0/sjHoA4s/n1KB7xg=
 github.com/gophercloud/gophercloud v0.0.0-20190126172459-c818fa66e4c8/go.mod h1:3WdhXV3rUYy9p6AUW8d94kr+HS62Y4VL9mBnFxsD8q4=
 github.com/gophercloud/gophercloud v0.5.0 h1:uM4HalWpEdxORniBrzicAtpYNTk45p5QLLS7zwc1uAU=
 github.com/gophercloud/gophercloud v0.5.0/go.mod h1:b1k/BkBA9smzYde6p6zYLIe5JNAEoJzUWaIRh+9A/j0=
@@ -170,6 +172,7 @@ github.com/logrusorgru/aurora v0.0.0-20190803045625-94edacc10f9b/go.mod h1:7rIyQ
 github.com/lucasb-eyer/go-colorful v1.0.2 h1:mCMFu6PgSozg9tDNMMK3g18oJBX7oYGrC09mS6CXfO4=
 github.com/lucasb-eyer/go-colorful v1.0.2/go.mod h1:0MS4r+7BZKSJ5mw4/S5MPN+qHFF1fYclkSPilDOKW0s=
 github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
+github.com/mattn/go-colorable v0.0.9 h1:UVL0vNpWh04HeJXV0KLcaT7r06gOH2l4OW6ddYRUIY4=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-isatty v0.0.4 h1:bnP0vzxcAdeI1zdubAl5PjU6zsERjGZb7raWodagDYs=
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
@@ -200,6 +203,8 @@ github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.10.1 h1:q/mM8GF/n0shIN8SaAZ0V+jnLPzen6WIVZdiwrRlMlo=
 github.com/onsi/ginkgo v1.10.1/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
+github.com/onsi/ginkgo v1.10.2 h1:uqH7bpe+ERSiDa34FDOF7RikN6RzXgduUF8yarlZp94=
+github.com/onsi/ginkgo v1.10.2/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v0.0.0-20190113212917-5533ce8a0da3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.7.0 h1:XPnZz8VVBHjVsy1vzJmRwIcSwiUO+JFfrv/xGiigmME=
@@ -229,6 +234,7 @@ github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMB
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/pflag v0.0.0-20170130214245-9ff6c6923cff/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.1/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
+github.com/spf13/pflag v1.0.3 h1:zPAT6CGy6wXeQ7NtTnaTerfKOsV6V6F8agHXFiazDkg=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/sticreations/spotigopher v0.0.0-20181009182052-98632f6f94b0 h1:WWyBZL7bRdl7Do39EvkJmBFXT11uXLACy0cJHHOZ7IE=
 github.com/sticreations/spotigopher v0.0.0-20181009182052-98632f6f94b0/go.mod h1:DjuRbAVIoxD4Lv7aE12Km2XYYYKrtXXNbpivYwXv2HE=
@@ -243,8 +249,6 @@ github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyC
 github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=
 github.com/wtfutil/todoist v0.0.1 h1:E3srzocggLHme8zIEAEXXoY/fQZtFRjW69m4OiYv3hg=
 github.com/wtfutil/todoist v0.0.1/go.mod h1:YuuGLJSsTK6DGBD5Zaf3J8LSMfpEC2WtzYPey3XVOdI=
-github.com/xanzy/go-gitlab v0.20.1 h1:+1BWDry84G5PzsnzG9DI4YjPbHeWKyouM0q0gfDPKgY=
-github.com/xanzy/go-gitlab v0.20.1/go.mod h1:LSfUQ9OPDnwRqulJk2HcWaAiFfCzaknyeGvjQI67MbE=
 github.com/xanzy/go-gitlab v0.21.0 h1:Ru55sR4TBoDNsAKwCOpzeaGtbiWj7xTksVmzBJbLu6c=
 github.com/xanzy/go-gitlab v0.21.0/go.mod h1:t4Bmvnxj7k37S4Y17lfLx+nLqkf/oQwT2HagfWKv5Og=
 github.com/zmb3/spotify v0.0.0-20191010212056-e12fb981aacb h1:uWB0RGxBo7AToSJ3rvoCZhXtLw4U7XISXSezPewmfic=
@@ -339,6 +343,7 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
+gopkg.in/inf.v0 v0.9.0 h1:3zYtXIO92bvsdS3ggAdA8Gb4Azj0YU+TVY1uGYNFA8o=
 gopkg.in/inf.v0 v0.9.0/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/jarcoal/httpmock.v1 v1.0.0-20181110093347-3be5f16b70eb h1:ggw12VRqlkVtHkyK+zh3QP+V6PIGAuKQG/u0Mnkn6TQ=
 gopkg.in/jarcoal/httpmock.v1 v1.0.0-20181110093347-3be5f16b70eb/go.mod h1:d3R+NllX3X5e0zlG1Rful3uLvsGC/Q3OHut5464DEQw=

--- a/go.sum
+++ b/go.sum
@@ -192,6 +192,8 @@ github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+
 github.com/nkovacs/streamquote v0.0.0-20170412213628-49af9bddb229/go.mod h1:0aYXnNPJ8l7uZxf45rWW1a/uME32OF0rhiYGNQ2oF2E=
 github.com/olebedev/config v0.0.0-20190528211619-364964f3a8e4 h1:JnVsYEQzhEcOspy6ngIYNF2u0h2mjkXZptzX0IzZQ4g=
 github.com/olebedev/config v0.0.0-20190528211619-364964f3a8e4/go.mod h1:RL5+WRxWTAXqqCi9i+eZlHrUtO7AQujUqWi+xMohmc4=
+github.com/olekukonko/tablewriter v0.0.1 h1:b3iUnf1v+ppJiOfNX4yxxqfWKMQPZR5yoh8urCTFX88=
+github.com/olekukonko/tablewriter v0.0.1/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.10.1 h1:q/mM8GF/n0shIN8SaAZ0V+jnLPzen6WIVZdiwrRlMlo=
@@ -225,7 +227,6 @@ github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMB
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/pflag v0.0.0-20170130214245-9ff6c6923cff/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.1/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
-github.com/spf13/pflag v1.0.3 h1:zPAT6CGy6wXeQ7NtTnaTerfKOsV6V6F8agHXFiazDkg=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/sticreations/spotigopher v0.0.0-20181009182052-98632f6f94b0 h1:WWyBZL7bRdl7Do39EvkJmBFXT11uXLACy0cJHHOZ7IE=
 github.com/sticreations/spotigopher v0.0.0-20181009182052-98632f6f94b0/go.mod h1:DjuRbAVIoxD4Lv7aE12Km2XYYYKrtXXNbpivYwXv2HE=
@@ -334,7 +335,6 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
-gopkg.in/inf.v0 v0.9.0 h1:3zYtXIO92bvsdS3ggAdA8Gb4Azj0YU+TVY1uGYNFA8o=
 gopkg.in/inf.v0 v0.9.0/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/jarcoal/httpmock.v1 v1.0.0-20181110093347-3be5f16b70eb h1:ggw12VRqlkVtHkyK+zh3QP+V6PIGAuKQG/u0Mnkn6TQ=
 gopkg.in/jarcoal/httpmock.v1 v1.0.0-20181110093347-3be5f16b70eb/go.mod h1:d3R+NllX3X5e0zlG1Rful3uLvsGC/Q3OHut5464DEQw=

--- a/go.sum
+++ b/go.sum
@@ -73,8 +73,6 @@ github.com/elazarl/goproxy v0.0.0-20170405201442-c4fc26588b6e/go.mod h1:/Zj4wYkg
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/evanphx/json-patch v0.0.0-20190203023257-5858425f7550/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
-github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
-github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/gdamore/encoding v1.0.0 h1:+7OoQ1Bc6eTm5niUzBa0Ctsh6JbMW6Ra+YNuAtDBdko=
@@ -127,8 +125,6 @@ github.com/googleapis/gax-go/v2 v2.0.5 h1:sjZBwGj9Jlw33ImPtvFviGYvseOtDM7hkSKB7+
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d h1:7XGaL1e6bYS1yIonGp9761ExpPPV1ui0SAC59Yube9k=
 github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
-github.com/gookit/color v1.2.0 h1:lHA77Kuyi5JpBnA9ESvwkY+nanLjRZ0mHbWQXRYk2Lk=
-github.com/gookit/color v1.2.0/go.mod h1:AhIE+pS6D4Ql0SQWbBeXPHw7gY0/sjHoA4s/n1KB7xg=
 github.com/gophercloud/gophercloud v0.0.0-20190126172459-c818fa66e4c8/go.mod h1:3WdhXV3rUYy9p6AUW8d94kr+HS62Y4VL9mBnFxsD8q4=
 github.com/gophercloud/gophercloud v0.5.0 h1:uM4HalWpEdxORniBrzicAtpYNTk45p5QLLS7zwc1uAU=
 github.com/gophercloud/gophercloud v0.5.0/go.mod h1:b1k/BkBA9smzYde6p6zYLIe5JNAEoJzUWaIRh+9A/j0=

--- a/modules/football/client.go
+++ b/modules/football/client.go
@@ -1,0 +1,45 @@
+package football
+
+import (
+	"fmt"
+	"net/http"
+)
+
+var (
+	footballAPIUrl = "http://api.football-data.org/v2"
+)
+
+type leagueInfo struct {
+	id      int
+	caption string
+}
+
+type Client struct {
+	apiKey string
+}
+
+func NewClient(apiKey string) *Client {
+	client := Client{
+		apiKey: apiKey,
+	}
+
+	return &client
+}
+
+func (client *Client) footballRequest(path string, id int) (*http.Response, error) {
+
+	url := fmt.Sprintf("%s/competitions/%d/%s", footballAPIUrl, id, path)
+	req, err := http.NewRequest("GET", url, nil)
+	req.Header.Add("Accept", "application/json")
+	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("X-Auth-Token", client.apiKey)
+	if err != nil {
+		return nil, err
+	}
+	httpClient := &http.Client{}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}

--- a/modules/football/settings.go
+++ b/modules/football/settings.go
@@ -1,0 +1,37 @@
+package football
+
+import (
+	"os"
+
+	"github.com/olebedev/config"
+	"github.com/wtfutil/wtf/cfg"
+)
+
+const (
+	defaultFocusable = true
+	defaultTitle     = "football"
+)
+
+type Settings struct {
+	common        *cfg.Common
+	apiKey        string `help:"Your Football-data API token."`
+	league        string `help:"Name of the competition. For example PL"`
+	favTeam       string `help:"Teams to follow in mentioned league"`
+	matchesFrom   int    `help:"Matches till Today (Today - Number of days), Default: 2"`
+	matchesTo     int    `help:"Matches from Today (Today + Number of days), Default: 5"`
+	standingCount int    `help:"Top N number of teams in standings, Default: 5"`
+}
+
+func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
+
+	settings := Settings{
+		common:        cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+		apiKey:        ymlConfig.UString("apiKey", ymlConfig.UString("apikey", os.Getenv("WTF_FOOTBALL_API_KEY"))),
+		league:        ymlConfig.UString("league", ymlConfig.UString("league", os.Getenv("WTF_FOOTBALL_LEAGUE"))),
+		favTeam:       ymlConfig.UString("favTeam", ymlConfig.UString("favTeam", os.Getenv("WTF_FOOTBALL_TEAM"))),
+		matchesFrom:   ymlConfig.UInt("matchesFrom", 5),
+		matchesTo:     ymlConfig.UInt("matchesTo", 5),
+		standingCount: ymlConfig.UInt("standingCount", 5),
+	}
+	return &settings
+}

--- a/modules/football/types.go
+++ b/modules/football/types.go
@@ -1,0 +1,46 @@
+package football
+
+type Team struct {
+	Name string `json:"name"`
+}
+
+type LeagueStandings struct {
+	Standings []struct {
+		Table []Table `json:"table"`
+	} `json:"standings"`
+}
+
+type Table struct {
+	Draw           int  `json:"draw"`
+	GoalDifference int  `json:"goalDifference"`
+	Lost           int  `json:"lost"`
+	Won            int  `json:"won"`
+	PlayedGames    int  `json:"playedGames"`
+	Points         int  `json:"points"`
+	Position       int  `json:"position"`
+	Team           Team `json:"team"`
+}
+
+type LeagueFixtuers struct {
+	Matches []Matches `json:"matches"`
+}
+
+type Matches struct {
+	AwayTeam Team   `json:"awayTeam"`
+	HomeTeam Team   `json:"homeTeam"`
+	Score    Score  `json:"score"`
+	Stage    string `json:"stage"`
+	Status   string `json:"status"`
+	Date     string `json:"utcDate"`
+}
+
+type Score struct {
+	FullTime ScoreByTime `json:"fullTime"`
+	HalfTime ScoreByTime `json:"halfTime"`
+	Winner   string      `json:"winner"`
+}
+
+type ScoreByTime struct {
+	AwayTeam int `json:"awayTeam"`
+	HomeTeam int `json:"homeTeam"`
+}

--- a/modules/football/util.go
+++ b/modules/football/util.go
@@ -1,0 +1,37 @@
+package football
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/olekukonko/tablewriter"
+)
+
+func createTable(header []string, buf *bytes.Buffer) *tablewriter.Table {
+
+	table := tablewriter.NewWriter(buf)
+	if len(header) != 0 {
+		table.SetHeader(header)
+	}
+	table.SetBorder(false)
+	table.SetCenterSeparator(" ")
+	table.SetColumnSeparator(" ")
+	table.SetRowSeparator(" ")
+	table.SetAlignment(tablewriter.ALIGN_LEFT)
+
+	return table
+}
+
+func parseDateString(d string) string {
+
+	return fmt.Sprintf("🕙 %s", strings.Replace(d, "T", " ", 1))
+}
+
+func getDateString(offset int) string {
+
+	today := time.Now()
+	return today.AddDate(0, 0, offset).Format("2006-01-02")
+
+}

--- a/modules/football/widget.go
+++ b/modules/football/widget.go
@@ -153,17 +153,19 @@ func (widget *Widget) GetMatches(leagueId int) string {
 
 	if len(l.Matches) != 0 {
 
-		for _, val := range l.Matches {
-			if strings.Contains(val.AwayTeam.Name, widget.settings.favTeam) || strings.Contains(val.HomeTeam.Name, widget.settings.favTeam) || widget.settings.favTeam == "" {
-				if val.Status == "SCHEDULED" {
-					row := []string{"⚽", val.HomeTeam.Name, "🆚", val.AwayTeam.Name, parseDateString(val.Date)}
-					tScheduled.Append(row)
-				} else if val.Status == "FINISHED" {
-					row := []string{"⚽", val.HomeTeam.Name, strconv.Itoa(val.Score.FullTime.HomeTeam), "🆚", val.AwayTeam.Name, strconv.Itoa(val.Score.FullTime.AwayTeam)}
-					tPlayed.Append(row)
-				}
+		for _, m := range l.Matches {
+
+			widget.markFavorite(&m)
+
+			if m.Status == "SCHEDULED" {
+				row := []string{m.HomeTeam.Name, "🆚", m.AwayTeam.Name, parseDateString(m.Date)}
+				tScheduled.Append(row)
+			} else if m.Status == "FINISHED" {
+				row := []string{m.HomeTeam.Name, strconv.Itoa(m.Score.FullTime.HomeTeam), "🆚", m.AwayTeam.Name, strconv.Itoa(m.Score.FullTime.AwayTeam)}
+				tPlayed.Append(row)
 			}
 		}
+
 		tScheduled.Render()
 		tPlayed.Render()
 		if playedBuf.String() != "" {
@@ -178,4 +180,17 @@ func (widget *Widget) GetMatches(leagueId int) string {
 	}
 
 	return content
+}
+
+func (widget *Widget) markFavorite(m *Matches) {
+
+	switch {
+
+	case widget.settings.favTeam == "":
+		return
+	case strings.Contains(m.AwayTeam.Name, widget.settings.favTeam):
+		m.AwayTeam.Name = fmt.Sprintf("%s ⭐", m.AwayTeam.Name)
+	case strings.Contains(m.HomeTeam.Name, widget.settings.favTeam):
+		m.HomeTeam.Name = fmt.Sprintf("%s ⭐", m.HomeTeam.Name)
+	}
 }

--- a/modules/football/widget.go
+++ b/modules/football/widget.go
@@ -1,0 +1,181 @@
+package football
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"strconv"
+	"strings"
+
+	"github.com/rivo/tview"
+	"github.com/wtfutil/wtf/view"
+)
+
+var leagueID = map[string]leagueInfo{
+	"BSA": {2013, "Brazil Série A"},
+	"PL":  {2021, "English Premier League"},
+	"EC":  {2016, "English Championship"},
+	"EUC": {2018, "European Championship"},
+	"EL2": {444, "Campeonato Brasileiro da Série A"},
+	"CL":  {2001, "UEFA Champions League"},
+	"FL1": {2015, "French Ligue 1"},
+	"GB":  {2002, "German Bundesliga"},
+	"ISA": {2019, "Italy Serie A"},
+	"NE":  {2003, "Netherlands Eredivisie"},
+	"PPL": {2017, "Portugal Primeira Liga"},
+	"SPD": {2014, "Spain Primera Division"},
+	"WC":  {2000, "FIFA World Cup"},
+}
+
+type Widget struct {
+	view.TextWidget
+	*Client
+	settings *Settings
+	League   leagueInfo
+	err      error
+}
+
+func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
+	var widget Widget
+	leagueId, err := getLeague(settings.league)
+	if err != nil {
+		widget = Widget{
+			err:      fmt.Errorf("Unable to get the league id for provided league '%s'", settings.league),
+			Client:   NewClient(settings.apiKey),
+			settings: settings,
+		}
+		return &widget
+	}
+	widget = Widget{
+		TextWidget: view.NewTextWidget(app, settings.common),
+		Client:     NewClient(settings.apiKey),
+		League:     leagueId,
+		settings:   settings,
+	}
+	return &widget
+}
+
+func (widget *Widget) Refresh() {
+	widget.Redraw(widget.content)
+}
+
+func (widget *Widget) content() (string, string, bool) {
+
+	var content string
+	title := fmt.Sprintf("%s %s", widget.CommonSettings().Title, widget.League.caption)
+	wrap := false
+	if widget.err != nil {
+		return title, widget.err.Error(), true
+	}
+	content += widget.GetStandings(widget.League.id)
+	content += widget.GetMatches(widget.League.id)
+
+	return title, content, wrap
+}
+
+func getLeague(league string) (leagueInfo, error) {
+
+	var l leagueInfo
+	if val, ok := leagueID[league]; ok {
+		return val, nil
+	}
+	return l, fmt.Errorf("No such league")
+}
+
+// GetStandings of particular league
+func (widget *Widget) GetStandings(leagueId int) string {
+
+	var l LeagueStandings
+	var content string
+	content += fmt.Sprintf("Standings:\n\n")
+	buf := new(bytes.Buffer)
+	tStandings := createTable([]string{"No.", "Team", "MP", "Won", "Draw", "Lost", "GD", "Points"}, buf)
+	resp, err := widget.Client.footballRequest("standings", leagueId)
+	if err != nil {
+		return fmt.Sprintf("Error fetching standings: %s", err.Error())
+	}
+	defer resp.Body.Close()
+	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Sprintf("Error fetching standings: %s", err.Error())
+	}
+	err = json.Unmarshal(data, &l)
+	if err != nil {
+		return fmt.Sprintf("Error fetching standings")
+	}
+
+	if len(l.Standings) > 0 {
+		for _, i := range l.Standings[0].Table {
+			if i.Position <= widget.settings.standingCount {
+				row := []string{strconv.Itoa(i.Position), i.Team.Name, strconv.Itoa(i.PlayedGames), strconv.Itoa(i.Won), strconv.Itoa(i.Draw), strconv.Itoa(i.Lost), strconv.Itoa(i.GoalDifference), strconv.Itoa(i.Points)}
+				tStandings.Append(row)
+			}
+		}
+	} else {
+		return fmt.Sprintf("Error fetching standings")
+	}
+
+	tStandings.Render()
+	content += buf.String()
+
+	return content
+}
+
+// GetMatches of particular league
+func (widget *Widget) GetMatches(leagueId int) string {
+
+	var l LeagueFixtuers
+	var content string
+	scheduledBuf := new(bytes.Buffer)
+	playedBuf := new(bytes.Buffer)
+
+	tScheduled := createTable([]string{}, scheduledBuf)
+	tPlayed := createTable([]string{}, playedBuf)
+
+	from := getDateString(-widget.settings.matchesFrom)
+	to := getDateString(widget.settings.matchesTo)
+
+	requestPath := fmt.Sprintf("matches?dateFrom=%s&dateTo=%s", from, to)
+	resp, err := widget.Client.footballRequest(requestPath, leagueId)
+	if err != nil {
+		return fmt.Sprintf("Error fetching matches: %s", err.Error())
+	}
+	defer resp.Body.Close()
+	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Sprintf("Error fetching matches: %s", err.Error())
+	}
+	err = json.Unmarshal(data, &l)
+	if err != nil {
+		return fmt.Sprintf("Error fetching matches: %s", err.Error())
+	}
+
+	if len(l.Matches) != 0 {
+
+		for _, val := range l.Matches {
+			if strings.Contains(val.AwayTeam.Name, widget.settings.favTeam) || strings.Contains(val.HomeTeam.Name, widget.settings.favTeam) || widget.settings.favTeam == "" {
+				if val.Status == "SCHEDULED" {
+					row := []string{"⚽", val.HomeTeam.Name, "🆚", val.AwayTeam.Name, parseDateString(val.Date)}
+					tScheduled.Append(row)
+				} else if val.Status == "FINISHED" {
+					row := []string{"⚽", val.HomeTeam.Name, strconv.Itoa(val.Score.FullTime.HomeTeam), "🆚", val.AwayTeam.Name, strconv.Itoa(val.Score.FullTime.AwayTeam)}
+					tPlayed.Append(row)
+				}
+			}
+		}
+		tScheduled.Render()
+		tPlayed.Render()
+		if playedBuf.String() != "" {
+			content += "\nMatches Played:\n\n"
+			content += playedBuf.String()
+
+		}
+		if scheduledBuf.String() != "" {
+			content += "\nUpcoming Matches:\n\n"
+			content += scheduledBuf.String()
+		}
+	}
+
+	return content
+}

--- a/modules/football/widget.go
+++ b/modules/football/widget.go
@@ -105,15 +105,15 @@ func (widget *Widget) GetStandings(leagueId int) string {
 		return fmt.Sprintf("Error fetching standings")
 	}
 
-	if len(l.Standings) > 0 {
-		for _, i := range l.Standings[0].Table {
-			if i.Position <= widget.settings.standingCount {
-				row := []string{strconv.Itoa(i.Position), i.Team.Name, strconv.Itoa(i.PlayedGames), strconv.Itoa(i.Won), strconv.Itoa(i.Draw), strconv.Itoa(i.Lost), strconv.Itoa(i.GoalDifference), strconv.Itoa(i.Points)}
-				tStandings.Append(row)
-			}
-		}
-	} else {
+	if len(l.Standings) == 0 {
 		return fmt.Sprintf("Error fetching standings")
+	}
+
+	for _, i := range l.Standings[0].Table {
+		if i.Position <= widget.settings.standingCount {
+			row := []string{strconv.Itoa(i.Position), i.Team.Name, strconv.Itoa(i.PlayedGames), strconv.Itoa(i.Won), strconv.Itoa(i.Draw), strconv.Itoa(i.Lost), strconv.Itoa(i.GoalDifference), strconv.Itoa(i.Points)}
+			tStandings.Append(row)
+		}
 	}
 
 	tStandings.Render()
@@ -151,32 +151,33 @@ func (widget *Widget) GetMatches(leagueId int) string {
 		return fmt.Sprintf("Error fetching matches: %s", err.Error())
 	}
 
-	if len(l.Matches) != 0 {
+	if len(l.Matches) == 0 {
+		return fmt.Sprintf("Error fetching matches")
+	}
 
-		for _, m := range l.Matches {
+	for _, m := range l.Matches {
 
-			widget.markFavorite(&m)
+		widget.markFavorite(&m)
 
-			if m.Status == "SCHEDULED" {
-				row := []string{m.HomeTeam.Name, "🆚", m.AwayTeam.Name, parseDateString(m.Date)}
-				tScheduled.Append(row)
-			} else if m.Status == "FINISHED" {
-				row := []string{m.HomeTeam.Name, strconv.Itoa(m.Score.FullTime.HomeTeam), "🆚", m.AwayTeam.Name, strconv.Itoa(m.Score.FullTime.AwayTeam)}
-				tPlayed.Append(row)
-			}
+		if m.Status == "SCHEDULED" {
+			row := []string{m.HomeTeam.Name, "🆚", m.AwayTeam.Name, parseDateString(m.Date)}
+			tScheduled.Append(row)
+		} else if m.Status == "FINISHED" {
+			row := []string{m.HomeTeam.Name, strconv.Itoa(m.Score.FullTime.HomeTeam), "🆚", m.AwayTeam.Name, strconv.Itoa(m.Score.FullTime.AwayTeam)}
+			tPlayed.Append(row)
 		}
+	}
 
-		tScheduled.Render()
-		tPlayed.Render()
-		if playedBuf.String() != "" {
-			content += "\nMatches Played:\n\n"
-			content += playedBuf.String()
+	tScheduled.Render()
+	tPlayed.Render()
+	if playedBuf.String() != "" {
+		content += "\nMatches Played:\n\n"
+		content += playedBuf.String()
 
-		}
-		if scheduledBuf.String() != "" {
-			content += "\nUpcoming Matches:\n\n"
-			content += scheduledBuf.String()
-		}
+	}
+	if scheduledBuf.String() != "" {
+		content += "\nUpcoming Matches:\n\n"
+		content += scheduledBuf.String()
 	}
 
 	return content


### PR DESCRIPTION
#hacktoberfest

Hi there,

If this merges, it will add a widget for football fixtures/standings. In order to use this widget, you need to register to [football-data](https://www.football-data.org/client/register) to get api key(Free tier).

![image](https://user-images.githubusercontent.com/20225764/67424797-1d4efb80-f5d7-11e9-8871-6c6740b208c4.png)

config.yaml:
```yaml

wtf:
  colors:
    border:
      focusable: darkslateblue
      focused: orange
      normal: gray
  grid:
    columns: [32, 32, 32, 32, 90]
    rows: [10, 10, 10, 4, 4, 90]
  refreshInterval: 1
  mods:
    football:
      enabled: true
      apiKey: "*******"              # football-data.org api key
      league: "SPD"                   # shortname for the league
      favTeam: "FC Barcelona"        # Favorite team from specific league, Default: ""
      standingCount: 10                  # Top teams count, Default: 5
      matchesFrom: 5           # Matches till Today (Today - Number of days), Default: "2"
      matchesTo: 7                  # Matches from Today (Today + Number of days), Default: "5"
      position:
        top: 1
        left: 0
        height: 3
        width: 3
      refreshInterval: 300
      title: "⚽"

Please let me know if there is anything which can be improved :)

I will create PR for the documentation as well if all looks good here.