### PR TITLE
Update goproxy to default proxy.golang.org

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,6 +1,6 @@
 env:
   - GO111MODULE=on
-  - GOPROXY="https://gocenter.io"
+  - GOPROXY="https://proxy.golang.org,direct"
 
 archives:
   - id: default

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,6 @@ before_install:
   - test ! -d $GOPATH/src/github.com/wtfutil/wtf && mv $TRAVIS_BUILD_DIR $GOPATH/src/github.com/wtfutil/wtf || true
   - export TRAVIS_BUILD_DIR=$HOME/gopath/src/github.com/wtfutil/wtf
   - cd $HOME/gopath/src/github.com/wtfutil/wtf
-  - export GOPROXY="https://gocenter.io" && export GO111MODULE=on
+  - export GOPROXY="https://proxy.golang.org,direct" && export GO111MODULE=on
 
 script: go get ./... && ./scripts/check-uncommitted-vendor-files.sh && go test -v github.com/wtfutil/wtf/...

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,14 @@
 language: go
+
 go:
-  - "1.12.x"
   - "1.13.x"
-sudo: false
+
 before_install:
   # Make sure travis builds work for forks
   - mkdir -p $TRAVIS_BUILD_DIR $GOPATH/src/github.com/wtfutil
   - test ! -d $GOPATH/src/github.com/wtfutil/wtf && mv $TRAVIS_BUILD_DIR $GOPATH/src/github.com/wtfutil/wtf || true
   - export TRAVIS_BUILD_DIR=$HOME/gopath/src/github.com/wtfutil/wtf
   - cd $HOME/gopath/src/github.com/wtfutil/wtf
-  - export GOPROXY="https://proxy.golang.org,direct" && export GO111MODULE=on
+  - export GOPROXY="https://proxy.golang.org,direct"
 
 script: go get ./... && ./scripts/check-uncommitted-vendor-files.sh && go test -v github.com/wtfutil/wtf/...

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN apk add --no-cache make ncurses
 
 COPY . $GOPATH/src/github.com/wtfutil/wtf
 
-ENV GOPROXY=https://gocenter.io
+ENV GOPROXY=https://proxy.golang.org,direct
 ENV GO111MODULE=on
 ENV GOSUMDB=off
 
@@ -14,4 +14,4 @@ ENV PATH=$PATH:./bin
 
 RUN make build
 
-ENTRYPOINT "wtfutil" 
+ENTRYPOINT "wtfutil"

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ endif
 
 # Set go modules to on and use GoCenter for immutable modules
 export GO111MODULE = on
-export GOPROXY = https://gocenter.io
+export GOPROXY = https://proxy.golang.org,direct
 
 # Determines the path to this Makefile
 THIS_FILE := $(lastword $(MAKEFILE_LIST))

--- a/README.md
+++ b/README.md
@@ -93,8 +93,8 @@ and you should be good to go.
 If you want to run the build command from within your `$GOPATH`:
 
 ```bash
-# Set the Go proxy variable to GoCenter
-export GOPROXY="https://gocenter.io"
+# Set the Go proxy
+export GOPROXY="https://proxy.golang.org,direct"
 
 # Disable the Go checksum database
 export GOSUMDB=off
@@ -111,8 +111,8 @@ make run
 If you want to run the build command from a folder that is not in your `$GOPATH`:
 
 ```bash
-# Set the Go proxy variable to GoCenter
-export GOPROXY="https://gocenter.io"
+# Set the Go proxy
+export GOPROXY="https://proxy.golang.org,direct"
 
 go get -u github.com/wtfutil/wtf
 cd $GOPATH/src/github.com/wtfutil/wtf
@@ -147,7 +147,7 @@ Find #wtfutil on https://gophers.slack.com/ and join us.
 
 ### Twitter
 
-Also, follow [on Twitter](https://twitter.com/wtfutil) for news and latest updates. 
+Also, follow [on Twitter](https://twitter.com/wtfutil) for news and latest updates.
 
 ## Documentation
 
@@ -182,7 +182,7 @@ If there is a bug that you really need to have fixed or a feature you really wan
 
 ## Contributing to the Source Code
 
-First, please read [Talk, then code](https://dave.cheney.net/2019/02/18/talk-then-code) by Dave Cheney. It's great advice and will often save a lot of time and effort. 
+First, please read [Talk, then code](https://dave.cheney.net/2019/02/18/talk-then-code) by Dave Cheney. It's great advice and will often save a lot of time and effort.
 
 Next, please read [CONTRIBUTING.md](CONTRIBUTING.md) for details on our code of conduct, and the process for submitting pull requests.
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/wtfutil/wtf
 
-go 1.12
+go 1.13
 
 require (
 	code.cloudfoundry.org/bytefmt v0.0.0-20190819182555-854d396b647c

--- a/scripts/check-uncommitted-vendor-files.sh
+++ b/scripts/check-uncommitted-vendor-files.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-GOPROXY="https://gocenter.io" GOSUMDB=off GO111MODULE=on go mod tidy
+GOPROXY="https://proxy.golang.org,direct" GOSUMDB=off GO111MODULE=on go mod tidy
 
 untracked_files=$(git ls-files --others --exclude-standard | wc -l)
 


### PR DESCRIPTION
Recently, when I tried to update `go.mod` file in goreleaser project, we found that gocenter hash for some dependency is not consistent with proxy.golang.org (which is the default goproxy).

Details are in this comment, https://github.com/goreleaser/goreleaser/pull/1217#issuecomment-547150158
And the golang proxy updated in this PR, https://github.com/goreleaser/goreleaser/pull/1220#issuecomment-547639705