### PR TITLE
WTF-730 Fix missing color key config error

### DIFF
--- a/_sample_configs/dynamic_sizing.yml
+++ b/_sample_configs/dynamic_sizing.yml
@@ -1,6 +1,4 @@
 wtf:
-  refreshInterval: 1
-  openFileUtil: "open"
   mods:
     battery:
       type: power

--- a/_sample_configs/dynamic_sizing.yml
+++ b/_sample_configs/dynamic_sizing.yml
@@ -1,0 +1,23 @@
+wtf:
+  refreshInterval: 1
+  openFileUtil: "open"
+  mods:
+    battery:
+      type: power
+      title: "⚡️"
+      enabled: true
+      position:
+        top: 0
+        left: 0
+        height: 1
+        width: 1
+      refreshInterval: 15
+    security_info:
+      type: security
+      enabled: true
+      position:
+        top: 0
+        left: 1
+        height: 1
+        width: 1
+      refreshInterval: 3600

--- a/app/display.go
+++ b/app/display.go
@@ -20,7 +20,13 @@ func NewDisplay(widgets []wtf.Wtfable, config *config.Config) *Display {
 		config: config,
 	}
 
-	display.Grid.SetBackgroundColor(wtf.ColorFor(config.UString("wtf.colors.background", "transparent")))
+	firstWidget := widgets[0]
+	display.Grid.SetBackgroundColor(
+		wtf.ColorFor(
+			firstWidget.CommonSettings().Colors.WidgetTheme.Background,
+		),
+	)
+
 	display.build(widgets)
 
 	return &display

--- a/app/focus_tracker.go
+++ b/app/focus_tracker.go
@@ -158,7 +158,11 @@ func (tracker *FocusTracker) blur(idx int) {
 	view := widget.TextView()
 	view.Blur()
 
-	view.SetBorderColor(wtf.ColorFor(widget.BorderColor()))
+	view.SetBorderColor(
+		wtf.ColorFor(
+			widget.BorderColor(),
+		),
+	)
 
 	tracker.IsFocused = false
 }
@@ -178,7 +182,11 @@ func (tracker *FocusTracker) focus(idx int) {
 	}
 
 	view := widget.TextView()
-	view.SetBorderColor(wtf.ColorFor(tracker.config.UString("wtf.colors.border.focused", "gray")))
+	view.SetBorderColor(
+		wtf.ColorFor(
+			widget.CommonSettings().Colors.BorderTheme.Focused,
+		),
+	)
 	tracker.App.SetFocus(view)
 }
 

--- a/app/wtf_app.go
+++ b/app/wtf_app.go
@@ -41,8 +41,6 @@ func NewWtfApp(app *tview.Application, config *config.Config, configFilePath str
 		return false
 	})
 
-	wtfApp.pages.Box.SetBackgroundColor(wtf.ColorFor(config.UString("wtf.colors.background", "transparent")))
-
 	wtfApp.app.SetInputCapture(wtfApp.keyboardIntercept)
 	wtfApp.widgets = MakeWidgets(wtfApp.app, wtfApp.pages, wtfApp.config)
 	wtfApp.display = NewDisplay(wtfApp.widgets, wtfApp.config)
@@ -53,6 +51,13 @@ func NewWtfApp(app *tview.Application, config *config.Config, configFilePath str
 	wtfApp.app.SetRoot(wtfApp.pages, true)
 
 	wtfApp.validator.Validate(wtfApp.widgets)
+
+	firstWidget := wtfApp.widgets[0]
+	wtfApp.pages.Box.SetBackgroundColor(
+		wtf.ColorFor(
+			firstWidget.CommonSettings().Colors.WidgetTheme.Background,
+		),
+	)
 
 	return &wtfApp
 }

