### PR TITLE
Add 'myName' option to pagerduty module

### DIFF
--- a/modules/pagerduty/settings.go
+++ b/modules/pagerduty/settings.go
@@ -12,22 +12,26 @@ const (
 	defaultTitle     = "PagerDuty"
 )
 
+// Settings defines the configuration properties for this module
 type Settings struct {
 	common *cfg.Common
 
 	apiKey           string        `help:"Your PagerDuty API key."`
 	escalationFilter []interface{} `help:"An array of schedule names you want to filter on."`
+	myName           string        `help:"The name to highlight when on-call in PagerDuty."`
 	scheduleIDs      []interface{} `help:"An array of schedule IDs you want to restrict the query to."`
 	showIncidents    bool          `help:"Whether or not to list incidents." optional:"true"`
 	showSchedules    bool          `help:"Whether or not to show schedules." optional:"true"`
 }
 
+// NewSettingsFromYAML creates a new settings instance from a YAML config block
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := Settings{
 		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		apiKey:           ymlConfig.UString("apiKey", ymlConfig.UString("apikey", os.Getenv("WTF_PAGERDUTY_API_KEY"))),
 		escalationFilter: ymlConfig.UList("escalationFilter"),
+		myName:           ymlConfig.UString("myName"),
 		scheduleIDs:      ymlConfig.UList("scheduleIDs", []interface{}{}),
 		showIncidents:    ymlConfig.UBool("showIncidents", true),
 		showSchedules:    ymlConfig.UBool("showSchedules", true),

--- a/modules/pagerduty/widget.go
+++ b/modules/pagerduty/widget.go
@@ -118,11 +118,21 @@ func (widget *Widget) contentFrom(onCalls []pagerduty.OnCall, incidents []pagerd
 					" [%s]%d - %s\n",
 					widget.settings.common.Colors.Text,
 					item.EscalationLevel,
-					item.User.Summary,
+					widget.userSummary(item),
 				)
 			}
 		}
 	}
 
 	return str
+}
+
+func (widget *Widget) userSummary(item pagerduty.OnCall) string {
+	summary := item.User.Summary
+
+	if summary == widget.settings.myName {
+		summary = fmt.Sprintf("[::b]%s", summary)
+	}
+
+	return summary
 }

--- a/modules/todo/settings.go
+++ b/modules/todo/settings.go
@@ -10,6 +10,7 @@ const (
 	defaultTitle     = "Todo"
 )
 
+// Settings defines the configuration properties for this module
 type Settings struct {
 	common *cfg.Common
 
@@ -18,6 +19,7 @@ type Settings struct {
 	unchecked string
 }
 
+// NewSettingsFromYAML creates a new settings instance from a YAML config block
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	common := cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig)
 


### PR DESCRIPTION
If defined, this name will be highlighted in the PagerDuty widget
when that person is on-call.

```
    pagerduty:
      myName: "Chris Cummer"
```

Signed-off-by: Chris Cummer <chriscummer@me.com>