### PR TITLE
modded resourceusage

### DIFF
--- a/modules/resourceusage/settings.go
+++ b/modules/resourceusage/settings.go
@@ -12,11 +12,13 @@ const (
 
 type Settings struct {
 	common *cfg.Common
+	cpuCombined bool
 }
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := Settings{
 		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+		cpuCombined: ymlConfig.UBool("cpuCombined"),
 	}
 
 	return &settings

--- a/modules/resourceusage/widget.go
+++ b/modules/resourceusage/widget.go
@@ -44,7 +44,8 @@ func NewWidget(app *tview.Application, settings *Settings) *Widget {
 
 // MakeGraph - Load the dead drop stats
 func MakeGraph(widget *Widget) {
-	cpuStats, err := cpu.Percent(time.Duration(0), true)
+
+	cpuStats, err := cpu.Percent(time.Duration(0), !widget.settings.cpuCombined)
 	if err != nil {
 		return
 	}
@@ -56,8 +57,15 @@ func MakeGraph(widget *Widget) {
 		stat = math.Min(100, stat)
 		stat = math.Max(0, stat)
 
+		var label string
+		if (widget.settings.cpuCombined) {
+			label = "CPU"
+		} else {
+			label = fmt.Sprint(i)
+		}
+		
 		bar := view.Bar{
-			Label:      fmt.Sprint(i),
+			Label:      label,
 			Percent:    int(stat),
 			ValueLabel: fmt.Sprintf("%d%%", int(stat)),
 			LabelColor: "red",
@@ -119,9 +127,8 @@ func (widget *Widget) Refresh() {
 		return
 	}
 
-	widget.View.Clear()
-
 	widget.app.QueueUpdateDraw(func() {
+		widget.View.Clear()	
 		display(widget)
 	})
 }


### PR DESCRIPTION
Modified resourceusage to allow for combined cpu usage (useful on machines with lots of cores and threads)

Change includes the config (see below). The variable `cpuCombined bool` is new - default is false, which makes the default behaviour equal to the old behaviour, i.e., not combined stats. Setting it to true, combines the core stats into one, and changes its title to 'CPU'.

There is also a change in widget Refresh function, which makes it flicker-free for me (it would flicker before, but I don't know the reasoning for why was it setup as it was before, so it might break something else).

Example of config:
```yaml
    resourceusage:
      enabled: true
      position:
        top: 0 
        left: 0
        height: 1
        width: 1
      refreshInterval: 1
      cpuCombined: true
```
