### PR TITLE
Gitlab: allow for opening items in browser

### DIFF
--- a/modules/gitlab/keyboard.go
+++ b/modules/gitlab/keyboard.go
@@ -1,13 +1,24 @@
 package gitlab
 
-import "github.com/gdamore/tcell"
+import (
+	"github.com/gdamore/tcell"
+)
 
 func (widget *Widget) initializeKeyboardControls() {
 	widget.InitializeCommonControls(widget.Refresh)
 
-	widget.SetKeyboardChar("h", widget.PrevSource, "Select previous project")
+	widget.SetKeyboardChar("j", widget.Next, "Select next item")
+	widget.SetKeyboardChar("k", widget.Prev, "Select previous item")
 	widget.SetKeyboardChar("l", widget.NextSource, "Select next project")
+	widget.SetKeyboardChar("h", widget.PrevSource, "Select previous project")
+	widget.SetKeyboardChar("o", widget.openRepo, "Open item in browser")
+	widget.SetKeyboardChar("p", widget.openPulls, "Open merge requests in browser")
+	widget.SetKeyboardChar("i", widget.openIssues, "Open issues in browser")
 
-	widget.SetKeyboardKey(tcell.KeyLeft, widget.PrevSource, "Select previous project")
+	widget.SetKeyboardKey(tcell.KeyDown, widget.Next, "Select next item")
+	widget.SetKeyboardKey(tcell.KeyUp, widget.Prev, "Select previous item")
 	widget.SetKeyboardKey(tcell.KeyRight, widget.NextSource, "Select next project")
+	widget.SetKeyboardKey(tcell.KeyLeft, widget.PrevSource, "Select previous project")
+	widget.SetKeyboardKey(tcell.KeyEnter, widget.openItemInBrowser, "Open item in browser")
+	widget.SetKeyboardKey(tcell.KeyEsc, widget.Unselect, "Clear selection")
 }


### PR DESCRIPTION
Implementing more keyboard actions for the GitLab module.
This stream lines both the code and the experience with the Github module.