### PR TITLE
Fix feed sorting issue and extra line issue with hightlightable text widget

### DIFF
--- a/modules/feedreader/widget.go
+++ b/modules/feedreader/widget.go
@@ -58,7 +58,7 @@ func getShowText(feedItem *FeedItem, showType ShowType) string {
 		returnValue = feedItem.item.Link
 	case SHOW_CONTENT:
 		text, _ := html2text.FromString(feedItem.item.Content, html2text.Options{PrettyTables: true})
-		returnValue = feedItem.item.Title + "\n" + strings.TrimSpace(text)
+		returnValue = strings.TrimSpace(feedItem.item.Title + "\n" + strings.TrimSpace(text))
 	}
 	return returnValue
 }
@@ -192,7 +192,9 @@ func (widget *Widget) content() (string, string, bool) {
 // feedItems are sorted by published date
 func (widget *Widget) sort(feedItems []*FeedItem) []*FeedItem {
 	sort.Slice(feedItems, func(i, j int) bool {
-		return feedItems[i].item.PublishedParsed.After(*feedItems[j].item.PublishedParsed)
+		return feedItems[i].item.PublishedParsed != nil &&
+			feedItems[j].item.PublishedParsed != nil &&
+			feedItems[i].item.PublishedParsed.After(*feedItems[j].item.PublishedParsed)
 	})
 
 	return feedItems

--- a/view/text_widget.go
+++ b/view/text_widget.go
@@ -1,6 +1,8 @@
 package view
 
 import (
+	"strings"
+
 	"github.com/rivo/tview"
 	"github.com/wtfutil/wtf/cfg"
 	"github.com/wtfutil/wtf/wtf"
@@ -36,7 +38,7 @@ func (widget *TextWidget) Redraw(data func() (string, string, bool)) {
 		widget.View.Clear()
 		widget.View.SetWrap(wrap)
 		widget.View.SetTitle(widget.ContextualTitle(title))
-		widget.View.SetText(content)
+		widget.View.SetText(strings.TrimSpace(content))
 	})
 }
 


### PR DESCRIPTION
This addresses https://github.com/wtfutil/wtf/issues/958 and https://github.com/wtfutil/wtf/issues/900

https://github.com/wtfutil/wtf/issues/958: in a mix of feeds with and without published date, the ones without published date will appear op top of those with published date.

https://github.com/wtfutil/wtf/issues/900: `text.HighlightableHelper()` always append a LF character to the input. So trimming whitespace in the text widget would help.


PS: I am really not doing this for the shitoberfest t-shirt :P