### PR TITLE
Add 'withDate' option to digitalclock module

### DIFF
--- a/modules/digitalclock/display.go
+++ b/modules/digitalclock/display.go
@@ -8,15 +8,20 @@ func mergeLines(outString []string) string {
 
 func renderWidget(widgetSettings Settings) string {
 	outputStrings := []string{}
+
 	clockString, needBorder := renderClock(widgetSettings)
 	if needBorder {
 		outputStrings = append(outputStrings, mergeLines([]string{"", clockString, ""}))
 	} else {
 		outputStrings = append(outputStrings, clockString)
 	}
-	outputStrings = append(outputStrings, getDate())
-	outputStrings = append(outputStrings, getUTC())
-	outputStrings = append(outputStrings, getEpoch())
+
+	if widgetSettings.withDate {
+		outputStrings = append(outputStrings, getDate())
+		outputStrings = append(outputStrings, getUTC())
+		outputStrings = append(outputStrings, getEpoch())
+	}
+
 	return mergeLines(outputStrings)
 }
 

--- a/modules/digitalclock/settings.go
+++ b/modules/digitalclock/settings.go
@@ -14,20 +14,21 @@ const (
 type Settings struct {
 	common *cfg.Common
 
-	hourFormat string `help:"The format of the clock." values:"12 or 24"`
 	color      string `help:"The color of the clock."`
 	font       string `help:"The font of the clock." values:"bigfont or digitalfont"`
+	hourFormat string `help:"The format of the clock." values:"12 or 24"`
+	withDate   bool   `help:"Whether or not to display date information"`
 }
 
 // NewSettingsFromYAML creates a new settings instance from a YAML config block
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
-
 	settings := Settings{
 		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		color:      ymlConfig.UString("color"),
 		font:       ymlConfig.UString("font"),
 		hourFormat: ymlConfig.UString("hourFormat", "24"),
+		withDate:   ymlConfig.UBool("withDate", true),
 	}
 
 	return &settings


### PR DESCRIPTION
When `withDate` is `true`, it displays date information below the clock.
When `withDate` is `false`, it does not display date information.
Defaults to `true`.

Signed-off-by: Chris Cummer <chriscummer@me.com>