### PR TITLE
Enable Jenkins module to work with Multi-configuration projects

### DIFF
--- a/modules/jenkins/client.go
+++ b/modules/jenkins/client.go
@@ -45,10 +45,13 @@ func (widget *Widget) Create(jenkinsURL string, username string, apiKey string) 
 		return view, err
 	}
 
-	jobs := []Job{}
+	respJobs := make([]Job, 0, len(view.Jobs) + len(view.ActiveConfigurations))
+	respJobs = append(append(respJobs, view.Jobs...), view.ActiveConfigurations...)
+
+	jobs := make([]Job, 0)
 
 	var validID = regexp.MustCompile(widget.settings.jobNameRegex)
-	for _, job := range view.Jobs {
+	for _, job := range respJobs {
 		if validID.MatchString(job.Name) {
 			jobs = append(jobs, job)
 		}

--- a/modules/jenkins/job.go
+++ b/modules/jenkins/job.go
@@ -1,7 +1,6 @@
 package jenkins
 
 type Job struct {
-	Class string `json:"_class"`
 	Name  string `json:"name"`
 	Url   string `json:"url"`
 	Color string `json:"color"`

--- a/modules/jenkins/view.go
+++ b/modules/jenkins/view.go
@@ -1,10 +1,9 @@
 package jenkins
 
 type View struct {
-	Class       string   `json:"_class"`
-	Description string   `json:"description"`
-	Jobs        []Job    `json:"jobs"`
-	Name        string   `json:"name"`
-	Property    []string `json:"property"`
-	Url         string   `json:"url"`
+	Description          string   `json:"description"`
+	Jobs                 []Job    `json:"jobs"`
+	ActiveConfigurations []Job    `json:"activeConfigurations"`
+	Name                 string   `json:"name"`
+	Url                  string   `json:"url"`
 }


### PR DESCRIPTION
# Enable Jenkins module to work with Multi-configuration projects

In practice it's quite often for teams to have Jenkins configurations not in just a plain Jenkins Project/View, but to rather have numerous Multi-configuration projects.

For such cases it would be very useful if the Jenkins module for `wtf` could support Multi-configuration projects.

This change aims to enable this scenario and thus further evolve the Jenkins module.

> Note: I've removed some configuration properties that were never used (and were actually somewhat incorrectly defined).