### PR TITLE
WTF-781 Switch Todoist IDs from `int` to `string`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/shirou/gopsutil v2.19.11+incompatible
 	github.com/stretchr/testify v1.4.0
 	github.com/wtfutil/spotigopher v0.0.0-20191127141047-7d8168fe103a
-	github.com/wtfutil/todoist v0.0.1
+	github.com/wtfutil/todoist v0.0.2-0.20191215183557-6f3412240454
 	github.com/xanzy/go-gitlab v0.22.2
 	github.com/zmb3/spotify v0.0.0-20191010212056-e12fb981aacb
 	github.com/zorkian/go-datadog-api v2.25.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -250,8 +250,8 @@ github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyC
 github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=
 github.com/wtfutil/spotigopher v0.0.0-20191127141047-7d8168fe103a h1:2eyMT9EpTPS4PiVfvXvqA8PKB5FoSl6gGjgb3CQ0cug=
 github.com/wtfutil/spotigopher v0.0.0-20191127141047-7d8168fe103a/go.mod h1:AlO4kKlF1zyOHTq2pBzxEERdBDStJev0VZNukFEqz/E=
-github.com/wtfutil/todoist v0.0.1 h1:E3srzocggLHme8zIEAEXXoY/fQZtFRjW69m4OiYv3hg=
-github.com/wtfutil/todoist v0.0.1/go.mod h1:YuuGLJSsTK6DGBD5Zaf3J8LSMfpEC2WtzYPey3XVOdI=
+github.com/wtfutil/todoist v0.0.2-0.20191215183557-6f3412240454 h1:XSwM0AhRpA80hXHSOQG2dCgF8Wp/l+6p3SlvcVJaWN8=
+github.com/wtfutil/todoist v0.0.2-0.20191215183557-6f3412240454/go.mod h1:YuuGLJSsTK6DGBD5Zaf3J8LSMfpEC2WtzYPey3XVOdI=
 github.com/xanzy/go-gitlab v0.22.2 h1:KYPewSm3Tl7WHrVON7BOwX6FZ1gaiFEdpOt0DNIYySA=
 github.com/xanzy/go-gitlab v0.22.2/go.mod h1:t4Bmvnxj7k37S4Y17lfLx+nLqkf/oQwT2HagfWKv5Og=
 github.com/zmb3/spotify v0.0.0-20191010212056-e12fb981aacb h1:uWB0RGxBo7AToSJ3rvoCZhXtLw4U7XISXSezPewmfic=

--- a/modules/todoist/project.go
+++ b/modules/todoist/project.go
@@ -14,7 +14,7 @@ type Project struct {
 	err   error
 }
 
-func NewProject(id int) *Project {
+func NewProject(id string) *Project {
 	// Todoist seems to experience a lot of network issues on their side
 	// If we can't connect, handle it with an empty project until we can
 	project, err := todoist.GetProject(id)
@@ -38,7 +38,7 @@ func (proj *Project) isLast() bool {
 }
 
 func (proj *Project) loadTasks() {
-	tasks, err := todoist.ListTask(todoist.QueryParam{"project_id": fmt.Sprintf("%d", proj.ID)})
+	tasks, err := todoist.ListTask(todoist.QueryParam{"project_id": fmt.Sprintf("%s", proj.ID)})
 	if err != nil {
 		proj.err = err
 		proj.tasks = nil

--- a/modules/todoist/settings.go
+++ b/modules/todoist/settings.go
@@ -18,7 +18,7 @@ type Settings struct {
 	common *cfg.Common
 
 	apiKey   string `help:"Your Todoist API key"`
-	projects []int
+	projects []string
 }
 
 // NewSettingsFromYAML creates a new settings instance from a YAML config block
@@ -27,7 +27,7 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		apiKey:   ymlConfig.UString("apiKey", ymlConfig.UString("apikey", os.Getenv("WTF_TODOIST_TOKEN"))),
-		projects: utils.ToInts(ymlConfig.UList("projects")),
+		projects: utils.ToStrs(ymlConfig.UList("projects")),
 	}
 
 	return &settings

--- a/vendor/github.com/wtfutil/todoist/projects.go
+++ b/vendor/github.com/wtfutil/todoist/projects.go
@@ -9,7 +9,7 @@ import (
 
 // Project is a model of todoist project entity
 type Project struct {
-	ID           int    `json:"id"`
+	ID           string `json:"id"`
 	Name         string `json:"name"`
 	CommentCount int    `json:"comment_count"`
 	Order        int    `json:"order"`
@@ -62,8 +62,8 @@ func ListProject() ([]Project, error) {
 //			panic(err)
 //		}
 //		fmt.Println(project)
-func GetProject(id int) (Project, error) {
-	path := fmt.Sprintf("projects/%d", id)
+func GetProject(id string) (Project, error) {
+	path := fmt.Sprintf("projects/%s", id)
 	res, err := makeRequest(http.MethodGet, path, nil)
 	if err != nil {
 		return Project{}, err
@@ -109,7 +109,7 @@ func CreateProject(name string) (Project, error) {
 //			panic(err)
 //		}
 func (p Project) Delete() error {
-	path := fmt.Sprintf("projects/%d", p.ID)
+	path := fmt.Sprintf("projects/%s", p.ID)
 	_, err := makeRequest(http.MethodDelete, path, nil)
 	if err != nil {
 		return err
@@ -133,7 +133,7 @@ func (p Project) Delete() error {
 //		}
 //		fmt.Println(project)
 func (p Project) Update() error {
-	path := fmt.Sprintf("projects/%d", p.ID)
+	path := fmt.Sprintf("projects/%s", p.ID)
 	project := struct {
 		Name string `json:"name"`
 	}{

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -264,7 +264,7 @@ github.com/spf13/pflag
 github.com/stretchr/testify/assert
 # github.com/wtfutil/spotigopher v0.0.0-20191127141047-7d8168fe103a
 github.com/wtfutil/spotigopher/spotigopher
-# github.com/wtfutil/todoist v0.0.1
+# github.com/wtfutil/todoist v0.0.2-0.20191215183557-6f3412240454
 github.com/wtfutil/todoist
 # github.com/xanzy/go-gitlab v0.22.2
 github.com/xanzy/go-gitlab


### PR DESCRIPTION
On platforms that convert an `int` to `int32`, like the Raspberry Pi,
an `int` is not large enough to store Todoist project IDs.

Using a `string` ensures this never becomes a problem.

Fixes #781

Signed-off-by: Chris Cummer <chriscummer@me.com>