### PR TITLE
Fix feed module item sorting

### DIFF
--- a/modules/feedreader/widget.go
+++ b/modules/feedreader/widget.go
@@ -3,16 +3,11 @@ package feedreader
 import (
 	"fmt"
 	"sort"
-	"time"
 
 	"github.com/mmcdole/gofeed"
 	"github.com/rivo/tview"
 	"github.com/wtfutil/wtf/utils"
 	"github.com/wtfutil/wtf/view"
-)
-
-const (
-	publishedDateLayout = "Mon, 02 2006 15:04:05"
 )
 
 // FeedItem represents an item returned from an RSS or Atom feed
@@ -158,10 +153,7 @@ func (widget *Widget) content() (string, string, bool) {
 // feedItems are sorted by published date
 func (widget *Widget) sort(feedItems []*FeedItem) []*FeedItem {
 	sort.Slice(feedItems, func(i, j int) bool {
-		iTime, _ := time.Parse(publishedDateLayout, feedItems[i].item.Published)
-		jTime, _ := time.Parse(publishedDateLayout, feedItems[j].item.Published)
-
-		return iTime.After(jTime)
+		return feedItems[i].item.PublishedParsed.After(*feedItems[j].item.PublishedParsed)
 	})
 
 	return feedItems


### PR DESCRIPTION
The original one doesn't sort the items at all, you can see this when you have multiple feeds and the items are never interleaved. Turns out `gofeed` already does date parsing, switch to using its parsed dates and it starts working.