### PR TITLE
PagerDuty: provides an option to display the date...

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,7 @@ install:
 
 ## lint: runs a number of code quality checks against the source code
 lint:
+	golangci-lint cache clean
 	golangci-lint run
 
 # lint:

--- a/go.sum
+++ b/go.sum
@@ -161,8 +161,6 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
-github.com/digitalocean/godo v1.37.0 h1:NEj5ne2cvLBHo1GJY1DNN/iEt9ipa72CMwwAjKEA530=
-github.com/digitalocean/godo v1.37.0/go.mod h1:p7dOjjtSBqCTUksqtA5Fd3uaKs9kyTq2xcz76ulEJRU=
 github.com/digitalocean/godo v1.38.0 h1:to+pLe5RJqflJiyxhaLJfJgT3YzwHRSg19mOWkKt6A0=
 github.com/digitalocean/godo v1.38.0/go.mod h1:p7dOjjtSBqCTUksqtA5Fd3uaKs9kyTq2xcz76ulEJRU=
 github.com/dlclark/regexp2 v1.2.0 h1:8sAhBGEM0dRWogWqWyQeIJnxjWO6oIjl8FKqREDsGfk=
@@ -647,8 +645,6 @@ github.com/sethgrid/pester v0.0.0-20171127025028-760f8913c048/go.mod h1:Ad7IjTpv
 github.com/sguiheux/go-coverage v0.0.0-20190710153556-287b082a7197 h1:qu90yDtRE5WEfRT5mn9v0Xz9RaopLguhbPwZKx4dHq8=
 github.com/sguiheux/go-coverage v0.0.0-20190710153556-287b082a7197/go.mod h1:0hhKrsUsoT7yvxwNGKa+TSYNA26DNWMqReeZEQq/9FI=
 github.com/shirou/gopsutil v0.0.0-20170406131756-e49a95f3d5f8/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
-github.com/shirou/gopsutil v2.20.4+incompatible h1:cMT4rxS55zx9NVUnCkrmXCsEB/RNfG9SwHY9evtX8Ng=
-github.com/shirou/gopsutil v2.20.4+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/shirou/gopsutil v2.20.6+incompatible h1:P37G9YH8M4vqkKcwBosp+URN5O8Tay67D2MbR361ioY=
 github.com/shirou/gopsutil v2.20.6+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/sirupsen/logrus v1.0.6/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
@@ -722,8 +718,6 @@ github.com/wtfutil/spotigopher v0.0.0-20191127141047-7d8168fe103a/go.mod h1:AlO4
 github.com/wtfutil/todoist v0.0.2-0.20191216004217-0ec29ceda61a h1:nD8ALd4TSo+zPHK5MqQWFj01G8fMMHFfC3rWvoq/9JA=
 github.com/wtfutil/todoist v0.0.2-0.20191216004217-0ec29ceda61a/go.mod h1:YuuGLJSsTK6DGBD5Zaf3J8LSMfpEC2WtzYPey3XVOdI=
 github.com/xanzy/go-gitlab v0.15.0/go.mod h1:8zdQa/ri1dfn8eS3Ir1SyfvOKlw7WBJ8DVThkpGiXrs=
-github.com/xanzy/go-gitlab v0.32.1 h1:eKGfAP2FWbqStD7DtGoRBb18IYwjuCxdtEVea2rNge4=
-github.com/xanzy/go-gitlab v0.32.1/go.mod h1:sPLojNBn68fMUWSxIJtdVVIP8uSBYqesTfDUseX11Ug=
 github.com/xanzy/go-gitlab v0.33.0 h1:MUJZknbLhVXSFzBA5eqGGhQ2yHSu8tPbGBPeB3sN4B0=
 github.com/xanzy/go-gitlab v0.33.0/go.mod h1:sPLojNBn68fMUWSxIJtdVVIP8uSBYqesTfDUseX11Ug=
 github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8/go.mod h1:HUYIGzjTL3rfEspMxjDjgmT5uz5wzYJKVo23qUhYTos=
