### PR TITLE
golangci-lint configuration file

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,20 @@
+name: golangci-lint
+on:
+  push:
+    tags:
+      - v*
+    branches:
+      - master
+  pull_request:
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v0.2.0
+        with:
+          # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
+          version: v1.27
+          args: ./...

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,15 @@
+linters:
+  enable:
+    - vet
+    - errcheck
+    - staticcheck
+#   - dupl
+#   - funlen
+#   - goconst
+#   - gocritic
+    - gofmt
+#   - golint
+#   - misspell
+#   - stylecheck
+    - unconvert
+#   - whitespace

--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,9 @@ install:
 	@echo "${APP} installed into ${INSTALLPATH}"
 
 ## lint: runs a number of code quality checks against the source code
+cilint:
+	golangci-lint run
+
 lint:
 	@echo "\033[35mhttps://github.com/kisielk/errcheck\033[0m"
 	errcheck ./app

--- a/app/focus_tracker.go
+++ b/app/focus_tracker.go
@@ -200,7 +200,7 @@ func (tracker *FocusTracker) focusables() []wtf.Wtfable {
 	}
 
 	// Sort for deterministic ordering
-	sort.SliceStable(focusable[:], func(i, j int) bool {
+	sort.SliceStable(focusable, func(i, j int) bool {
 		iTop := focusable[i].CommonSettings().Top
 		jTop := focusable[j].CommonSettings().Top
 

--- a/app/wtf_app.go
+++ b/app/wtf_app.go
@@ -109,6 +109,7 @@ func (wtfApp *WtfApp) keyboardIntercept(event *tcell.EventKey) *tcell.EventKey {
 		switch string(event.Rune()) {
 		case "/":
 			return nil
+		default:
 		}
 	}
 

--- a/cfg/config_files.go
+++ b/cfg/config_files.go
@@ -78,7 +78,7 @@ func WtfConfigDir() (string, error) {
 	if configDir == "" {
 		configDir = WtfConfigDirV2
 	} else {
-		configDir = configDir + "/wtf/"
+		configDir += "/wtf/"
 	}
 	configDir, err := expandHomeDir(configDir)
 	if err != nil {

--- a/modules/cds/queue/display.go
+++ b/modules/cds/queue/display.go
@@ -73,11 +73,12 @@ func (widget *Widget) generateQueueJobLine(id int64, parameters []sdk.Parameter,
 	row[2] = pad(run, 7)
 	row[3] = pad(prj+"/"+workflow+"/"+node, 40)
 
-	if status == sdk.StatusBuilding {
+	switch {
+	case status == sdk.StatusBuilding:
 		row[1] = pad(fmt.Sprintf(" %s.%s ", executedJob.WorkerName, executedJob.WorkerID), 27)
-	} else if bookedBy.ID != 0 {
+	case bookedBy.ID != 0:
 		row[1] = pad(fmt.Sprintf(" %s.%d ", bookedBy.Name, bookedBy.ID), 27)
-	} else {
+	default:
 		row[1] = pad("", 27)
 	}
 

--- a/modules/cds/status/display.go
+++ b/modules/cds/status/display.go
@@ -43,17 +43,18 @@ func (widget *Widget) displayStatus() string {
 	)
 
 	for _, line := range status.Lines {
-		if line.Status == sdk.MonitoringStatusWarn && strings.Contains(line.Component, "Global") {
+		switch {
+		case line.Status == sdk.MonitoringStatusWarn && strings.Contains(line.Component, "Global"):
 			globalWarn = append(globalWarn, line.String())
-		} else if line.Status != sdk.MonitoringStatusOK && strings.Contains(line.Component, "Global") {
+		case line.Status != sdk.MonitoringStatusOK && strings.Contains(line.Component, "Global"):
 			globalRed = append(globalRed, line.String())
-		} else if strings.Contains(line.Component, "Global") {
+		case strings.Contains(line.Component, "Global"):
 			global = append(global, line.String())
-		} else if line.Status == sdk.MonitoringStatusWarn {
+		case line.Status == sdk.MonitoringStatusWarn:
 			warn = append(warn, line.String())
-		} else if line.Status == sdk.MonitoringStatusOK {
+		case line.Status == sdk.MonitoringStatusOK:
 			ok = append(ok, line.String())
-		} else {
+		default:
 			red = append(red, line.String())
 		}
 	}

--- a/modules/cryptoexchanges/cryptolive/price/widget.go
+++ b/modules/cryptoexchanges/cryptolive/price/widget.go
@@ -129,7 +129,6 @@ func (widget *Widget) updateCurrencies() {
 
 		setPrices(&jsonResponse, fromCurrency)
 	}
-
 }
 
 func makeRequest(currency *fromCurrency) *http.Request {

--- a/modules/digitalclock/clocks.go
+++ b/modules/digitalclock/clocks.go
@@ -13,7 +13,7 @@ const AM = "A"
 const PM = "P"
 const minRowsForBorder = 3
 
-// Converts integer to string along with makes sure the lenght of string is > 2
+// Converts integer to string along with makes sure the length of string is > 2
 func intStrConv(val int) string {
 	valStr := strconv.Itoa(val)
 
@@ -39,9 +39,9 @@ func getHourMinute(hourFormat string) string {
 
 	}
 
-	strMintues := intStrConv(time.Now().Minute())
-	strMintues = strMintues + AMPM
-	return strHours + getColon() + strMintues
+	strMinutes := intStrConv(time.Now().Minute())
+	strMinutes += AMPM
+	return strHours + getColon() + strMinutes
 }
 
 // Returns the : with blinking based on the seconds

--- a/modules/digitalclock/display.go
+++ b/modules/digitalclock/display.go
@@ -3,7 +3,7 @@ package digitalclock
 import "strings"
 
 func mergeLines(outString []string) string {
-	return strings.Join(outString[:], "\n")
+	return strings.Join(outString, "\n")
 }
 
 func renderWidget(widgetSettings Settings) string {

--- a/modules/gcal/display.go
+++ b/modules/gcal/display.go
@@ -147,11 +147,12 @@ func (widget *Widget) timeUntil(calEvent *CalEvent) string {
 	untilStr := ""
 
 	color := "[lightblue]"
-	if days > 0 {
+	switch {
+	case days > 0:
 		untilStr = fmt.Sprintf("%dd", days)
-	} else if hours > 0 {
+	case hours > 0:
 		untilStr = fmt.Sprintf("%dh", hours)
-	} else {
+	default:
 		untilStr = fmt.Sprintf("%dm", mins)
 		if mins < 30 {
 			color = "[red]"

--- a/modules/gitlabtodo/widget.go
+++ b/modules/gitlabtodo/widget.go
@@ -90,7 +90,7 @@ func (widget *Widget) getTodos(apiKey string) ([]*gitlab.Todo, error) {
 func (widget *Widget) trimTodoBody(body string) string {
 	r := []rune(body)
 
-	// Cut at first occurance of a newline
+	// Cut at first occurence of a newline
 	for i, a := range r {
 		if a == '\n' {
 			return string(r[:i])

--- a/modules/hibp/widget.go
+++ b/modules/hibp/widget.go
@@ -68,7 +68,7 @@ func (widget *Widget) content() (string, string, bool) {
 		return title, widget.err.Error(), true
 	}
 
-	title = title + widget.sinceDateForTitle()
+	title += widget.sinceDateForTitle()
 	str := ""
 
 	for _, status := range widget.statuses {

--- a/modules/jenkins/widget.go
+++ b/modules/jenkins/widget.go
@@ -82,7 +82,7 @@ func (widget *Widget) content() (string, string, bool) {
 		row := fmt.Sprintf(
 			`[%s] [%s]%-6s[white]`,
 			widget.RowColor(idx),
-			widget.jobColor(&job),
+			widget.jobColor(job),
 			jobName,
 		)
 
@@ -92,7 +92,7 @@ func (widget *Widget) content() (string, string, bool) {
 	return title, str, false
 }
 
-func (widget *Widget) jobColor(job *Job) string {
+func (widget *Widget) jobColor(job Job) string {
 	switch job.Color {
 	case "blue":
 		// Override color if successBallColor boolean param provided in config

--- a/modules/kubernetes/widget.go
+++ b/modules/kubernetes/widget.go
@@ -198,11 +198,12 @@ func (client *clientInstance) getNodes() ([]string, error) {
 		var nodeStatus string
 		for _, condition := range node.Status.Conditions {
 			if condition.Reason == "KubeletReady" {
-				if condition.Status == "True" {
+				switch {
+				case condition.Status == "True":
 					nodeStatus = "Ready"
-				} else if condition.Reason == "False" {
+				case condition.Reason == "False":
 					nodeStatus = "NotReady"
-				} else {
+				default:
 					nodeStatus = "Unknown"
 				}
 			}

--- a/modules/pocket/client.go
+++ b/modules/pocket/client.go
@@ -178,7 +178,7 @@ func (client *Client) GetAccessToken(requestToken string) (accessToken string, e
 
 }
 
-/*LinkState  represents links states to be retrived
+/*LinkState  represents link states to be retrieved
 According to the api https://getpocket.com/developer/docs/v3/retrieve
 there are 3 states:
 	1-archive
@@ -197,7 +197,7 @@ const (
 	Unread LinkState = "unread"
 )
 
-// GetLinks retrive links of a given states https://getpocket.com/developer/docs/v3/retrieve
+// GetLinks retrieve links of a given states https://getpocket.com/developer/docs/v3/retrieve
 func (client *Client) GetLinks(state LinkState) (response ItemLists, err error) {
 	url := fmt.Sprintf("%s/get?sort=newest&state=%s&consumer_key=%s&access_token=%s", client.baseURL, state, client.consumerKey, *client.accessToken)
 	req := request{

--- a/modules/resourceusage/widget.go
+++ b/modules/resourceusage/widget.go
@@ -121,7 +121,7 @@ func MakeGraph(widget *Widget) {
 		}
 	}
 
-	widget.BarGraph.BuildBars(stats[:])
+	widget.BarGraph.BuildBars(stats)
 
 }
 

--- a/modules/transmission/display.go
+++ b/modules/transmission/display.go
@@ -57,11 +57,12 @@ func (widget *Widget) torrentPercentDone(torrent *transmissionrpc.Torrent) strin
 	pctDone := *torrent.PercentDone
 	str := fmt.Sprintf("%3d%%↓", int(pctDone*100))
 
-	if pctDone == 0.0 {
+	switch pctDone {
+	case 0.0:
 		str = "[gray::b]" + str
-	} else if pctDone == 1.0 {
+	case 1.0:
 		str = "[green::b]" + str
-	} else {
+	default:
 		str = "[lightblue::b]" + str
 	}
 

--- a/modules/travisci/widget.go
+++ b/modules/travisci/widget.go
@@ -77,7 +77,7 @@ func (widget *Widget) content() (string, string, bool) {
 			row := fmt.Sprintf(
 				rowFormat,
 				widget.RowColor(idx),
-				buildColor(&build),
+				buildColor(build),
 				build.Repository.Name,
 				build.Number,
 				build.Branch.Name,
@@ -92,7 +92,7 @@ func (widget *Widget) content() (string, string, bool) {
 	return title, str, false
 }
 
-func buildColor(build *Build) string {
+func buildColor(build Build) string {
 	switch build.State {
 	case "broken":
 		return "red"

--- a/modules/zendesk/tickets.go
+++ b/modules/zendesk/tickets.go
@@ -67,7 +67,6 @@ func (widget *Widget) listTickets(pag ...string) (*TicketArray, error) {
 	}
 
 	return TicketStruct, err
-
 }
 
 func (widget *Widget) newTickets() (*TicketArray, error) {

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -70,7 +70,7 @@ func Test_ExecuteCommand(t *testing.T) {
 }
 
 func Test_FindMatch(t *testing.T) {
-	expected := [][]string([][]string{[]string{"SSID: 7E5B5C", "7E5B5C"}})
+	expected := [][]string{{"SSID: 7E5B5C", "7E5B5C"}}
 	result := FindMatch(`s*SSID: (.+)s*`, "SSID: 7E5B5C")
 
 	assert.Equal(t, expected, result)
@@ -115,7 +115,7 @@ func Test_ReadFileBytes(t *testing.T) {
 		expected []byte
 	}{
 		{
-			name:     "with non-existant file",
+			name:     "with non-existent file",
 			file:     "/tmp/junk-daa6bf613f4c.md",
 			expected: []byte{},
 		},

--- a/view/base.go
+++ b/view/base.go
@@ -65,11 +65,12 @@ func (base *Base) ConfigText() string {
 }
 
 func (base *Base) ContextualTitle(defaultStr string) string {
-	if defaultStr == "" && base.FocusChar() == "" {
+	switch {
+	case defaultStr == "" && base.FocusChar() == "":
 		return ""
-	} else if defaultStr != "" && base.FocusChar() == "" {
+	case defaultStr != "" && base.FocusChar() == "":
 		return fmt.Sprintf(" %s ", defaultStr)
-	} else if defaultStr == "" && base.FocusChar() != "" {
+	case defaultStr == "" && base.FocusChar() != "":
 		return fmt.Sprintf(" [darkgray::u]%s[::-][white] ", base.FocusChar())
 	}
 


### PR DESCRIPTION
golangci-lint can run all the currently enabled linters, and as far as I
can tell, does it in under 5 seconds as opposed to over 180 seconds
(compare `time make cilint` and `time make lint`).

Some of the linters that are listed in the "enabled" section but
commented out looked like a good idea to me, and fairly low hanging
fruit to fix, but they are not passing at the moment.

All the linters covered in the current Makefile are run.

TODO:
- replace lint target in Makefile with golangci-lint
- remove .github/workflow/errcheck.yml

-----

Just a suggestion. It might be much faster, and yet do the same thing, win-win. I did some fixing of things `gocritic` didn't like (its a big fan of switch statements over if/if else/if else/else series), but then stopped and disabled it. Some of the sec warnings seem not applicable to wtf given that it does shell out to user-defined commands at times, so enabling gosec would involve whitelisting some of the warnings. Etc.

On the down side, since this is passing, I won't see the line-annotation feature that is supposed to be enabled... maybe I should enable a couple of the failing linters temporarily in the PR, so that feature is visible?