### PR TITLE
WTF-748 Fixes and improves module templating

### DIFF
--- a/generator/settings.tpl
+++ b/generator/settings.tpl
@@ -1,0 +1,29 @@
+package {{(Lower .Name)}}
+
+import (
+	"github.com/olebedev/config"
+	"github.com/wtfutil/wtf/cfg"
+)
+
+const (
+	defaultFocusable = false
+	defaultTitle     = "{{(.Name)}}"
+)
+
+// Settings defines the configuration properties for this module
+type Settings struct {
+	common *cfg.Common
+
+    // Define your settings attributes here
+}
+
+// NewSettingsFromYAML creates a new settings instance from a YAML config block
+func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
+	settings := Settings{
+        common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+
+        // Configure your settings attributes here. See http://github.com/olebedev/config for type details
+	}
+
+	return &settings
+}

--- a/generator/textwidget.go
+++ b/generator/textwidget.go
@@ -36,17 +36,43 @@ func main() {
 		widgetName,
 	}
 
-	tpl, _ := template.New("textwidget.tpl").Funcs(template.FuncMap{
-		"Lower": strings.ToLower,
-		"Title": strings.Title,
-	}).ParseFiles("generator/textwidget.tpl")
+	createModuleDirectory(data)
 
-	err := os.Mkdir(strings.ToLower(widgetName), os.ModePerm)
+	generateWidgetFile(data)
+	generateSettingsFile(data)
+
+	fmt.Println("Done")
+}
+
+/* -------------------- Unexported Functions -------------------- */
+
+func createModuleDirectory(data struct { Name string }) {
+	err := os.MkdirAll(strings.ToLower(fmt.Sprintf("modules/%s", data.Name)), os.ModePerm)
 	if err != nil {
 		fmt.Println(err.Error())
 	}
+}
 
-	out, err := os.Create(fmt.Sprintf("%s/widget.go", strings.ToLower(widgetName)))
+func generateWidgetFile(data struct { Name string }) {
+	tpl, _ := template.New("textwidget.tpl").Funcs(template.FuncMap{
+		"Lower": strings.ToLower,
+	}).ParseFiles("generator/textwidget.tpl")
+
+	out, err := os.Create(fmt.Sprintf("modules/%s/widget.go", strings.ToLower(data.Name)))
+	if err != nil {
+		fmt.Println(err.Error())
+	}
+	defer out.Close()
+
+	tpl.Execute(out, data)
+}
+
+func generateSettingsFile(data struct { Name string }) {
+    tpl, _ := template.New("settings.tpl").Funcs(template.FuncMap{
+		"Lower": strings.ToLower,
+	}).ParseFiles("generator/settings.tpl")
+
+	out, err := os.Create(fmt.Sprintf("modules/%s/settings.go", strings.ToLower(data.Name)))
 	if err != nil {
 		fmt.Println(err.Error())
 	}

--- a/generator/textwidget.tpl
+++ b/generator/textwidget.tpl
@@ -1,56 +1,47 @@
-// Package {{(Lower .Name)}}
 package {{(Lower .Name)}}
 
 import (
-	"strconv"
-
-	"github.com/gdamore/tcell"
 	"github.com/rivo/tview"
-	"github.com/wtfutil/wtf/wtf"
+	"github.com/wtfutil/wtf/view"
 )
 
-const HelpText = `
- Keyboard commands for {{(Title .Name)}}:
-`
-
+// Widget is the container for your module's data
 type Widget struct {
-	wtf.HelpfulWidget
-	wtf.KeyboardWidget
-	wtf.TextWidget
+	view.TextWidget
 
+    app      *tview.Application
 	settings *Settings
 }
 
+// NewWidget creates and returns an instance of Widget
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		HelpfulWidget: wtf.NewHelpfulWidget(app, pages, HelpText),
-		KeyboardWidget: wtf.NewKeyboardWidget(),
-		TextWidget:    wtf.NewTextWidget(app, settings.common, false),
+		TextWidget: view.NewTextWidget(app, settings.common),
 
+		app:      app,
 		settings: settings,
 	}