--- a/cfg/default_color_theme.go
+++ b/cfg/default_color_theme.go
@@ -1,0 +1,106 @@
+package cfg
+
+import (
+	"github.com/olebedev/config"
+	"gopkg.in/yaml.v2"
+)
+
+// BorderTheme defines the default color scheme for drawing widget borders
+type BorderTheme struct {
+	Focusable   string
+	Focused     string
+	Unfocusable string
+}
+
+// CheckboxTheme defines the default color scheme for drawing checkable rows in widgets
+type CheckboxTheme struct {
+	Checked string
+}
+
+// RowTheme defines the default color scheme for row text
+type RowTheme struct {
+	EvenBackground string
+	EvenForeground string
+
+	OddBackground string
+	OddForeground string
+
+	HighlightedBackground string
+	HighlightedForeground string
+}
+
+// TextTheme defines the default color scheme for text rendering
+type TextTheme struct {
+	Subheading string
+	Text       string
+	Title      string
+}
+
+type WidgetTheme struct {
+	Background string
+}
+
+// ColorTheme is an alamgam of all the default color settings
+type ColorTheme struct {
+	BorderTheme
+	CheckboxTheme
+	RowTheme
+	TextTheme
+	WidgetTheme
+}
+
+// NewDefaultColorTheme creates and returns an instance of DefaultColorTheme
+func NewDefaultColorTheme() ColorTheme {
+	defaultTheme := ColorTheme{
+		BorderTheme: BorderTheme{
+			Focusable:   "blue",
+			Focused:     "orange",
+			Unfocusable: "gray",
+		},
+
+		CheckboxTheme: CheckboxTheme{
+			Checked: "white",
+		},
+
+		RowTheme: RowTheme{
+			EvenBackground: "transparent",
+			EvenForeground: "white",
+
+			OddBackground: "transparent",
+			OddForeground: "lightblue",
+
+			HighlightedForeground: "black",
+			HighlightedBackground: "green",
+		},
+
+		TextTheme: TextTheme{
+			Subheading: "red",
+			Text:       "white",
+			Title:      "green",
+		},
+
+		WidgetTheme: WidgetTheme{
+			Background: "transparent",
+		},
+	}
+
+	return defaultTheme
+}
+
+// NewDefaultColorConfig creates and returns a config.Config-compatible configuration struct
+// using a DefaultColorTheme to pre-populate all the relevant values
+func NewDefaultColorConfig() (*config.Config, error) {
+	colorTheme := NewDefaultColorTheme()
+
+	yamlBytes, err := yaml.Marshal(colorTheme)
+	if err != nil {
+		return nil, err
+	}
+
+	cfg, err := config.ParseYamlBytes(yamlBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	return cfg, nil
+}

--- a/cfg/default_color_theme.go
+++ b/cfg/default_color_theme.go
@@ -59,7 +59,7 @@ func NewDefaultColorTheme() ColorTheme {
 		},
 
 		CheckboxTheme: CheckboxTheme{
-			Checked: "white",
+			Checked: "gray",
 		},
 
 		RowTheme: RowTheme{

--- a/cfg/default_color_theme_test.go
+++ b/cfg/default_color_theme_test.go
@@ -1,0 +1,26 @@
+package cfg
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_NewDefaultColorTheme(t *testing.T) {
+	theme := NewDefaultColorTheme()
+
+	assert.Equal(t, "orange", theme.BorderTheme.Focused)
+	assert.Equal(t, "red", theme.TextTheme.Subheading)
+	assert.Equal(t, "transparent", theme.WidgetTheme.Background)
+}
+
+func Test_NewDefaultColorConfig(t *testing.T) {
+	cfg, err := NewDefaultColorConfig()
+
+	assert.Nil(t, err)
+
+	assert.Equal(t, "orange", cfg.UString("bordertheme.focused"))
+	assert.Equal(t, "red", cfg.UString("texttheme.subheading"))
+	assert.Equal(t, "transparent", cfg.UString("widgettheme.background"))
+	assert.Equal(t, "", cfg.UString("widgettheme.missing"))
+}

--- a/cfg/position_validation_test.go
+++ b/cfg/position_validation_test.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/alecthomas/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 var (

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d // indirect
 	github.com/VictorAvelar/devto-api-go v1.0.0
 	github.com/adlio/trello v1.4.0
-	github.com/alecthomas/assert v0.0.0-20170929043011-405dbfeb8e38
 	github.com/alecthomas/chroma v0.6.8
 	github.com/andygrunwald/go-gerrit v0.0.0-20190825170856-5959a9bf9ff8
 	github.com/briandowns/openweathermap v0.0.0-20180804155945-5f41b7c9d92d

--- a/modules/datadog/widget.go
+++ b/modules/datadog/widget.go
@@ -85,7 +85,10 @@ func (widget *Widget) content() (string, string, bool) {
 	if len(triggeredMonitors) > 0 {
 		str += fmt.Sprintf(
 			" %s\n",
-			"[red]Triggered Monitors[white]",
+			fmt.Sprintf(
+				"[%s]Triggered Monitors[white]",
+				widget.settings.common.Colors.Subheading,
+			),
 		)
 		for idx, triggeredMonitor := range triggeredMonitors {
 			row := fmt.Sprintf(`[%s][red] %s[%s]`,

--- a/modules/docker/client.go
+++ b/modules/docker/client.go
@@ -41,13 +41,13 @@ func (widget *Widget) getSystemInfo() string {
 	}{
 		{
 			name:  "name:",
-			value: fmt.Sprintf("[%s]%s", widget.settings.common.Foreground, info.Name),
+			value: fmt.Sprintf("[%s]%s", widget.settings.common.Colors.RowTheme.EvenForeground, info.Name),
 		}, {
 			name:  "version:",
-			value: fmt.Sprintf("[%s]%s", widget.settings.common.Foreground, info.ServerVersion),
+			value: fmt.Sprintf("[%s]%s", widget.settings.common.Colors.RowTheme.EvenForeground, info.ServerVersion),
 		}, {
 			name:  "root:",
-			value: fmt.Sprintf("[%s]%s", widget.settings.common.Foreground, info.DockerRootDir),
+			value: fmt.Sprintf("[%s]%s", widget.settings.common.Colors.RowTheme.EvenForeground, info.DockerRootDir),
 		},
 		{
 			name: "containers:",
@@ -57,15 +57,15 @@ func (widget *Widget) getSystemInfo() string {
 		},
 		{
 			name:  "images:",
-			value: fmt.Sprintf("[%s]%d", widget.settings.common.Foreground, info.Images),
+			value: fmt.Sprintf("[%s]%d", widget.settings.common.Colors.RowTheme.EvenForeground, info.Images),
 		},
 		{
 			name:  "volumes:",
-			value: fmt.Sprintf("[%s]%v", widget.settings.common.Foreground, len(diskUsage.Volumes)),
+			value: fmt.Sprintf("[%s]%v", widget.settings.common.Colors.RowTheme.EvenForeground, len(diskUsage.Volumes)),
 		},
 		{
 			name:  "memory limit:",
-			value: fmt.Sprintf("[%s]%s", widget.settings.common.Foreground, humanize.Bytes(uint64(info.MemTotal))),
+			value: fmt.Sprintf("[%s]%s", widget.settings.common.Colors.RowTheme.EvenForeground, humanize.Bytes(uint64(info.MemTotal))),
 		},
 		{
 			name: "disk usage:",
@@ -76,19 +76,19 @@ func (widget *Widget) getSystemInfo() string {
     [%s]* [::b]total:      [%s]%s[::-]
 `,
 				widget.settings.labelColor,
-				widget.settings.common.Foreground,
+				widget.settings.common.Colors.RowTheme.EvenForeground,
 				humanize.Bytes(uint64(duContainer)),
 
 				widget.settings.labelColor,
-				widget.settings.common.Foreground,
+				widget.settings.common.Colors.RowTheme.EvenForeground,
 				humanize.Bytes(uint64(duImg)),
 
 				widget.settings.labelColor,
-				widget.settings.common.Foreground,
+				widget.settings.common.Colors.RowTheme.EvenForeground,
 				humanize.Bytes(uint64(duVol)),
 
 				widget.settings.labelColor,
-				widget.settings.common.Foreground,
+				widget.settings.common.Colors.RowTheme.EvenForeground,
 				humanize.Bytes(uint64(duContainer+duImg+duVol))),
 		},
 	}

--- a/modules/feedreader/widget.go
+++ b/modules/feedreader/widget.go
@@ -140,7 +140,7 @@ func (widget *Widget) content() (string, string, bool) {
 			// Grays out viewed items in the list, while preserving background highlighting when selected
 			rowColor = "gray"
 			if idx == widget.Selected {
-				rowColor = fmt.Sprintf("gray:%s", widget.settings.common.Colors.HighlightBack)
+				rowColor = fmt.Sprintf("gray:%s", widget.settings.common.Colors.RowTheme.HighlightedBackground)
 			}
 		}
 

--- a/modules/gerrit/display.go
+++ b/modules/gerrit/display.go
@@ -23,13 +23,13 @@ func (widget *Widget) content() (string, string, bool) {
 
 	_, _, width, _ := widget.View.GetRect()
 	str := widget.settings.common.SigilStr(len(widget.GerritProjects), widget.Idx, width) + "\n"
-	str += " [red]Stats[white]\n"
+	str += fmt.Sprintf(" [%s]Stats[white]\n", widget.settings.common.Colors.Subheading)
 	str += widget.displayStats(project)
 	str += "\n"
-	str += " [red]Open Incoming Reviews[white]\n"
+	str += fmt.Sprintf(" [%s]Open Incoming Reviews[white]\n", widget.settings.common.Colors.Subheading)
 	str += widget.displayMyIncomingReviews(project, widget.settings.username)
 	str += "\n"
-	str += " [red]My Outgoing Reviews[white]\n"
+	str += fmt.Sprintf(" [%s]My Outgoing Reviews[white]\n", widget.settings.common.Colors.Subheading)
 	str += widget.displayMyOutgoingReviews(project, widget.settings.username)
 
 	return title, str, false

--- a/modules/git/display.go
+++ b/modules/git/display.go
@@ -16,7 +16,11 @@ func (widget *Widget) content() (string, string, bool) {
 		return widget.CommonSettings().Title, " Git repo data is unavailable ", false
 	}
 
-	title := fmt.Sprintf("%s - [green]%s[white]", widget.CommonSettings().Title, repoData.Repository)
+	title := fmt.Sprintf(
+		"%s - %s[white]",
+		widget.settings.common.Colors.TextTheme.Title,
+		repoData.Repository,
+	)
 
 	_, _, width, _ := widget.View.GetRect()
 	str := widget.settings.common.SigilStr(len(widget.GitRepos), widget.Idx, width) + "\n"

--- a/modules/git/display.go
+++ b/modules/git/display.go
@@ -20,7 +20,7 @@ func (widget *Widget) content() (string, string, bool) {
 
 	_, _, width, _ := widget.View.GetRect()
 	str := widget.settings.common.SigilStr(len(widget.GitRepos), widget.Idx, width) + "\n"
-	str += " [red]Branch[white]\n"
+	str += fmt.Sprintf(" [%s]Branch[white]\n", widget.settings.common.Colors.Subheading)
 	str += fmt.Sprintf(" %s", repoData.Branch)
 	str += "\n"
 	str += widget.formatChanges(repoData.ChangedFiles)
@@ -31,7 +31,7 @@ func (widget *Widget) content() (string, string, bool) {
 }
 
 func (widget *Widget) formatChanges(data []string) string {
-	str := " [red]Changed Files[white]\n"
+	str := fmt.Sprintf(" [%s]Changed Files[white]\n", widget.settings.common.Colors.Subheading)
 
 	if len(data) == 1 {
 		str += " [grey]none[white]\n"

--- a/modules/git/display.go
+++ b/modules/git/display.go
@@ -18,7 +18,7 @@ func (widget *Widget) content() (string, string, bool) {
 
 	title := fmt.Sprintf(
 		"%s - %s[white]",
-		widget.settings.common.Colors.TextTheme.Title,
+		widget.CommonSettings().Title,
 		repoData.Repository,
 	)
 
@@ -72,7 +72,7 @@ func (widget *Widget) formatChange(line string) string {
 }
 
 func (widget *Widget) formatCommits(data []string) string {
-	str := " [red]Recent Commits[white]\n"
+	str := fmt.Sprintf(" [%s]Recent Commits[white]\n", widget.settings.common.Colors.Subheading)
 
 	for _, line := range data {
 		str += widget.formatCommit(line)

--- a/modules/github/display.go
+++ b/modules/github/display.go
@@ -127,7 +127,12 @@ func (widget *Widget) displayStats(repo *GithubRepo) string {
 }
 
 func (widget *Widget) title(repo *GithubRepo) string {
-	return fmt.Sprintf("[green]%s - %s[white]", repo.Owner, repo.Name)
+	return fmt.Sprintf(
+		"[%s]%s - %s[white]",
+		widget.settings.common.Colors.TextTheme.Title,
+		repo.Owner,
+		repo.Name,
+	)
 }
 
 var mergeIcons = map[string]string{

--- a/modules/github/display.go
+++ b/modules/github/display.go
@@ -34,14 +34,14 @@ func (widget *Widget) content() (string, string, bool) {
 
 	_, _, width, _ := widget.View.GetRect()
 	str := widget.settings.common.SigilStr(len(widget.GithubRepos), widget.Idx, width) + "\n"
-	str += " [red]Stats[white]\n"
+	str += fmt.Sprintf(" [%s]Stats[white]\n", widget.settings.common.Colors.Subheading)
 	str += widget.displayStats(repo)
-	str += "\n [red]Open Review Requests[white]\n"
+	str += fmt.Sprintf("\n [%s]Open Review Requests[white]\n", widget.settings.common.Colors.Subheading)
 	str += widget.displayMyReviewRequests(repo, username)
-	str += "\n [red]My Pull Requests[white]\n"
+	str += fmt.Sprintf("\n [%s]My Pull Requests[white]\n", widget.settings.common.Colors.Subheading)
 	str += widget.displayMyPullRequests(repo, username)
 	for _, customQuery := range widget.settings.customQueries {
-		str += fmt.Sprintf("\n [red]%s[white]\n", customQuery.title)
+		str += fmt.Sprintf("\n [%s]%s[white]\n", widget.settings.common.Colors.Subheading, customQuery.title)
 		str += widget.displayCustomQuery(repo, customQuery.filter, customQuery.perPage)
 	}
 

--- a/modules/gitlab/display.go
+++ b/modules/gitlab/display.go
@@ -19,19 +19,19 @@ func (widget *Widget) content() (string, string, bool) {
 
 	_, _, width, _ := widget.View.GetRect()
 	str := widget.settings.common.SigilStr(len(widget.GitlabProjects), widget.Idx, width) + "\n"
-	str += " [red]Stats[white]\n"
+	str += fmt.Sprintf(" [%s]Stats[white]\n", widget.settings.common.Colors.Subheading)
 	str += widget.displayStats(project)
 	str += "\n"
-	str += " [red]Open Assigned Merge Requests[white]\n"
+	str += fmt.Sprintf(" [%s]Open Assigned Merge Requests[white]\n", widget.settings.common.Colors.Subheading)
 	str += widget.displayMyAssignedMergeRequests(project, widget.settings.username)
 	str += "\n"
-	str += " [red]My Merge Requests[white]\n"
+	str += fmt.Sprintf(" [%s]My Merge Requests[white]\n", widget.settings.common.Colors.Subheading)
 	str += widget.displayMyMergeRequests(project, widget.settings.username)
 	str += "\n"
-	str += " [red]Open Assigned Issues[white]\n"
+	str += fmt.Sprintf(" [%s]Open Assigned Issues[white]\n", widget.settings.common.Colors.Subheading)
 	str += widget.displayMyAssignedIssues(project, widget.settings.username)
 	str += "\n"
-	str += " [red]My Issues[white]\n"
+	str += fmt.Sprintf(" [%s]My Issues[white]\n", widget.settings.common.Colors.Subheading)
 	str += widget.displayMyIssues(project, widget.settings.username)
 
 	return title, str, false

--- a/modules/jira/widget.go
+++ b/modules/jira/widget.go
@@ -2,6 +2,7 @@ package jira
 
 import (
 	"fmt"
+
 	"github.com/rivo/tview"
 	"github.com/wtfutil/wtf/utils"
 	"github.com/wtfutil/wtf/view"
@@ -78,7 +79,7 @@ func (widget *Widget) content() (string, string, bool) {
 
 	title := fmt.Sprintf("%s- [green]%s[white]", widget.CommonSettings().Title, widget.settings.projects)
 
-	str := " [red]Assigned Issues[white]\n"
+	str := fmt.Sprintf(" [%s]Assigned Issues[white]\n", widget.settings.common.Colors.Subheading)
 
 	if widget.result == nil || len(widget.result.Issues) == 0 {
 		return title, "No results to display", false

--- a/modules/kubernetes/widget.go
+++ b/modules/kubernetes/widget.go
@@ -56,7 +56,7 @@ func (widget *Widget) Refresh() {
 			widget.Redraw(func() (string, string, bool) { return title, "[red] Error getting node data [white]\n", true })
 			return
 		}
-		content += "[red]Nodes[white]\n"
+		content += fmt.Sprintf("[%s]Nodes[white]\n", widget.settings.common.Colors.Subheading)
 		for _, node := range nodeList {
 			content += fmt.Sprintf("%s\n", node)
 		}
@@ -69,7 +69,7 @@ func (widget *Widget) Refresh() {
 			widget.Redraw(func() (string, string, bool) { return title, "[red] Error getting deployment data [white]\n", true })
 			return
 		}
-		content += "[red]Deployments[white]\n"
+		content += fmt.Sprintf("[%s]Deployments[white]\n", widget.settings.common.Colors.Subheading)
 		for _, deployment := range deploymentList {
 			content += fmt.Sprintf("%s\n", deployment)
 		}
@@ -82,7 +82,7 @@ func (widget *Widget) Refresh() {
 			widget.Redraw(func() (string, string, bool) { return title, "[red] Error getting pod data [white]\n", false })
 			return
 		}
-		content += "[red]Pods[white]\n"
+		content += fmt.Sprintf("[%s]Pods[white]\n", widget.settings.common.Colors.Subheading)
 		for _, pod := range podList {
 			content += fmt.Sprintf("%s\n", pod)
 		}

--- a/modules/mercurial/display.go
+++ b/modules/mercurial/display.go
@@ -20,7 +20,7 @@ func (widget *Widget) content() (string, string, bool) {
 
 	_, _, width, _ := widget.View.GetRect()
 	str := widget.settings.common.SigilStr(len(widget.Data), widget.Idx, width) + "\n"
-	str += " [red]Branch:Bookmark[white]\n"
+	str += fmt.Sprintf(" [%s]Branch:Bookmark[white]\n", widget.settings.common.Colors.Subheading)
 	str += fmt.Sprintf(" %s:%s\n", repoData.Branch, repoData.Bookmark)
 	str += "\n"
 	str += widget.formatChanges(repoData.ChangedFiles)
@@ -31,7 +31,7 @@ func (widget *Widget) content() (string, string, bool) {
 }
 
 func (widget *Widget) formatChanges(data []string) string {
-	str := " [red]Changed Files[white]\n"
+	str := fmt.Sprintf(" [%s]Changed Files[white]\n", widget.settings.common.Colors.Subheading)
 
 	if len(data) == 1 {
 		str += " [grey]none[white]\n"
@@ -68,7 +68,7 @@ func (widget *Widget) formatChange(line string) string {
 }
 
 func (widget *Widget) formatCommits(data []string) string {
-	str := " [red]Recent Commits[white]\n"
+	str := fmt.Sprintf(" [%s]Recent Commits[white]\n", widget.settings.common.Colors.Subheading)
 
 	for _, line := range data {
 		str += widget.formatCommit(line)

--- a/modules/mercurial/display.go
+++ b/modules/mercurial/display.go
@@ -16,7 +16,11 @@ func (widget *Widget) content() (string, string, bool) {
 		return widget.CommonSettings().Title, " Mercurial repo data is unavailable ", false
 	}
 
-	title := fmt.Sprintf("%s - [green]%s[white]", widget.CommonSettings().Title, repoData.Repository)
+	title := fmt.Sprintf(
+		"%s - %s[white]",
+		widget.settings.common.Colors.TextTheme.Title,
+		repoData.Repository,
+	)
 
 	_, _, width, _ := widget.View.GetRect()
 	str := widget.settings.common.SigilStr(len(widget.Data), widget.Idx, width) + "\n"

--- a/modules/nbascore/widget.go
+++ b/modules/nbascore/widget.go
@@ -79,8 +79,9 @@ func (widget *Widget) nbascore() (string, string, bool) {
 	}
 	result := map[string]interface{}{}
 	json.Unmarshal(contents, &result)
-	allGame := "" // store result in allgame
-	allGame += (" " + "[red]" + (cur.Format(utils.FriendlyDateFormat) + "\n\n") + "[white]")
+
+	allGame := fmt.Sprintf(" [%s]", widget.settings.common.Colors.Subheading) + (cur.Format(utils.FriendlyDateFormat) + "\n\n") + "[white]"
+
 	for _, game := range result["games"].([]interface{}) {
 		vTeam, hTeam, vScore, hScore := "", "", "", ""
 		quarter := 0.

--- a/modules/newrelic/display.go
+++ b/modules/newrelic/display.go
@@ -37,7 +37,10 @@ func (widget *Widget) content() (string, string, bool) {
 func (widget *Widget) contentFrom(deploys []nr.ApplicationDeployment) string {
 	str := fmt.Sprintf(
 		" %s\n",
-		"[red]Latest Deploys[white]",
+		fmt.Sprintf(
+			"[%s]Latest Deploys[white]",
+			widget.settings.common.Colors.Subheading,
+		),
 	)
 
 	revisions := []string{}

--- a/modules/pagerduty/widget.go
+++ b/modules/pagerduty/widget.go
@@ -104,11 +104,22 @@ func (widget *Widget) contentFrom(onCalls []pagerduty.OnCall, incidents []pagerd
 
 		// Print out policies, and escalation order of users
 		for _, key := range keys {
-			str += fmt.Sprintf("\n [green::b]%s\n", key)
+			str += fmt.Sprintf(
+				"\n [%s]%s\n",
+				widget.settings.common.Colors.Subheading,
+				key,
+			)
+
 			values := tree[key]
 			sort.Sort(ByEscalationLevel(values))
+
 			for _, item := range values {
-				str += fmt.Sprintf(" [white]%d - %s\n", item.EscalationLevel, item.User.Summary)
+				str += fmt.Sprintf(
+					" [%s]%d - %s\n",
+					widget.settings.common.Colors.Text,
+					item.EscalationLevel,
+					item.User.Summary,
+				)
 			}
 		}
 	}

--- a/modules/pagerduty/widget.go
+++ b/modules/pagerduty/widget.go
@@ -70,7 +70,7 @@ func (widget *Widget) contentFrom(onCalls []pagerduty.OnCall, incidents []pagerd
 	if len(incidents) > 0 {
 		str += "[yellow]Incidents[white]\n"
 		for _, incident := range incidents {
-			str += fmt.Sprintf("[red]%s[white]\n", incident.Summary)
+			str += fmt.Sprintf("[%s]%s[white]\n", widget.settings.common.Colors.Subheading, incident.Summary)
 			str += fmt.Sprintf("Status: %s\n", incident.Status)
 			str += fmt.Sprintf("Service: %s\n", incident.Service.Summary)
 			str += fmt.Sprintf("Escalation: %s\n", incident.EscalationPolicy.Summary)
@@ -100,7 +100,7 @@ func (widget *Widget) contentFrom(onCalls []pagerduty.OnCall, incidents []pagerd
 	sort.Strings(keys)
 
 	if len(keys) > 0 {
-		str += "[red] Schedules[white]\n"
+		str += fmt.Sprintf("[%s] Schedules[white]\n", widget.settings.common.Colors.Subheading)
 		// Print out policies, and escalation order of users
 		for _, key := range keys {
 			str += fmt.Sprintf("\n [green::b]%s\n", key)

--- a/modules/pagerduty/widget.go
+++ b/modules/pagerduty/widget.go
@@ -101,6 +101,7 @@ func (widget *Widget) contentFrom(onCalls []pagerduty.OnCall, incidents []pagerd
 
 	if len(keys) > 0 {
 		str += fmt.Sprintf("[%s] Schedules[white]\n", widget.settings.common.Colors.Subheading)
+
 		// Print out policies, and escalation order of users
 		for _, key := range keys {
 			str += fmt.Sprintf("\n [green::b]%s\n", key)

--- a/modules/resourceusage/widget.go
+++ b/modules/resourceusage/widget.go
@@ -58,12 +58,12 @@ func MakeGraph(widget *Widget) {
 		stat = math.Max(0, stat)
 
 		var label string
-		if (widget.settings.cpuCombined) {
+		if widget.settings.cpuCombined {
 			label = "CPU"
 		} else {
 			label = fmt.Sprint(i)
 		}
-		
+
 		bar := view.Bar{
 			Label:      label,
 			Percent:    int(stat),
@@ -122,13 +122,12 @@ func MakeGraph(widget *Widget) {
 
 // Refresh & update after interval time
 func (widget *Widget) Refresh() {
-
 	if widget.Disabled() {
 		return
 	}
 
 	widget.app.QueueUpdateDraw(func() {
-		widget.View.Clear()	
+		widget.View.Clear()
 		display(widget)
 	})
 }

--- a/modules/security/widget.go
+++ b/modules/security/widget.go
@@ -40,21 +40,21 @@ func (widget *Widget) Refresh() {
 func (widget *Widget) content() (string, string, bool) {
 	data := NewSecurityData()
 	data.Fetch()
-	str := " [red]WiFi[white]\n"
+	str := fmt.Sprintf(" [%s]WiFi[white]\n", widget.settings.common.Colors.Subheading)
 	str += fmt.Sprintf(" %8s: %s\n", "Network", data.WifiName)
 	str += fmt.Sprintf(" %8s: %s\n", "Crypto", data.WifiEncryption)
 	str += "\n"
 
-	str += " [red]Firewall[white]\n"
+	str += fmt.Sprintf(" [%s]Firewall[white]\n", widget.settings.common.Colors.Subheading)
 	str += fmt.Sprintf(" %8s: %4s\n", "Status", data.FirewallEnabled)
 	str += fmt.Sprintf(" %8s: %4s\n", "Stealth", data.FirewallStealth)
 	str += "\n"
 
-	str += " [red]Users[white]\n"
+	str += fmt.Sprintf(" [%s]Users[white]\n", widget.settings.common.Colors.Subheading)
 	str += fmt.Sprintf("  %s", strings.Join(data.LoggedInUsers, "\n  "))
 	str += "\n\n"
 
-	str += " [red]DNS[white]\n"
+	str += fmt.Sprintf(" [%s]DNS[white]\n", widget.settings.common.Colors.Subheading)
 	str += fmt.Sprintf("  %12s\n", data.DnsAt(0))
 	str += fmt.Sprintf("  %12s\n", data.DnsAt(1))
 	str += "\n"

--- a/modules/textfile/widget.go
+++ b/modules/textfile/widget.go
@@ -71,7 +71,11 @@ func (widget *Widget) HelpText() string {
 /* -------------------- Unexported Functions -------------------- */
 
 func (widget *Widget) content() (string, string, bool) {
-	title := fmt.Sprintf("[green]%s[white]", widget.CurrentSource())
+	title := fmt.Sprintf(
+		"[%s]%s[white]",
+		widget.settings.common.Colors.TextTheme.Title,
+		widget.CurrentSource(),
+	)
 
 	_, _, width, _ := widget.View.GetRect()
 	text := widget.settings.common.SigilStr(len(widget.Sources), widget.Idx, width) + "\n"

--- a/modules/todo/display.go
+++ b/modules/todo/display.go
@@ -41,25 +41,23 @@ func (widget *Widget) content() (string, string, bool) {
 	return widget.CommonSettings().Title, str, false
 }
 
-func (widget *Widget) formattedItemLine(idx int, item *checklist.ChecklistItem, selectedItem *checklist.ChecklistItem, maxLen int) string {
-	foreColor, backColor := widget.settings.common.Colors.Text, widget.settings.common.Colors.Background
+func (widget *Widget) formattedItemLine(idx int, currItem *checklist.ChecklistItem, selectedItem *checklist.ChecklistItem, maxLen int) string {
+	rowColor := widget.RowColor(idx)
 
-	if item.Checked {
-		foreColor = widget.settings.common.Colors.CheckboxTheme.Checked
+	if currItem.Checked {
+		rowColor = widget.settings.common.Colors.CheckboxTheme.Checked
 	}
 
-	if widget.View.HasFocus() && (item == selectedItem) {
-		foreColor = widget.settings.common.Colors.RowTheme.HighlightedForeground
-		backColor = widget.settings.common.Colors.RowTheme.HighlightedBackground
+	if widget.View.HasFocus() && (currItem == selectedItem) {
+		rowColor = widget.RowColor(idx)
 	}
 
 	row := fmt.Sprintf(
-		` [%s:%s]|%s| %s[white]`,
-		foreColor,
-		backColor,
-		item.CheckMark(),
-		tview.Escape(item.Text),
+		` [%s]|%s| %s[white]`,
+		rowColor,
+		currItem.CheckMark(),
+		tview.Escape(currItem.Text),
 	)
 
-	return utils.HighlightableHelper(widget.View, row, idx, len(item.Text))
+	return utils.HighlightableHelper(widget.View, row, idx, len(currItem.Text))
 }

--- a/modules/todo/display.go
+++ b/modules/todo/display.go
@@ -45,7 +45,7 @@ func (widget *Widget) formattedItemLine(idx int, item *checklist.ChecklistItem, 
 	foreColor, backColor := widget.settings.common.Colors.Text, widget.settings.common.Colors.Background
 
 	if item.Checked {
-		foreColor = widget.settings.common.Colors.Checked
+		foreColor = widget.settings.common.Colors.CheckboxTheme.Checked
 	}
 
 	if widget.View.HasFocus() && (item == selectedItem) {

--- a/modules/todo/display.go
+++ b/modules/todo/display.go
@@ -49,8 +49,8 @@ func (widget *Widget) formattedItemLine(idx int, item *checklist.ChecklistItem, 
 	}
 
 	if widget.View.HasFocus() && (item == selectedItem) {
-		foreColor = widget.settings.common.Colors.HighlightFore
-		backColor = widget.settings.common.Colors.HighlightBack
+		foreColor = widget.settings.common.Colors.RowTheme.HighlightedForeground
+		backColor = widget.settings.common.Colors.RowTheme.HighlightedBackground
 	}
 
 	row := fmt.Sprintf(

--- a/modules/todoist/display.go
+++ b/modules/todoist/display.go
@@ -18,7 +18,11 @@ func (widget *Widget) content() (string, string, bool) {
 		return widget.CommonSettings().Title, proj.err.Error(), true
 	}
 
-	title := fmt.Sprintf("[green]%s[white]", proj.Project.Name)
+	title := fmt.Sprintf(
+		"[%s]%s[white]",
+		widget.settings.common.Colors.TextTheme.Title,
+		proj.Project.Name,
+	)
 
 	str := ""
 

--- a/modules/trello/widget.go
+++ b/modules/trello/widget.go
@@ -62,7 +62,7 @@ func (widget *Widget) content() (string, string, bool) {
 			widget.settings.board,
 		)
 		for list, cardArray := range searchResult.TrelloCards {
-			content += fmt.Sprintf(" [red]%s[white]\n", list)
+			content += fmt.Sprintf(" [%s]%s[white]\n", widget.settings.common.Colors.Subheading, list)
 
 			for _, card := range cardArray {
 				content += fmt.Sprintf(" %s[white]\n", card.Name)

--- a/modules/twitterstats/widget.go
+++ b/modules/twitterstats/widget.go
@@ -10,13 +10,16 @@ import (
 type Widget struct {
 	view.TextWidget
 
-	client *Client
+	client   *Client
+	settings *Settings
 }
 
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
 		TextWidget: view.NewTextWidget(app, settings.common),
-		client:     NewClient(settings),
+
+		client:   NewClient(settings),
+		settings: settings,
 	}
 
 	widget.View.SetBorderPadding(1, 1, 1, 1)
@@ -31,18 +34,25 @@ func (widget *Widget) Refresh() {
 }
 
 func (widget *Widget) content() (string, string, bool) {
-	usernames := widget.client.screenNames
+	// Add header row
+	str := fmt.Sprintf(
+		"[%s]%-12s %10s %8s[white]\n",
+		widget.settings.common.Colors.Subheading,
+		"Username",
+		"Followers",
+		"Tweets",
+	)
+
 	stats := widget.client.GetStats()
 
-	// Add header row
-	str := fmt.Sprintf("%-16s %8s %8s\n", "Username", "Followers", "Tweets")
-
 	// Add rows for each of the followed usernames
-	for i, username := range usernames {
-		followerCount := stats[i].FollowerCount
-		tweetCount := stats[i].TweetCount
-
-		str += fmt.Sprintf("%-16s %8d %8d\n", username, followerCount, tweetCount)
+	for i, username := range widget.client.screenNames {
+		str += fmt.Sprintf(
+			"%-12s %10d %8d\n",
+			username,
+			stats[i].FollowerCount,
+			stats[i].TweetCount,
+		)
 	}
 
 	return "Twitter Stats", str, true

--- a/modules/zendesk/widget.go
+++ b/modules/zendesk/widget.go
@@ -74,7 +74,7 @@ func (widget *Widget) content() (string, string, bool) {
 func (widget *Widget) format(ticket Ticket, idx int) string {
 	textColor := widget.settings.common.Colors.Background
 	if idx == widget.GetSelected() {
-		textColor = widget.settings.common.Colors.BorderFocused
+		textColor = widget.settings.common.Colors.BorderTheme.Focused
 	}
 
 	requesterName := widget.parseRequester(ticket)

--- a/view/bargraph.go
+++ b/view/bargraph.go
@@ -107,12 +107,12 @@ func (widget *BarGraph) TextView() *tview.TextView {
 func (widget *BarGraph) createView(bordered bool) *tview.TextView {
 	view := tview.NewTextView()
 
-	view.SetBackgroundColor(wtf.ColorFor(widget.commonSettings.Colors.Background))
+	view.SetBackgroundColor(wtf.ColorFor(widget.commonSettings.Colors.WidgetTheme.Background))
 	view.SetBorder(bordered)
 	view.SetBorderColor(wtf.ColorFor(widget.BorderColor()))
 	view.SetDynamicColors(true)
 	view.SetTitle(widget.ContextualTitle(widget.CommonSettings().Title))
-	view.SetTitleColor(wtf.ColorFor(widget.commonSettings.Colors.Title))
+	view.SetTitleColor(wtf.ColorFor(widget.commonSettings.Colors.TextTheme.Title))
 	view.SetWrap(false)
 
 	return view

--- a/view/base.go
+++ b/view/base.go
@@ -49,10 +49,10 @@ func (base *Base) Bordered() bool {
 
 func (base *Base) BorderColor() string {
 	if base.Focusable() {
-		return base.commonSettings.Colors.BorderFocusable
+		return base.commonSettings.Colors.BorderTheme.Focusable
 	}
 
-	return base.commonSettings.Colors.BorderNormal
+	return base.commonSettings.Colors.BorderTheme.Unfocusable
 }
 
 func (base *Base) CommonSettings() *cfg.Common {

--- a/view/base.go
+++ b/view/base.go
@@ -47,6 +47,7 @@ func (base *Base) Bordered() bool {
 	return base.bordered
 }
 
+// BorderColor returns the color that the border of this widget should be drawn in
 func (base *Base) BorderColor() string {
 	if base.Focusable() {
 		return base.commonSettings.Colors.BorderTheme.Focusable
@@ -69,10 +70,10 @@ func (base *Base) ContextualTitle(defaultStr string) string {
 	} else if defaultStr != "" && base.FocusChar() == "" {
 		return fmt.Sprintf(" %s ", defaultStr)
 	} else if defaultStr == "" && base.FocusChar() != "" {
-		return fmt.Sprintf(" [darkgray::u]%s[::-][green] ", base.FocusChar())
-	} else {
-		return fmt.Sprintf(" %s [darkgray::u]%s[::-][green] ", defaultStr, base.FocusChar())
+		return fmt.Sprintf(" [darkgray::u]%s[::-][white] ", base.FocusChar())
 	}
+
+	return fmt.Sprintf(" %s [darkgray::u]%s[::-][white] ", defaultStr, base.FocusChar())
 }
 
 func (base *Base) Disable() {

--- a/view/text_widget.go
+++ b/view/text_widget.go
@@ -44,12 +44,12 @@ func (widget *TextWidget) Redraw(data func() (string, string, bool)) {
 func (widget *TextWidget) createView(bordered bool) *tview.TextView {
 	view := tview.NewTextView()
 
-	view.SetBackgroundColor(wtf.ColorFor(widget.commonSettings.Colors.Background))
+	view.SetBackgroundColor(wtf.ColorFor(widget.commonSettings.Colors.WidgetTheme.Background))
 	view.SetBorder(bordered)
 	view.SetBorderColor(wtf.ColorFor(widget.BorderColor()))
 	view.SetDynamicColors(true)
-	view.SetTextColor(wtf.ColorFor(widget.commonSettings.Colors.Text))
-	view.SetTitleColor(wtf.ColorFor(widget.commonSettings.Colors.Title))
+	view.SetTextColor(wtf.ColorFor(widget.commonSettings.Colors.TextTheme.Text))
+	view.SetTitleColor(wtf.ColorFor(widget.commonSettings.Colors.TextTheme.Title))
 	view.SetWrap(false)
 
 	return view


### PR DESCRIPTION
Redesigns the color configuration to provide a set of logical defaults, the ability to over-ride globally, and the ability to over-ride locally per module.

Also fixes #718 and fixes #730 by allowing the global config to **not** have a `colors` configuration key. 

Signed-off-by: Chris Cummer <chriscummer@me.com>