### PR TITLE
make PiHole module compatible with both versions 4 and 5 of PiHole.

### DIFF
--- a/modules/pihole/client.go
+++ b/modules/pihole/client.go
@@ -23,9 +23,9 @@ type Status struct {
 	Status              string `json:"status"`
 	GravityLastUpdated  struct {
 		Relative struct {
-			Days    string `json:"days"`
-			Hours   string `json:"hours"`
-			Minutes string `json:"minutes"`
+			Days    FlexInt `json:"days"`
+			Hours   FlexInt `json:"hours"`
+			Minutes FlexInt `json:"minutes"`
 		}
 	} `json:"gravity_last_updated"`
 }
@@ -76,11 +76,34 @@ func getStatus(c http.Client, apiURL string) (status Status, err error) {
 	}
 
 	if err = json.Unmarshal(rBody, &status); err != nil {
-		return status, fmt.Errorf(" failed to retrieve top items: check provided api URL and token\n %s",
+		return status, fmt.Errorf(" failed to retrieve status: check provided api URL and token\n %s",
 			parseError(err))
 	}
 
 	return status, err
+}
+
+type FlexInt int
+
+func (fi *FlexInt) UnmarshalJSON(b []byte) error {
+	if b[0] != '"' {
+		return json.Unmarshal(b, (*int)(fi))
+	}
+
+	var s string
+
+	if err := json.Unmarshal(b, &s); err != nil {
+		return err
+	}
+
+	i, err := strconv.Atoi(s)
+	if err != nil {
+		return err
+	}
+
+	*fi = FlexInt(i)
+
+	return nil
 }
 
 type TopItems struct {

--- a/modules/pihole/view.go
+++ b/modules/pihole/view.go
@@ -38,7 +38,7 @@ func getSummaryView(c http.Client, settings *Settings) string {
 	summaryTable := createTable([]string{}, buf)
 	summaryTable.Append([]string{"Domain blocklist", s.DomainsBeingBlocked, "Queries today", s.DNSQueriesToday})
 	summaryTable.Append([]string{"Ads blocked today", fmt.Sprintf("%s (%s%%)", s.AdsBlockedToday, s.AdsPercentageToday), "Cached queries", s.QueriesCached})
-	summaryTable.Append([]string{"Blocklist Age", fmt.Sprintf("%sd %sh %sm", s.GravityLastUpdated.Relative.Days,
+	summaryTable.Append([]string{"Blocklist Age", fmt.Sprintf("%dd %dh %dm", s.GravityLastUpdated.Relative.Days,
 		s.GravityLastUpdated.Relative.Hours, s.GravityLastUpdated.Relative.Minutes), "Forwarded queries", s.QueriesForwarded})
 	summaryTable.Render()
 


### PR DESCRIPTION
Fix for https://github.com/wtfutil/wtf/issues/907.
The issue was that the PiHole API in version 4 returns the relative blocklist age components as strings: 
`"relative":{"days":"0","hours":"00","minutes":"08"}`
whilst version 5 returns them as integers:
`"relative":{"days":0,"hours":7,"minutes":0}`
PR makes module compatible with both.