### PR TITLE
Added SpaceX Module

### DIFF
--- a/app/widget_maker.go
+++ b/app/widget_maker.go
@@ -47,6 +47,7 @@ import (
 	"github.com/wtfutil/wtf/modules/resourceusage"
 	"github.com/wtfutil/wtf/modules/rollbar"
 	"github.com/wtfutil/wtf/modules/security"
+	"github.com/wtfutil/wtf/modules/spacex"
 	"github.com/wtfutil/wtf/modules/spotify"
 	"github.com/wtfutil/wtf/modules/spotifyweb"
 	"github.com/wtfutil/wtf/modules/status"
@@ -227,6 +228,9 @@ func MakeWidget(
 	case "security":
 		settings := security.NewSettingsFromYAML(moduleName, moduleConfig, config)
 		widget = security.NewWidget(app, settings)
+	case "spacex":
+		settings := spacex.NewSettingsFromYAML(moduleName, moduleConfig, config)
+		widget = spacex.NewWidget(app, settings)
 	case "spotify":
 		settings := spotify.NewSettingsFromYAML(moduleName, moduleConfig, config)
 		widget = spotify.NewWidget(app, pages, settings)

--- a/modules/spacex/client.go
+++ b/modules/spacex/client.go
@@ -1,0 +1,50 @@
+package spacex
+
+import (
+	"github.com/wtfutil/wtf/utils"
+	"net/http"
+)
+
+const (
+	spacexLaunchAPI = "https://api.spacexdata.com/v3/launches/next"
+)
+
+type Launch struct {
+	FlightNumber int        `json:"flight_number"`
+	MissionName  string     `json:"mission_name"`
+	LaunchDate   int64      `json:"launch_date_unix"`
+	IsTentative  bool       `json:"tentative"`
+	Rocket       Rocket     `json:"rocket"`
+	LaunchSite   LaunchSite `json:"launch_site"`
+	Links        Links      `json:"links"`
+	Details      string     `json:"details"`
+}
+
+type LaunchSite struct {
+	Name string `json:"site_name_long"`
+}
+
+type Rocket struct {
+	Name string `json:"rocket_name"`
+}
+
+type Links struct {
+	RedditLink  string `json:"reddit_campaign"`
+	YouTubeLink string `json:"video_link"`
+}
+
+func NextLaunch() (*Launch, error) {
+	resp, err := http.Get(spacexLaunchAPI)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var data Launch
+	err = utils.ParseJSON(&data, resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	return &data, nil
+}

--- a/modules/spacex/settings.go
+++ b/modules/spacex/settings.go
@@ -1,0 +1,22 @@
+package spacex
+
+import (
+	"github.com/olebedev/config"
+	"github.com/wtfutil/wtf/cfg"
+)
+
+const (
+	defaultFocusable = false
+)
+
+type Settings struct {
+	common *cfg.Common
+}
+
+func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
+	spacex := ymlConfig.UString("spacex")
+	settings := Settings{
+		common: cfg.NewCommonSettingsFromModule(name, spacex, defaultFocusable, ymlConfig, globalConfig),
+	}
+	return &settings
+}

--- a/modules/spacex/widget.go
+++ b/modules/spacex/widget.go
@@ -1,0 +1,71 @@
+package spacex
+
+import (
+	"fmt"
+	"github.com/rivo/tview"
+	"github.com/wtfutil/wtf/view"
+	"github.com/wtfutil/wtf/wtf"
+	"time"
+)
+
+type Widget struct {
+	view.TextWidget
+	settings *Settings
+	err      error
+	launch   Launch
+}
+
+func NewWidget(app *tview.Application, settings *Settings) *Widget {
+	widget := &Widget{
+		TextWidget: view.NewTextWidget(app, settings.common),
+		settings:   settings,
+	}
+	return widget
+}
+
+func (widget *Widget) Refresh() {
+	if widget.Disabled() {
+		return
+	}
+	widget.Redraw(widget.content)
+}
+
+func (widget *Widget) Render() {
+	widget.Redraw(widget.content)
+}
+
+func (widget *Widget) content() (string, string, bool) {
+	var title = "Next SpaceX 🚀"
+	if widget.CommonSettings().Title != "" {
+		title = widget.CommonSettings().Title
+	}
+
+	launch, err := NextLaunch()
+	var str string
+	if err != nil {
+		handleError(widget, err)
+	} else {
+
+		str = fmt.Sprintf("[%s]Mission[white]\n", widget.settings.common.Colors.Subheading)
+		str += fmt.Sprintf("%s: %s\n", "Name", launch.MissionName)
+		str += fmt.Sprintf("%s: %s\n", "Date", wtf.UnixTime(launch.LaunchDate).Format(time.RFC822))
+		str += fmt.Sprintf("%s: %s\n", "Site", launch.LaunchSite.Name)
+		str += "\n"
+
+		str += fmt.Sprintf("[%s]Links[white]\n", widget.settings.common.Colors.Subheading)
+		str += fmt.Sprintf("%s: %s\n", "YouTube", launch.Links.YouTubeLink)
+		str += fmt.Sprintf("%s: %s\n", "Reddit", launch.Links.RedditLink)
+
+		if widget.CommonSettings().Height >= 2 {
+			str += "\n"
+			str += fmt.Sprintf("[%s]Details[white]\n", widget.settings.common.Colors.Subheading)
+			str += fmt.Sprintf("%s: %s\n", "RocketName", launch.Rocket.Name)
+			str += fmt.Sprintf("%s: %s\n", "Details", launch.Details)
+		}
+	}
+	return title, str, true
+}
+
+func handleError(widget *Widget, err error) {
+	widget.err = err
+}


### PR DESCRIPTION
Next SpaceX Launch Widget 

No config parameters since the API is unauthenticated [API Docs](https://docs.spacexdata.com/?version=latest#c75a20cf-50e7-4a4a-8856-ee729e0d3868)

![Screen Shot 2020-01-06 at 11 23 54 PM](https://user-images.githubusercontent.com/1467156/71876462-a1475880-30db-11ea-8371-270e1285c8d3.png)

If widget height >= 2 it also displays a description of the launch. It can be quite a bit of text, hence the height requirement.

I'm a big fan of watching these live so this will be a nice reminder.