### PR TITLE
Add TeamIDs and UserIDs filters for Pagerduty Incidents

### DIFF
--- a/modules/pagerduty/client.go
+++ b/modules/pagerduty/client.go
@@ -38,8 +38,8 @@ func GetOnCalls(apiKey string, scheduleIDs []string) ([]pagerduty.OnCall, error)
 	return results, nil
 }
 
-// GetIncidents returns a list of people currently on call
-func GetIncidents(apiKey string) ([]pagerduty.Incident, error) {
+// GetIncidents returns a list of unresolved incidents
+func GetIncidents(apiKey string, teamIDs []string, userIDs []string) ([]pagerduty.Incident, error) {
 	client := pagerduty.NewClient(apiKey)
 
 	var results []pagerduty.Incident
@@ -47,6 +47,8 @@ func GetIncidents(apiKey string) ([]pagerduty.Incident, error) {
 	var queryOpts pagerduty.ListIncidentsOptions
 	queryOpts.DateRange = "all"
 	queryOpts.Statuses = []string{"triggered", "acknowledged"}
+	queryOpts.TeamIDs = teamIDs
+	queryOpts.UserIDs = userIDs
 
 	items, err := client.ListIncidents(queryOpts)
 	if err != nil {

--- a/modules/pagerduty/settings.go
+++ b/modules/pagerduty/settings.go
@@ -17,11 +17,13 @@ type Settings struct {
 	common *cfg.Common
 
 	apiKey           string        `help:"Your PagerDuty API key."`
-	escalationFilter []interface{} `help:"An array of schedule names you want to filter on."`
+	escalationFilter []interface{} `help:"An array of schedule names you want to filter the OnCalls on."`
 	myName           string        `help:"The name to highlight when on-call in PagerDuty."`
-	scheduleIDs      []interface{} `help:"An array of schedule IDs you want to restrict the query to."`
+	scheduleIDs      []interface{} `help:"An array of schedule IDs you want to restrict the OnCalls query to."`
 	showIncidents    bool          `help:"Whether or not to list incidents." optional:"true"`
 	showSchedules    bool          `help:"Whether or not to show schedules." optional:"true"`
+	teamIDs          []interface{} `help:"An array of team IDs to restrict the incidents query to" optional:"true"`
+	userIDs          []interface{} `help:"An array of user IDs to restrict the incidents query to" optional:"true"`
 }
 
 // NewSettingsFromYAML creates a new settings instance from a YAML config block
@@ -35,6 +37,8 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 		scheduleIDs:      ymlConfig.UList("scheduleIDs", []interface{}{}),
 		showIncidents:    ymlConfig.UBool("showIncidents", true),
 		showSchedules:    ymlConfig.UBool("showSchedules", true),
+		teamIDs:          ymlConfig.UList("teamIDs", []interface{}{}),
+		userIDs:          ymlConfig.UList("userIDs", []interface{}{}),
 	}
 
 	cfg.ModuleSecret(name, globalConfig, &settings.apiKey).Load()

--- a/modules/pagerduty/widget.go
+++ b/modules/pagerduty/widget.go
@@ -79,7 +79,7 @@ func (widget *Widget) contentFrom(onCalls []pagerduty.OnCall, incidents []pagerd
 				str += fmt.Sprintf(" Escalation: %s\n", incident.EscalationPolicy.Summary)
 			}
 		} else {
-			str += "\n No unresolved incidents\n"
+			str += "\n No open incidents\n"
 		}
 	}
 

--- a/modules/pagerduty/widget.go
+++ b/modules/pagerduty/widget.go
@@ -36,7 +36,9 @@ func (widget *Widget) Refresh() {
 	var err2 error
 
 	if widget.settings.showIncidents {
-		incidents, err2 = GetIncidents(widget.settings.apiKey)
+		teamIDs := utils.ToStrs(widget.settings.teamIDs)
+		userIDs := utils.ToStrs(widget.settings.userIDs)
+		incidents, err2 = GetIncidents(widget.settings.apiKey, teamIDs, userIDs)
 	}
 
 	if widget.settings.showSchedules {

--- a/modules/pagerduty/widget.go
+++ b/modules/pagerduty/widget.go
@@ -69,13 +69,17 @@ func (widget *Widget) Refresh() {
 func (widget *Widget) contentFrom(onCalls []pagerduty.OnCall, incidents []pagerduty.Incident) string {
 	var str string
 
-	if len(incidents) > 0 {
-		str += "[yellow]Incidents[white]\n"
-		for _, incident := range incidents {
-			str += fmt.Sprintf("[%s]%s[white]\n", widget.settings.common.Colors.Subheading, incident.Summary)
-			str += fmt.Sprintf("Status: %s\n", incident.Status)
-			str += fmt.Sprintf("Service: %s\n", incident.Service.Summary)
-			str += fmt.Sprintf("Escalation: %s\n", incident.EscalationPolicy.Summary)
+	if widget.settings.showIncidents {
+		str += "[yellow] Incidents[white]"
+		if len(incidents) > 0 {
+			for _, incident := range incidents {
+				str += fmt.Sprintf("\n [%s]%s[white]\n", widget.settings.common.Colors.Subheading, incident.Summary)
+				str += fmt.Sprintf(" Status: %s\n", incident.Status)
+				str += fmt.Sprintf(" Service: %s\n", incident.Service.Summary)
+				str += fmt.Sprintf(" Escalation: %s\n", incident.EscalationPolicy.Summary)
+			}
+		} else {
+			str += "\n No unresolved incidents\n"
 		}
 	}
 
@@ -102,7 +106,7 @@ func (widget *Widget) contentFrom(onCalls []pagerduty.OnCall, incidents []pagerd
 	sort.Strings(keys)
 
 	if len(keys) > 0 {
-		str += fmt.Sprintf("[%s] Schedules[white]\n", widget.settings.common.Colors.Subheading)
+		str += fmt.Sprintf("\n[%s] Schedules[white]\n", widget.settings.common.Colors.Subheading)
 
 		// Print out policies, and escalation order of users
 		for _, key := range keys {


### PR DESCRIPTION
This PR adds optional `TeamIDs` and `UserIDs` settings to pass to the `ListIncidents` API call, and updates some comments to clarify where `ScheduleIDs` and `EscalationFilter` settings are used.

Also I'd like to say thanks for maintaining this tool, I've found it very helpful to stay on top of things while being stuck in work from home mode for the year.