### PR TITLE
Default domain for gitlab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### 🐞 Fixed
 
-* Exchange Rates module now displays rates in alphabetical order, sorted by the base rate, by [@senorprogrammer](https://github.com/senorprogrammer) 
+* Exchange Rates module now displays rates in alphabetical order, sorted by the base rate, by [@senorprogrammer](https://github.com/senorprogrammer)
 * Feed Reader module no longer crashes on feeds that don't have a published date, [#958](https://github.com/wtfutil/wtf/issues/958) by [@cyingfan](https://github.com/cyingfan)
 * Stray blank lines no longer appear at the end of highlightable lists, [#977](https://github.com/wtfutil/wtf/pull/977) by [@cyingfan](https://github.com/cyingfan)
 * `config.yml` now properly set to `0600` instead of `0666`, by [@cyingfan](https://github.com/cyingfan)
@@ -481,7 +481,7 @@
 
 ### ⚡️ Added
 
-* Dependencies are now managed and installed using Go modules. See README.md for details, [#406](https://github.com/wtfutil/wtf/issues/406) by [@retgits](https://github.com/retgits) 
+* Dependencies are now managed and installed using Go modules. See README.md for details, [#406](https://github.com/wtfutil/wtf/issues/406) by [@retgits](https://github.com/retgits)
 
 ## 0.7.2
 
@@ -530,7 +530,7 @@
 ### ⚡️ Added
 
 * Resource Usage module added by [@nicholas-eden](https://github.com/nicholas-eden)
-* Recursive repo search in Git module ([#126](https://github.com/wtfutil/wtf/issues/126) by [@anandsudhir](http://github.com/anandsudhir)) 
+* Recursive repo search in Git module ([#126](https://github.com/wtfutil/wtf/issues/126) by [@anandsudhir](http://github.com/anandsudhir))
 * HTTP/HTTPS handling in OpenFile() util function by [@jdenoy](https://github.com/jdenoy)
 * Honor system http proxies when using non-default transport by [@skymeyer](https://github.com/skymeyer)
 * VictorOps module added by [ImDevinC](https://github.com/ImDevinC)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Clocks module now supports `natural` ordering option, [#896](https://github.com/wtfutil/wtf/issues/896) by [@seanstoppable](https://github.com/Seanstoppable)
 * Exit banner message added, by [@senorprogrammer](https://github.com/senorprogrammer)
 * [UptimeRobot module added](https://github.com/wtfutil/wtf/pull/983), by [@franga2000](https://github.com/franga2000)
+* Gitlab module now defaults domain to `https://gitlab.com`
 
 ### 🐞 Fixed
 

--- a/modules/gitlab/settings.go
+++ b/modules/gitlab/settings.go
@@ -28,7 +28,7 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		apiKey:   ymlConfig.UString("apiKey", ymlConfig.UString("apikey", os.Getenv("WTF_GITLAB_TOKEN"))),
-		domain:   ymlConfig.UString("domain"),
+		domain:   ymlConfig.UString("domain", "https://gitlab.com"),
 		username: ymlConfig.UString("username"),
 	}
 


### PR DESCRIPTION
The [Gitlab module docs](https://wtfutil.com/modules/gitlab/) has the domain marked as optional.
But when I start it without one, I get `Get "/api/v4/user": unsupported protocol scheme ""`.

This makes the default domain `https://gitlab.com` which allows you to track open source projects like `gitlab-org/gitlab` or `inkscape/inkscape`.

Alternatively, the docs could be changed to mark the field as required.