### PR TITLE
Google Calendar subheading now obey global subheading color

### DIFF
--- a/modules/gcal/display.go
+++ b/modules/gcal/display.go
@@ -83,8 +83,7 @@ func (widget *Widget) dayDivider(event, prevEvent *CalEvent) string {
 	eventStartDay := toMidnight(event.Start())
 
 	if !eventStartDay.Equal(prevStartDay) {
-
-		return fmt.Sprintf("[%s::b]",
+		return fmt.Sprintf("[%s]",
 			widget.settings.colors.day) +
 			event.Start().Format(utils.FullDateFormat) +
 			"\n"

--- a/modules/gcal/settings.go
+++ b/modules/gcal/settings.go
@@ -58,7 +58,7 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 		calendarReadLevel:     ymlConfig.UString("calendarReadLevel", "writer"),
 	}
 
-	settings.colors.day = ymlConfig.UString("colors.day", "forestgreen")
+	settings.colors.day = ymlConfig.UString("colors.day", settings.common.Colors.Subheading)
 	settings.colors.description = ymlConfig.UString("colors.description", "white")
 	// settings.colors.eventTime is a new feature introduced via issue #638. Prior to this, the color of the event
 	// time was (unintentionally) customized via settings.colors.description. To maintain backwards compatibility


### PR DESCRIPTION
This can still be over-written by setting:

```
   gcal:
      colors:
        day: "orange::b"
```
explicitly in your gCal configuration.

Signed-off-by: Chris Cummer <chriscummer@me.com>