@@ -943,10 +937,6 @@ google.golang.org/api v0.15.0/go.mod h1:iLdEw5Ide6rF15KTC1Kkl0iskquN2gFfn9o9XIsb
 google.golang.org/api v0.17.0/go.mod h1:BwFmGc8tA3vsd7r/7kR8DY7iEEGSU04BFxCo5jP/sfE=
 google.golang.org/api v0.18.0/go.mod h1:BwFmGc8tA3vsd7r/7kR8DY7iEEGSU04BFxCo5jP/sfE=
 google.golang.org/api v0.20.0/go.mod h1:BwFmGc8tA3vsd7r/7kR8DY7iEEGSU04BFxCo5jP/sfE=
-google.golang.org/api v0.25.0 h1:LodzhlzZEUfhXzNUMIfVlf9Gr6Ua5MMtoFWh7+f47qA=
-google.golang.org/api v0.25.0/go.mod h1:lIXQywCXRcnZPGlsd8NbLnOjtAoL6em04bJ9+z0MncE=
-google.golang.org/api v0.28.0 h1:jMF5hhVfMkTZwHW1SDpKq5CkgWLXOb31Foaca9Zr3oM=
-google.golang.org/api v0.28.0/go.mod h1:lIXQywCXRcnZPGlsd8NbLnOjtAoL6em04bJ9+z0MncE=
 google.golang.org/api v0.29.0 h1:BaiDisFir8O4IJxvAabCGGkQ6yCJegNQqSVoYUNAnbk=
 google.golang.org/api v0.29.0/go.mod h1:Lcubydp8VUV7KeIHD9z2Bys/sm/vGKnG1UHuDBSrHWM=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=

--- a/modules/pagerduty/client.go
+++ b/modules/pagerduty/client.go
@@ -6,6 +6,10 @@ import (
 	"github.com/PagerDuty/go-pagerduty"
 )
 
