### PR TITLE
fix digitalclock display bug.

### DIFF
--- a/modules/digitalclock/clocks.go
+++ b/modules/digitalclock/clocks.go
@@ -40,7 +40,6 @@ func getHourMinute(hourFormat string) string {
 	}
 
 	strMintues := intStrConv(time.Now().Minute())
-	fmt.Println(AMPM)
 	strMintues = strMintues + AMPM
 	return strHours + getColon() + strMintues
 }


### PR DESCRIPTION
This is a fix for https://github.com/wtfutil/wtf/issues/811.
I believe the issue is in the digitalclock module where the developer has accidentally left a print statement.

I was able to recreate with the following config:
```
digitalclock:
      color: orange
      enabled: true
      font: bigfont
      hourFormat: 12
      position:
        top: 0
        left: 0
        height: 1
        width: 1
      refreshInterval: 1
      title: "big clock"
      type: "digitalclock"
```
and you can see the P at the bottom-left and on the right-hand side. 
<img width="613" alt="image" src="https://user-images.githubusercontent.com/843944/80397427-0652d400-88ae-11ea-97d2-4b7fcfc85282.png">
The clue was in Epoch showing a P after the number, when Epoch doesn't include AM/PM. It's not clear that @andersmmg is using the module, but the random A or P (for AM or PM) would fit the behaviour. It should at least fix issue seen by @BonoVanderpoorten with this module.