### PR TITLE
Add settings to hide default sections of Github module

### DIFF
--- a/modules/github/display.go
+++ b/modules/github/display.go
@@ -34,12 +34,18 @@ func (widget *Widget) content() (string, string, bool) {
 
 	_, _, width, _ := widget.View.GetRect()
 	str := widget.settings.common.SigilStr(len(widget.GithubRepos), widget.Idx, width) + "\n"
-	str += fmt.Sprintf(" [%s]Stats[white]\n", widget.settings.common.Colors.Subheading)
-	str += widget.displayStats(repo)
-	str += fmt.Sprintf("\n [%s]Open Review Requests[white]\n", widget.settings.common.Colors.Subheading)
-	str += widget.displayMyReviewRequests(repo, username)
-	str += fmt.Sprintf("\n [%s]My Pull Requests[white]\n", widget.settings.common.Colors.Subheading)
-	str += widget.displayMyPullRequests(repo, username)
+	if widget.settings.showStats {
+		str += fmt.Sprintf(" [%s]Stats[white]\n", widget.settings.common.Colors.Subheading)
+		str += widget.displayStats(repo)
+	}
+	if widget.settings.showOpenReviewRequests {
+		str += fmt.Sprintf("\n [%s]Open Review Requests[white]\n", widget.settings.common.Colors.Subheading)
+		str += widget.displayMyReviewRequests(repo, username)
+	}
+	if widget.settings.showMyPullRequests {
+		str += fmt.Sprintf("\n [%s]My Pull Requests[white]\n", widget.settings.common.Colors.Subheading)
+		str += widget.displayMyPullRequests(repo, username)
+	}
 	for _, customQuery := range widget.settings.customQueries {
 		str += fmt.Sprintf("\n [%s]%s[white]\n", widget.settings.common.Colors.Subheading, customQuery.title)
 		str += widget.displayCustomQuery(repo, customQuery.filter, customQuery.perPage)

--- a/modules/github/display.go
+++ b/modules/github/display.go
@@ -33,9 +33,9 @@ func (widget *Widget) content() (string, string, bool) {
 	}
 
 	_, _, width, _ := widget.View.GetRect()
-	str := widget.settings.common.SigilStr(len(widget.GithubRepos), widget.Idx, width) + "\n"
+	str := widget.settings.common.SigilStr(len(widget.GithubRepos), widget.Idx, width)
 	if widget.settings.showStats {
-		str += fmt.Sprintf(" [%s]Stats[white]\n", widget.settings.common.Colors.Subheading)
+		str += fmt.Sprintf("\n [%s]Stats[white]\n", widget.settings.common.Colors.Subheading)
 		str += widget.displayStats(repo)
 	}
 	if widget.settings.showOpenReviewRequests {

--- a/modules/github/settings.go
+++ b/modules/github/settings.go
@@ -16,16 +16,16 @@ const (
 type Settings struct {
 	common *cfg.Common
 
-	apiKey        string        `help:"Your GitHub API token."`
-	baseURL       string        `help:"Your GitHub Enterprise API URL." optional:"true"`
-	customQueries []customQuery `help:"Custom queries allow you to filter pull requests and issues however you like. Give the query a title and a filter. Filters can be copied directly from GitHub’s UI." optional:"true"`
-	enableStatus  bool          `help:"Display pull request mergeability status (‘dirty’, ‘clean’, ‘unstable’, ‘blocked’)." optional:"true"`
-	repositories  []string      `help:"A list of github repositories." values:"Example: wtfutil/wtf"`
-	showMyPullRequests     bool `help:"Show my pull requests section" optional:"true"`
-	showOpenReviewRequests bool `help:"Show open review requests section" optional:"true"`
-	showStats              bool `help:"Show repository stats section" optional:"true"`
-	uploadURL     string        `help:"Your GitHub Enterprise upload URL (often the same as API URL)." optional:"true"`
-	username      string        `help:"Your GitHub username. Used to figure out which review requests you’ve been added to."`
+	apiKey                 string        `help:"Your GitHub API token."`
+	baseURL                string        `help:"Your GitHub Enterprise API URL." optional:"true"`
+	customQueries          []customQuery `help:"Custom queries allow you to filter pull requests and issues however you like. Give the query a title and a filter. Filters can be copied directly from GitHub’s UI." optional:"true"`
+	enableStatus           bool          `help:"Display pull request mergeability status (‘dirty’, ‘clean’, ‘unstable’, ‘blocked’)." optional:"true"`
+	repositories           []string      `help:"A list of github repositories." values:"Example: wtfutil/wtf"`
+	showMyPullRequests     bool          `help:"Show my pull requests section" optional:"true"`
+	showOpenReviewRequests bool          `help:"Show open review requests section" optional:"true"`
+	showStats              bool          `help:"Show repository stats section" optional:"true"`
+	uploadURL              string        `help:"Your GitHub Enterprise upload URL (often the same as API URL)." optional:"true"`
+	username               string        `help:"Your GitHub username. Used to figure out which review requests you’ve been added to."`
 }
 
 type customQuery struct {
@@ -39,14 +39,14 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	settings := Settings{
 		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
-		apiKey:       ymlConfig.UString("apiKey", ymlConfig.UString("apikey", os.Getenv("WTF_GITHUB_TOKEN"))),
-		baseURL:      ymlConfig.UString("baseURL", os.Getenv("WTF_GITHUB_BASE_URL")),
-		enableStatus: ymlConfig.UBool("enableStatus", false),
-		showMyPullRequests: ymlConfig.UBool("showMyPullRequests", true),
+		apiKey:                 ymlConfig.UString("apiKey", ymlConfig.UString("apikey", os.Getenv("WTF_GITHUB_TOKEN"))),
+		baseURL:                ymlConfig.UString("baseURL", os.Getenv("WTF_GITHUB_BASE_URL")),
+		enableStatus:           ymlConfig.UBool("enableStatus", false),
+		showMyPullRequests:     ymlConfig.UBool("showMyPullRequests", true),
 		showOpenReviewRequests: ymlConfig.UBool("showOpenReviewRequests", true),
-		showStats: ymlConfig.UBool("showStats", true),
-		uploadURL:    ymlConfig.UString("uploadURL", os.Getenv("WTF_GITHUB_UPLOAD_URL")),
-		username:     ymlConfig.UString("username"),
+		showStats:              ymlConfig.UBool("showStats", true),
+		uploadURL:              ymlConfig.UString("uploadURL", os.Getenv("WTF_GITHUB_UPLOAD_URL")),
+		username:               ymlConfig.UString("username"),
 	}
 	settings.repositories = cfg.ParseAsMapOrList(ymlConfig, "repositories")
 	settings.customQueries = parseCustomQueries(ymlConfig)

--- a/modules/github/settings.go
+++ b/modules/github/settings.go
@@ -21,6 +21,9 @@ type Settings struct {
 	customQueries []customQuery `help:"Custom queries allow you to filter pull requests and issues however you like. Give the query a title and a filter. Filters can be copied directly from GitHub’s UI." optional:"true"`
 	enableStatus  bool          `help:"Display pull request mergeability status (‘dirty’, ‘clean’, ‘unstable’, ‘blocked’)." optional:"true"`
 	repositories  []string      `help:"A list of github repositories." values:"Example: wtfutil/wtf"`
+	showMyPullRequests     bool `help:"Show my pull requests section" optional:"true"`
+	showOpenReviewRequests bool `help:"Show open review requests section" optional:"true"`
+	showStats              bool `help:"Show repository stats section" optional:"true"`
 	uploadURL     string        `help:"Your GitHub Enterprise upload URL (often the same as API URL)." optional:"true"`
 	username      string        `help:"Your GitHub username. Used to figure out which review requests you’ve been added to."`
 }
@@ -39,6 +42,9 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 		apiKey:       ymlConfig.UString("apiKey", ymlConfig.UString("apikey", os.Getenv("WTF_GITHUB_TOKEN"))),
 		baseURL:      ymlConfig.UString("baseURL", os.Getenv("WTF_GITHUB_BASE_URL")),
 		enableStatus: ymlConfig.UBool("enableStatus", false),
+		showMyPullRequests: ymlConfig.UBool("showMyPullRequests", true),
+		showOpenReviewRequests: ymlConfig.UBool("showOpenReviewRequests", true),
+		showStats: ymlConfig.UBool("showStats", true),
 		uploadURL:    ymlConfig.UString("uploadURL", os.Getenv("WTF_GITHUB_UPLOAD_URL")),
 		username:     ymlConfig.UString("username"),
 	}


### PR DESCRIPTION
Add `showStats`, `showOpenReviewRequests`, and `showMyPullRequests`  settings to configure default sections of the Github module. They are all set to `true` by default.

Closes #864 