### PR TITLE
Add shortcuts for GitHub Pull Requests and Issues

### DIFF
--- a/modules/github/github_repo.go
+++ b/modules/github/github_repo.go
@@ -10,6 +10,12 @@ import (
 	"golang.org/x/oauth2"
 )
 
+const (
+	pullRequestsPath = "/pulls"
+	issuesPath = "/issues"
+)
+
+
 // GithubRepo defines a new GithubRepo structure
 type GithubRepo struct {
 	apiKey    string
@@ -40,6 +46,16 @@ func NewGithubRepo(name, owner, apiKey, baseURL, uploadURL string) *GithubRepo {
 // Open will open the GitHub Repo URL using the utils helper
 func (repo *GithubRepo) Open() {
 	utils.OpenFile(*repo.RemoteRepo.HTMLURL)
+}
+
+// Open will open the GitHub Pull Requests URL using the utils helper
+func (repo *GithubRepo) OpenPulls() {
+	utils.OpenFile(*repo.RemoteRepo.HTMLURL + pullRequestsPath)
+}
+
+// Open will open the GitHub Issues URL using the utils helper
+func (repo *GithubRepo) OpenIssues() {
+	utils.OpenFile(*repo.RemoteRepo.HTMLURL + issuesPath)
 }
 
 // Refresh reloads the github data via the Github API

--- a/modules/github/keyboard.go
+++ b/modules/github/keyboard.go
@@ -12,6 +12,8 @@ func (widget *Widget) initializeKeyboardControls() {
 	widget.SetKeyboardChar("l", widget.NextSource, "Select next source")
 	widget.SetKeyboardChar("h", widget.PrevSource, "Select previous source")
 	widget.SetKeyboardChar("o", widget.openRepo, "Open item in browser")
+	widget.SetKeyboardChar("p", widget.openPulls, "Open pull requests in browser")
+	widget.SetKeyboardChar("i", widget.openIssues, "Open issues in browser")
 
 	widget.SetKeyboardKey(tcell.KeyDown, widget.Next, "Select next item")
 	widget.SetKeyboardKey(tcell.KeyUp, widget.Prev, "Select previous item")

--- a/modules/github/widget.go
+++ b/modules/github/widget.go
@@ -157,3 +157,19 @@ func (widget *Widget) openRepo() {
 		repo.Open()
 	}
 }
+
+func (widget *Widget) openPulls() {
+	repo := widget.currentGithubRepo()
+
+	if repo != nil {
+		repo.OpenPulls()
+	}
+}
+
+func (widget *Widget) openIssues() {
+	repo := widget.currentGithubRepo()
+
+	if repo != nil {
+		repo.OpenIssues()
+	}
+}


### PR DESCRIPTION
# Add shortcuts for GitHub Pull Requests and Issues

## Use case:

Often times I find myself needing to view some of the PRs that are open, but have already reviewed or have not been assigned as reviewer.

When you've already reviewed a PR or are not assigned to it, it will no longer show up in the `Open Review Requests` list, but the PR counter at the top will still reflect that there are open pull requests. I'd like to be able to quickly open GithHub on the Pull Requests page so I can see if the PRs that are left are once I've indeed reviewed or are left unreviewed (as I was maybe not assigned as reviewer originally).

It would also be useful to be able to quickly open the GitHub issues view and is why I've also added a shortcut for that.