### PR TITLE
Fix config file path

### DIFF
--- a/cfg/config_files.go
+++ b/cfg/config_files.go
@@ -37,7 +37,7 @@ func CreateFile(fileName string) (string, error) {
 		return "", err
 	}
 
-	filePath := fmt.Sprintf("%s/%s", configDir, fileName)
+	filePath := filepath.Join(configDir, fileName)
 
 	// Check if the file already exists; if it does not, create it
 	_, err = os.Stat(filePath)
@@ -106,7 +106,7 @@ func LoadWtfConfigFile(filePath string) *config.Config {
 // chmodConfigFile sets the mode of the config file to r+w for the owner only
 func chmodConfigFile() {
 	configDir, _ := WtfConfigDir()
-	relPath := fmt.Sprintf("%s%s", configDir, WtfConfigFile)
+	relPath := filepath.Join(configDir, WtfConfigFile)
 	absPath, _ := expandHomeDir(relPath)
 
 	_, err := os.Stat(absPath)


### PR DESCRIPTION
Background:
I noticed that my default config file (~/.config/wtf/config.yml) has the permission 666 but the expected permission is 600.
I traced down the issue to `cfg.chmodConfigFile()` where variable `relPath` carries the value `~/.config/wtfconfig.yml`.

Solution:
Use `filepath.Join()`