### PR TITLE
Dockerfile - Use progressive build to reduce final image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,11 @@
-FROM golang:1.13-alpine
+FROM golang:1.13-alpine as build
 
-RUN apk add --no-cache make ncurses
+ARG version=master
 
-COPY . $GOPATH/src/github.com/wtfutil/wtf
+RUN apk add git make ncurses && \
+    git clone https://github.com/wtfutil/wtf.git $GOPATH/src/github.com/wtfutil/wtf && \
+    cd $GOPATH/src/github.com/wtfutil/wtf && \
+    git checkout $version
 
 ENV GOPROXY=https://proxy.golang.org,direct
 ENV GO111MODULE=on
@@ -14,4 +17,6 @@ ENV PATH=$PATH:./bin
 
 RUN make build
 
+FROM alpine
+COPY --from=build /go/src/github.com/wtfutil/wtf/bin/wtfutil /usr/local/bin/
 ENTRYPOINT "wtfutil"

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,5 +18,9 @@ ENV PATH=$PATH:./bin
 RUN make build
 
 FROM alpine
+
 COPY --from=build /go/src/github.com/wtfutil/wtf/bin/wtfutil /usr/local/bin/
-ENTRYPOINT "wtfutil"
+RUN adduser -h /config -DG users -u 20000 wtf
+
+USER wtf
+ENTRYPOINT ["wtfutil"]

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,0 +1,18 @@
+FROM golang:1.13 as build
+
+ARG version=master
+
+RUN git clone https://github.com/wtfutil/wtf.git $GOPATH/src/github.com/wtfutil/wtf && \
+    cd $GOPATH/src/github.com/wtfutil/wtf && \
+    git checkout $version
+
+ENV GOPROXY=https://proxy.golang.org,direct
+ENV GO111MODULE=on
+ENV GOSUMDB=off
+
+WORKDIR $GOPATH/src/github.com/wtfutil/wtf
+
+ENV PATH=$PATH:./bin
+
+RUN make build && \
+    cp bin/wtfutil /usr/local/bin/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build clean contrib_check coverage help install isntall lint run size test uninstall
+.PHONY: build clean contrib_check coverage docker-build docker-install help install isntall lint run size test uninstall
 
 # detect GOPATH if not set
 ifndef $(GOPATH)
@@ -47,6 +47,21 @@ contrib-check:
 coverage:
 	go test -coverprofile=coverage.out ./...
 	go tool cover -html=coverage.out
+
+## docker-build: builds in docker
+docker-build:
+	@echo "Building ${APP} in Docker..."
+	docker build -t wtfutil:build --build-arg=version=master -f Dockerfile.build .
+	@echo "Done with docker build"
+
+## docker-install: installs a local version of the app from docker build
+docker-install:
+	@echo "Installing ${APP}..."
+	docker create --name wtf_build wtfutil:build
+	docker cp wtf_build:/usr/local/bin/wtfutil ~/.local/bin/
+	$(eval INSTALLPATH = $(shell which ${APP}))
+	@echo "${APP} installed into ${INSTALLPATH}"
+	docker rm wtf_build
 
 ## gosec: runs the gosec static security scanner against the source code
 gosec:

--- a/README.md
+++ b/README.md
@@ -122,11 +122,14 @@ make run
 You can run `wtf` inside a docker container:
 
 ```bash
-# download the source
-git clone https://github.com/wtfutil/wtf
+# download or create the Dockerfile
+curl -o Dockerfile https://raw.githubusercontent.com/wtfutil/wtf/master/Dockerfile
 
 # build the docker container
 docker build -t wtfutil .
+
+# or for a particular tag or branch
+docker build --build-args=version=v0.25.0 -t wtfutil .
 
 # run the container
 docker run -it wtfutil

--- a/README.md
+++ b/README.md
@@ -133,6 +133,9 @@ docker build --build-args=version=v0.25.0 -t wtfutil .
 
 # run the container
 docker run -it wtfutil
+
+# run container with a local config file
+docker run -it -v path/to/config.yml:/config/config.yml wtfutil --config=/config/config.yml
 ```
 
 ## Communication

--- a/README.md
+++ b/README.md
@@ -115,6 +115,19 @@ make install
 make run
 ```
 
+### Installing from Source using Docker
+
+All building is done inside a docker container. You can then copy the binary to
+your local machine.
+
+```bash
+curl -o Dockerfile.build https://raw.githubusercontent.com/wtfutil/wtf/master/Dockerfile.build
+docker build -f Dockerfile.build -t wtfutil --build-args=version=master .
+docker create --name wtf_build wtfutil
+docker cp wtf_build:/usr/local/bin/wtfutil ~/.local/bin
+docker rm wtf_build
+```
+
 **Note:** WTF is _only_ compatible with Go versions **1.12.0** or later (due to the use of Go modules and newer standard library functions). If you would like to use `gccgo` to compile, you _must_ use `gccgo-9` or later which introduces support for Go modules.
 
 ## Running via Docker


### PR DESCRIPTION
- Use progressive build to reduce final image size
- Download source during build so only Dockerfile is required to be present on the build host
- Add a `version` arg so any tag or branch can be built: `docker build --build-arg=version=v0.25.0 -t wtf .`