### PR TITLE
Prevent flickering in cmdRunner widgets

### DIFF
--- a/modules/cmdrunner/widget.go
+++ b/modules/cmdrunner/widget.go
@@ -48,9 +48,6 @@ func NewWidget(app *tview.Application, settings *Settings) *Widget {
 // Refresh signals the runCommandLoop to continue, or triggers a re-draw if the
 // command is still running.
 func (widget *Widget) Refresh() {
-	widget.m.Lock()
-	defer widget.m.Unlock()
-
 	// Try to run the command. If the command is still running, let it keep
 	// running and do a refresh instead. Otherwise, the widget will redraw when
 	// the command completes.


### PR DESCRIPTION
This commit removes flickering in the cmdRunner widgets while preserving the live-update functionality. It amends https://github.com/wtfutil/wtf/commit/45b955 by not redrawing on every write call. Instead, the logic in Refresh is as follows:

1. If the command is already running, it will not try to re-run the
command. The default case in the select will trigger a re-draw instead
so that new output can be seen. This accommodates long-runing commands
eg. tailing a log.
2. If the command is not already running, it will trigger a new run.
When the command terminates, it will trigger a re-draw. This means the
widget refreshes as soon as possible, to accommodate the original use
case of running a command and displaying its output in the widget.

In all cases, the widget will not re-draw more often than the refresh interval. This is what eliminates flickering, since the previous implementation before using goroutines was not redrawing more than once per refresh interval.

I haven't written a lot of Go code before so don't hesitate to nitpick the style etc.

Partially fixes #732 (I don't know what's wrong with the tail configuration so I didn't try to fix it here).