-
-  widget.initializeKeyboardControls()
-	widget.View.SetInputCapture(widget.InputCapture)
-
-	widget.View.SetScrollable(true)
-	widget.View.SetRegions(true)
-
-	widget.HelpfulWidget.SetView(widget.View)
 
 	return &widget
 }
 
 /* -------------------- Exported Functions -------------------- */
 
+// Refresh updates the onscreen contents of the widget
 func (widget *Widget) Refresh() {
 
-	// The last call should always be to the display function
-  widget.display()
+    // The last call should always be to the display function
+    widget.display()
 }
 
 /* -------------------- Unexported Functions -------------------- */
 
+func (widget *Widget) content() string {
+	return "This is my widget"
+}
+
 func (widget *Widget) display() {
-  widget.Redraw(widget.CommonSettings().Title, "Some text", false)
+	widget.Redraw(func() (string, string, bool) {
+		return widget.CommonSettings().Title, widget.content(), false
+	})
 }

--- a/modules/digitalclock/display.go
+++ b/modules/digitalclock/display.go
@@ -24,5 +24,4 @@ func (widget *Widget) display() {
 	widget.Redraw(func() (string, string, bool) {
 		return widget.CommonSettings().Title, renderWidget(*widget.settings), false
 	})
-
 }

--- a/modules/digitalclock/settings.go
+++ b/modules/digitalclock/settings.go
@@ -10,9 +10,8 @@ const (
 	defaultTitle     = "Clocks"
 )
 
-// Settings struct to define settings got digital clock
+// Settings defines the configuration properties for this module
 type Settings struct {
-	// hello
 	common *cfg.Common
 
 	hourFormat string `help:"The format of the clock." values:"12 or 24"`
@@ -20,7 +19,7 @@ type Settings struct {
 	font       string `help:"The font of the clock." values:"bigfont or digitalfont"`
 }
 
-// NewSettingsFromYAML functino to create setting instance from yaml file
+// NewSettingsFromYAML creates a new settings instance from a YAML config block
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{

--- a/modules/digitalclock/widget.go
+++ b/modules/digitalclock/widget.go
@@ -5,7 +5,7 @@ import (
 	"github.com/wtfutil/wtf/view"
 )
 
-// Widget a text widget struct to hold info about the current widget
+// Widget is a text widget struct to hold info about the current widget
 type Widget struct {
 	view.TextWidget
 
@@ -15,7 +15,6 @@ type Widget struct {
 
 // NewWidget creates a new widget using settings
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
-
 	widget := Widget{
 		TextWidget: view.NewTextWidget(app, settings.common),
 
@@ -30,9 +29,5 @@ func NewWidget(app *tview.Application, settings *Settings) *Widget {
 
 // Refresh updates the onscreen contents of the widget
 func (widget *Widget) Refresh() {
-	widget.app.QueueUpdateDraw(func() {
-		widget.display()
-	})
+	widget.display()
 }
-
-/* -------------------- Unexported Functions -------------------- */

--- a/modules/digitalocean/widget.go
+++ b/modules/digitalocean/widget.go
@@ -28,7 +28,7 @@ func (t *tokenSource) Token() (*oauth2.Token, error) {
 
 /* -------------------- Widget -------------------- */
 
-// Widget is the container for transmission data
+// Widget is the container for droplet data
 type Widget struct {
 	view.KeyboardWidget
 	view.ScrollableWidget


### PR DESCRIPTION
Fixes and improves the module templating for creating new bare-bones
text widgets.

This command:

    WTF_WIDGET_NAME=MyNewWidget go generate -run=text

now properly generates:

    * the module directory in the /modules directory
    * the widget.go file
    * the settings.go file

with no linter warnings or errors.

Fixes #748 

Signed-off-by: Chris Cummer <chriscummer@me.com>