### PR TITLE
Added a setting to hide the completed downloads in the transmission module

### DIFF
--- a/modules/transmission/settings.go
+++ b/modules/transmission/settings.go
@@ -14,12 +14,13 @@ const (
 type Settings struct {
 	common *cfg.Common
 
-	host     string `help:"The address of the machine the Transmission daemon is running on"`
-	https    bool   `help:"Whether or not to connect to the host via HTTPS"`
-	password string `help:"The password for the Transmission user"`
-	port     uint16 `help:"The port to connect to the Transmission daemon on"`
-	url      string `help:"The RPC URI that the daemon is accessible at"`
-	username string `help:"The username of the Transmission user"`
+	host         string `help:"The address of the machine the Transmission daemon is running on"`
+	https        bool   `help:"Whether or not to connect to the host via HTTPS"`
+	password     string `help:"The password for the Transmission user"`
+	port         uint16 `help:"The port to connect to the Transmission daemon on"`
+	url          string `help:"The RPC URI that the daemon is accessible at"`
+	username     string `help:"The username of the Transmission user"`
+	hideComplete bool   `help:"Hide the torrents that are finished downloading"`
 }
 
 // NewSettingsFromYAML creates a new settings instance from a YAML config block
@@ -27,12 +28,13 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	settings := Settings{
 		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
-		host:     ymlConfig.UString("host"),
-		https:    ymlConfig.UBool("https", false),
-		password: ymlConfig.UString("password"),
-		port:     uint16(ymlConfig.UInt("port", 9091)),
-		url:      ymlConfig.UString("url", "/transmission/"),
-		username: ymlConfig.UString("username", ""),
+		host:         ymlConfig.UString("host"),
+		https:        ymlConfig.UBool("https", false),
+		password:     ymlConfig.UString("password"),
+		port:         uint16(ymlConfig.UInt("port", 9091)),
+		url:          ymlConfig.UString("url", "/transmission/"),
+		username:     ymlConfig.UString("username", ""),
+		hideComplete: ymlConfig.UBool("hideComplete", false),
 	}
 
 	return &settings

--- a/modules/transmission/widget.go
+++ b/modules/transmission/widget.go
@@ -57,7 +57,20 @@ func (widget *Widget) Fetch() ([]*transmissionrpc.Torrent, error) {
 		return nil, err
 	}
 
-	return torrents, nil
+	if !widget.settings.hideComplete {
+		return torrents, nil
+	}
+
+	out := make([]*transmissionrpc.Torrent, 0)
+	for _, torrent := range torrents {
+		if *torrent.PercentDone == 1.0 {
+			continue
+		}
+
+		out = append(out, torrent)
+	}
+
+	return out, nil
 }
 
 // Refresh updates the data for this widget and displays it onscreen


### PR DESCRIPTION
This adds a setting to the existing transmission module called `hideComplete` which when set to true will simply hide all the torrents that are at 100% from the view.