+const (
+	queryTimeFmt = "2006-01-02T15:04:05Z07:00"
+)
+
 // GetOnCalls returns a list of people currently on call
 func GetOnCalls(apiKey string, scheduleIDs []string) ([]pagerduty.OnCall, error) {
 	client := pagerduty.NewClient(apiKey)
@@ -14,10 +18,8 @@ func GetOnCalls(apiKey string, scheduleIDs []string) ([]pagerduty.OnCall, error)
 	var queryOpts pagerduty.ListOnCallOptions
 
 	queryOpts.ScheduleIDs = scheduleIDs
-
-	timeFmt := "2006-01-02T15:04:05Z07:00"
-	queryOpts.Since = time.Now().Format(timeFmt)
-	queryOpts.Until = time.Now().Format(timeFmt)
+	queryOpts.Since = time.Now().Format(queryTimeFmt)
+	queryOpts.Until = time.Now().Format(queryTimeFmt)
 
 	oncalls, err := client.ListOnCalls(queryOpts)
 	if err != nil {

--- a/modules/pagerduty/settings.go
+++ b/modules/pagerduty/settings.go
@@ -21,6 +21,7 @@ type Settings struct {
 	myName           string        `help:"The name to highlight when on-call in PagerDuty."`
 	scheduleIDs      []interface{} `help:"An array of schedule IDs you want to restrict the OnCalls query to."`
 	showIncidents    bool          `help:"Whether or not to list incidents." optional:"true"`
+	showOnCallEnd    bool          `help:"Whether or not to display the date the oncall schedule ends." optional:"true"`
 	showSchedules    bool          `help:"Whether or not to show schedules." optional:"true"`
 	teamIDs          []interface{} `help:"An array of team IDs to restrict the incidents query to" optional:"true"`
 	userIDs          []interface{} `help:"An array of user IDs to restrict the incidents query to" optional:"true"`
@@ -36,6 +37,7 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 		myName:           ymlConfig.UString("myName"),
 		scheduleIDs:      ymlConfig.UList("scheduleIDs", []interface{}{}),
 		showIncidents:    ymlConfig.UBool("showIncidents", true),
+		showOnCallEnd:    ymlConfig.UBool("showOnCallEnd", false),
 		showSchedules:    ymlConfig.UBool("showSchedules", true),
 		teamIDs:          ymlConfig.UList("teamIDs", []interface{}{}),
 		userIDs:          ymlConfig.UList("userIDs", []interface{}{}),

--- a/modules/pagerduty/widget.go
+++ b/modules/pagerduty/widget.go
@@ -79,17 +79,21 @@ func (widget *Widget) contentFrom(onCalls []pagerduty.OnCall, incidents []pagerd
 	// Incidents
 
 	if widget.settings.showIncidents {
-		str += "[yellow] Incidents[white]"
+		str += fmt.Sprintf("[%s] Incidents[white]\n", widget.settings.common.Colors.Subheading)
+
 		if len(incidents) > 0 {
 			for _, incident := range incidents {
-				str += fmt.Sprintf("\n[%s]%s[white]\n", widget.settings.common.Colors.Subheading, incident.Summary)
-				str += fmt.Sprintf(" Status: %s\n", incident.Status)
-				str += fmt.Sprintf(" Service: %s\n", incident.Service.Summary)
+				str += fmt.Sprintf("\n [%s]%s[white]\n", widget.settings.common.Colors.Label, tview.Escape(incident.Summary))
+				str += fmt.Sprintf("     Status: %s\n", incident.Status)
+				str += fmt.Sprintf("    Service: %s\n", incident.Service.Summary)
 				str += fmt.Sprintf(" Escalation: %s\n", incident.EscalationPolicy.Summary)
+				str += fmt.Sprintf("       Link: %s\n", incident.HTMLURL)
 			}
 		} else {
 			str += "\n No open incidents\n"
 		}
+
+		str += "\n"
 	}
 
 	onCallTree := make(map[string][]pagerduty.OnCall)
@@ -117,13 +121,13 @@ func (widget *Widget) contentFrom(onCalls []pagerduty.OnCall, incidents []pagerd
 	sort.Strings(keys)
 
 	if len(keys) > 0 {
-		str += fmt.Sprintf("\n[%s] Schedules[white]\n", widget.settings.common.Colors.Subheading)
+		str += fmt.Sprintf("[%s] Schedules[white]\n", widget.settings.common.Colors.Subheading)
 
 		// Print out policies, and escalation order of users
 		for _, key := range keys {
 			str += fmt.Sprintf(
 				"\n [%s]%s\n",
-				widget.settings.common.Colors.Subheading,
+				widget.settings.common.Colors.Label,
 				key,
 			)
 

--- a/modules/pagerduty/widget.go
+++ b/modules/pagerduty/widget.go
@@ -154,7 +154,11 @@ func (widget *Widget) contentFrom(onCalls []pagerduty.OnCall, incidents []pagerd
 
 // onCallEndSummary may or may not return the date that the specified onCall schedule ends
 func (widget *Widget) onCallEndSummary(onCall pagerduty.OnCall) string {
-	if !widget.settings.showOnCallEnd || onCall.End == "" {
+	if !widget.settings.showOnCallEnd {
+		return ""
+	}
+
+	if onCall.End == "" {
 		return ""
 	}
 
@@ -166,7 +170,7 @@ func (widget *Widget) onCallEndSummary(onCall pagerduty.OnCall) string {
 	return end.Format(onCallTimeDisplayLayout)
 }
 
-// userSummary returns the name of the person assigned to the specified onCall scehdule
+// userSummary returns the name of the person assigned to the specified onCall schedule
 func (widget *Widget) userSummary(onCall pagerduty.OnCall) string {
 	summary := onCall.User.Summary
 


### PR DESCRIPTION
the onCall schedule will end.

Config setting:

```
  pagerduty:
    showOnCallEnd: [true|false]
```
Default is `false`.

If `true`, the date will be displayed below the onCall person's name:

```
eng-droplet
1 - Chris Cummer
    Jul 27, 2020
```

Signed-off-by: Chris Cummer <chriscummer@me.com>