### PR TITLE
Bugfix for exchangerates module

### DIFF
--- a/modules/exchangerates/settings.go
+++ b/modules/exchangerates/settings.go
@@ -16,6 +16,7 @@ type Settings struct {
 	common *cfg.Common
 
 	rates map[string][]string `help:"Defines what currency rates we want to know about`
+	order []string
 }
 
 // NewSettingsFromYAML creates a new settings instance from a YAML config block
@@ -24,10 +25,12 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		rates: map[string][]string{},
+		order: []string{},
 	}
 
 	raw := ymlConfig.UMap("rates", map[string]interface{}{})
 	for key, value := range raw {
+		settings.order = append(settings.order, key)
 		settings.rates[key] = []string{}
 		switch value.(type) {
 		case string:

--- a/modules/exchangerates/widget.go
+++ b/modules/exchangerates/widget.go
@@ -55,10 +55,11 @@ func (widget *Widget) content() (string, string, bool) {
 	if widget.err != nil {
 		out = widget.err.Error()
 	} else {
-		for base, rates := range widget.rates {
+		for base, rates := range widget.settings.rates {
 			out += fmt.Sprintf("[%s]Rates from %s[white]\n", widget.settings.common.Colors.Subheading, base)
 			idx := 0
-			for cur, rate := range rates {
+			for _, cur := range rates {
+				rate := widget.rates[base][cur]
 				out += fmt.Sprintf("[%s]%s - %f[white]\n", widget.CommonSettings().RowColor(idx), cur, rate)
 				idx++
 			}


### PR DESCRIPTION
As I indicated in #749 I found a tiny bug that should be fixed with this release. If you're running the exchangerates module with a refreshInterval it could be that throughout the runtime of wtfutil the order that results would appear in change randomly. This merge request simply keeps the order and displays it accordingly.