### PR TITLE
20201123 Launch documentation from modules

### DIFF
--- a/app/wtf_app.go
+++ b/app/wtf_app.go
@@ -22,8 +22,8 @@ type WtfApp struct {
 	config         *config.Config
 	configFilePath string
 	display        *Display
-	ghUser         *support.GitHubUser
 	focusTracker   FocusTracker
+	ghUser         *support.GitHubUser
 	pages          *tview.Pages
 	validator      *ModuleValidator
 	widgets        []wtf.Wtfable

--- a/cfg/common_settings.go
+++ b/cfg/common_settings.go
@@ -28,13 +28,16 @@ type Common struct {
 	PositionSettings `help:"Defines where in the grid this module’s widget will be displayed."`
 	Sigils
 
-	Colors          ColorTheme
+	Colors ColorTheme
+	Config *config.Config
+
+	DocPath string
+
 	Bordered        bool   `help:"Whether or not the module should be displayed with a border." values:"true, false" optional:"true" default:"true"`
 	Enabled         bool   `help:"Whether or not this module is executed and if its data displayed onscreen." values:"true, false" optional:"true" default:"false"`
 	Focusable       bool   `help:"Whether or  not this module is focusable." values:"true, false" optional:"true" default:"false"`
 	RefreshInterval int    `help:"How often, in seconds, this module will update its data." values:"A positive integer, 0..n." optional:"true"`
 	Title           string `help:"The title string to show when displaying this module" optional:"true"`
-	Config          *config.Config
 
 	focusChar int `help:"Define one of the number keys as a short cut key to access the widget." optional:"true"`
 }
@@ -165,6 +168,15 @@ func (common *Common) PaginationMarker(len, pos, width int) string {
 	}
 
 	return sigils
+}
+
+// SetDocumentationPath is used to explicitly set the documentation path that should be opened
+// when the key to open the documentation is pressed.
+// Setting this is probably not necessary unless the module documentation is nested inside a
+// documentation subdirectory in the /wtfutildocs repo, or the module here has a different
+// name than the module's display name in the documentation (which ideally wouldn't be a thing).
+func (common *Common) SetDocumentationPath(path string) {
+	common.DocPath = path
 }
 
 // Validations aggregates all the validations from all the sub-sections in Common into a

--- a/generator/textwidget.go
+++ b/generator/textwidget.go
@@ -40,8 +40,6 @@ func main() {
 
 	generateWidgetFile(data)
 	generateSettingsFile(data)
-
-	fmt.Println("Done")
 }
 
 /* -------------------- Unexported Functions -------------------- */

--- a/modules/azuredevops/settings.go
+++ b/modules/azuredevops/settings.go
@@ -14,7 +14,7 @@ const (
 
 // Settings defines the configuration options for this module
 type Settings struct {
-	common *cfg.Common
+	*cfg.Common
 
 	apiToken    string `help:"Your Azure DevOps Access Token."`
 	labelColor  string
@@ -26,7 +26,7 @@ type Settings struct {
 // NewSettingsFromYAML creates and returns an instance of Settings with configuration options populated
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocus, ymlConfig, globalConfig),
+		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocus, ymlConfig, globalConfig),
 
 		apiToken:    ymlConfig.UString("apiToken", os.Getenv("WTF_AZURE_DEVOPS_API_TOKEN")),
 		labelColor:  ymlConfig.UString("labelColor", "white"),

--- a/modules/azuredevops/widget.go
+++ b/modules/azuredevops/widget.go
@@ -21,7 +21,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, pages, settings.common),
+		TextWidget: view.NewTextWidget(app, pages, settings.Common),
 		settings:   settings,
 	}
 

--- a/modules/azuredevops/widget.go
+++ b/modules/azuredevops/widget.go
@@ -21,7 +21,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, settings.common),
+		TextWidget: view.NewTextWidget(app, pages, settings.common),
 		settings:   settings,
 	}
 

--- a/modules/bamboohr/settings.go
+++ b/modules/bamboohr/settings.go
@@ -13,7 +13,7 @@ const (
 )
 
 type Settings struct {
-	common *cfg.Common
+	*cfg.Common
 
 	apiKey    string `help:"Your BambooHR API token."`
 	subdomain string `help:"Your BambooHR API subdomain name."`
@@ -21,7 +21,7 @@ type Settings struct {
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		apiKey:    ymlConfig.UString("apiKey", ymlConfig.UString("apikey", os.Getenv("WTF_BAMBOO_HR_TOKEN"))),
 		subdomain: ymlConfig.UString("subdomain", os.Getenv("WTF_BAMBOO_HR_SUBDOMAIN")),

--- a/modules/bamboohr/widget.go
+++ b/modules/bamboohr/widget.go
@@ -21,7 +21,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, settings.common),
+		TextWidget: view.NewTextWidget(app, nil, settings.common),
 
 		settings: settings,
 	}

--- a/modules/bamboohr/widget.go
+++ b/modules/bamboohr/widget.go
@@ -21,7 +21,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, nil, settings.common),
+		TextWidget: view.NewTextWidget(app, nil, settings.Common),
 
 		settings: settings,
 	}

--- a/modules/bargraph/settings.go
+++ b/modules/bargraph/settings.go
@@ -11,12 +11,12 @@ const (
 )
 
 type Settings struct {
-	common *cfg.Common
+	*cfg.Common
 }
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 	}
 
 	return &settings

--- a/modules/bargraph/widget.go
+++ b/modules/bargraph/widget.go
@@ -23,7 +23,7 @@ type Widget struct {
 // NewWidget Make new instance of widget
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		BarGraph: view.NewBarGraph(app, "Sample Bar Graph", settings.common),
+		BarGraph: view.NewBarGraph(app, "Sample Bar Graph", settings.Common),
 
 		app: app,
 	}

--- a/modules/buildkite/keyboard.go
+++ b/modules/buildkite/keyboard.go
@@ -1,5 +1,5 @@
 package buildkite
 
 func (widget *Widget) initializeKeyboardControls() {
-	widget.InitializeCommonControls(widget.Refresh)
+	widget.InitializeRefreshKeyboardControl(widget.Refresh)
 }

--- a/modules/buildkite/settings.go
+++ b/modules/buildkite/settings.go
@@ -21,7 +21,8 @@ type PipelineSettings struct {
 
 // Settings defines the configuration properties for this module
 type Settings struct {
-	common    *cfg.Common
+	*cfg.Common
+
 	apiKey    string             `help:"Your Buildkite API Token"`
 	orgSlug   string             `help:"Organization Slug"`
 	pipelines []PipelineSettings `help:"An array of pipelines to get data from"`
@@ -30,7 +31,8 @@ type Settings struct {
 // NewSettingsFromYAML creates a new settings instance from a YAML config block
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := Settings{
-		common:    cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+
 		apiKey:    ymlConfig.UString("apiKey", os.Getenv("WTF_BUILDKITE_TOKEN")),
 		orgSlug:   ymlConfig.UString("organizationSlug"),
 		pipelines: buildPipelineSettings(ymlConfig),

--- a/modules/buildkite/widget.go
+++ b/modules/buildkite/widget.go
@@ -23,7 +23,6 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 
 	widget.initializeKeyboardControls()
 	widget.View.SetScrollable(true)
-	widget.KeyboardWidget.SetView(widget.View)
 
 	return &widget
 }

--- a/modules/buildkite/widget.go
+++ b/modules/buildkite/widget.go
@@ -7,12 +7,7 @@ import (
 	"github.com/wtfutil/wtf/view"
 )
 
-const HelpText = `
- Keyboard commands for Buildkite:
-`
-
 type Widget struct {
-	view.KeyboardWidget
 	view.TextWidget
 	settings *Settings
 
@@ -22,13 +17,11 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		KeyboardWidget: view.NewKeyboardWidget(app, pages, settings.common),
-		TextWidget:     view.NewTextWidget(app, settings.common),
-		settings:       settings,
+		TextWidget: view.NewTextWidget(app, pages, settings.common),
+		settings:   settings,
 	}
 
 	widget.initializeKeyboardControls()
-	widget.View.SetInputCapture(widget.InputCapture)
 	widget.View.SetScrollable(true)
 	widget.KeyboardWidget.SetView(widget.View)
 

--- a/modules/buildkite/widget.go
+++ b/modules/buildkite/widget.go
@@ -17,7 +17,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, pages, settings.common),
+		TextWidget: view.NewTextWidget(app, pages, settings.Common),
 		settings:   settings,
 	}
 

--- a/modules/cds/favorites/display.go
+++ b/modules/cds/favorites/display.go
@@ -25,7 +25,7 @@ func (widget *Widget) content() (string, string, bool) {
 	}
 
 	_, _, width, _ := widget.View.GetRect()
-	str := widget.settings.common.PaginationMarker(len(widget.workflows), widget.Idx, width) + "\n"
+	str := widget.settings.PaginationMarker(len(widget.workflows), widget.Idx, width) + "\n"
 	title := fmt.Sprintf("%s - %s", widget.CommonSettings().Title, widget.title(workflow))
 
 	str += widget.displayWorkflowRuns(workflow)
@@ -36,7 +36,7 @@ func (widget *Widget) content() (string, string, bool) {
 func (widget *Widget) title(workflow *sdk.Workflow) string {
 	return fmt.Sprintf(
 		"[%s]%s/%s[white]",
-		widget.settings.common.Colors.TextTheme.Title,
+		widget.settings.Colors.TextTheme.Title,
 		workflow.ProjectKey, workflow.Name,
 	)
 }

--- a/modules/cds/favorites/keyboard.go
+++ b/modules/cds/favorites/keyboard.go
@@ -5,7 +5,7 @@ import (
 )
 
 func (widget *Widget) initializeKeyboardControls() {
-	widget.InitializeCommonControls(widget.Refresh)
+	widget.InitializeRefreshKeyboardControl(widget.Refresh)
 
 	widget.SetKeyboardChar("j", widget.Next, "Select next workflow")
 	widget.SetKeyboardChar("k", widget.Prev, "Select previous workflow")

--- a/modules/cds/favorites/settings.go
+++ b/modules/cds/favorites/settings.go
@@ -32,5 +32,8 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 		apiURL:   ymlConfig.UString("apiURL", os.Getenv("CDS_API_URL")),
 		hideTags: utils.ToStrs(ymlConfig.UList("hideTags")),
 	}
+
+	settings.SetDocumentationPath("cds/favorites")
+
 	return &settings
 }

--- a/modules/cds/favorites/settings.go
+++ b/modules/cds/favorites/settings.go
@@ -15,7 +15,8 @@ const (
 
 // Settings defines the configuration properties for this module
 type Settings struct {
-	common   *cfg.Common
+	*cfg.Common
+
 	token    string `help:"Your CDS API token."`
 	apiURL   string `help:"Your CDS API URL."`
 	uiURL    string
@@ -25,7 +26,8 @@ type Settings struct {
 // NewSettingsFromYAML creates a new settings instance from a YAML config block
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := Settings{
-		common:   cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+
 		token:    ymlConfig.UString("token", ymlConfig.UString("token", os.Getenv("CDS_TOKEN"))),
 		apiURL:   ymlConfig.UString("apiURL", os.Getenv("CDS_API_URL")),
 		hideTags: utils.ToStrs(ymlConfig.UList("hideTags")),

--- a/modules/cds/favorites/widget.go
+++ b/modules/cds/favorites/widget.go
@@ -40,7 +40,6 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 	widget.SetDisplayFunction(widget.display)
 
 	widget.Unselect()
-	widget.KeyboardWidget.SetView(widget.View)
 
 	widget.client = cdsclient.New(cdsclient.Config{
 		Host:                              settings.apiURL,

--- a/modules/cds/favorites/widget.go
+++ b/modules/cds/favorites/widget.go
@@ -29,8 +29,8 @@ type Widget struct {
 // NewWidget creates a new instance of the widget
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		MultiSourceWidget: view.NewMultiSourceWidget(settings.common, "workflow", "workflows"),
-		TextWidget:        view.NewTextWidget(app, pages, settings.common),
+		MultiSourceWidget: view.NewMultiSourceWidget(settings.Common, "workflow", "workflows"),
+		TextWidget:        view.NewTextWidget(app, pages, settings.Common),
 
 		settings: settings,
 	}

--- a/modules/cds/favorites/widget.go
+++ b/modules/cds/favorites/widget.go
@@ -14,7 +14,6 @@ import (
 // Widget define wtf widget to register widget later
 type Widget struct {
 	view.MultiSourceWidget
-	view.KeyboardWidget
 	view.TextWidget
 
 	workflows []sdk.Workflow
@@ -30,16 +29,14 @@ type Widget struct {
 // NewWidget creates a new instance of the widget
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		KeyboardWidget:    view.NewKeyboardWidget(app, pages, settings.common),
 		MultiSourceWidget: view.NewMultiSourceWidget(settings.common, "workflow", "workflows"),
-		TextWidget:        view.NewTextWidget(app, settings.common),
+		TextWidget:        view.NewTextWidget(app, pages, settings.common),
 
 		settings: settings,
 	}
 
 	widget.initializeKeyboardControls()
 	widget.View.SetRegions(true)
-	widget.View.SetInputCapture(widget.InputCapture)
 	widget.SetDisplayFunction(widget.display)
 
 	widget.Unselect()
@@ -108,11 +105,6 @@ func (widget *Widget) Unselect() {
 // Refresh reloads the data
 func (widget *Widget) Refresh() {
 	widget.display()
-}
-
-// HelpText displays the widgets controls
-func (widget *Widget) HelpText() string {
-	return widget.KeyboardWidget.HelpText()
 }
 
 /* -------------------- Unexported Functions -------------------- */

--- a/modules/cds/queue/display.go
+++ b/modules/cds/queue/display.go
@@ -23,7 +23,7 @@ func (widget *Widget) content() (string, string, bool) {
 	filter := widget.currentFilter()
 	_, _, width, _ := widget.View.GetRect()
 
-	str := widget.settings.common.PaginationMarker(len(widget.filters), widget.Idx, width) + "\n"
+	str := widget.settings.PaginationMarker(len(widget.filters), widget.Idx, width) + "\n"
 	str += widget.displayQueue(filter)
 
 	title := fmt.Sprintf("%s - %s", widget.CommonSettings().Title, widget.title(filter))
@@ -34,7 +34,7 @@ func (widget *Widget) content() (string, string, bool) {
 func (widget *Widget) title(filter string) string {
 	return fmt.Sprintf(
 		"[%s]%d - %s[white]",
-		widget.settings.common.Colors.TextTheme.Title,
+		widget.settings.Colors.TextTheme.Title,
 		widget.maxItems,
 		filter,
 	)

--- a/modules/cds/queue/keyboard.go
+++ b/modules/cds/queue/keyboard.go
@@ -5,7 +5,7 @@ import (
 )
 
 func (widget *Widget) initializeKeyboardControls() {
-	widget.InitializeCommonControls(widget.Refresh)
+	widget.InitializeRefreshKeyboardControl(widget.Refresh)
 
 	widget.SetKeyboardChar("j", widget.Next, "Select next workflow")
 	widget.SetKeyboardChar("k", widget.Prev, "Select previous workflow")

--- a/modules/cds/queue/settings.go
+++ b/modules/cds/queue/settings.go
@@ -14,7 +14,8 @@ const (
 
 // Settings defines the configuration properties for this module
 type Settings struct {
-	common *cfg.Common
+	*cfg.Common
+
 	token  string `help:"Your CDS API token."`
 	apiURL string `help:"Your CDS API URL."`
 	uiURL  string
@@ -23,7 +24,8 @@ type Settings struct {
 // NewSettingsFromYAML creates a new settings instance from a YAML config block
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+
 		token:  ymlConfig.UString("token", ymlConfig.UString("token", os.Getenv("CDS_TOKEN"))),
 		apiURL: ymlConfig.UString("apiURL", os.Getenv("CDS_API_URL")),
 	}

--- a/modules/cds/queue/settings.go
+++ b/modules/cds/queue/settings.go
@@ -29,5 +29,8 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 		token:  ymlConfig.UString("token", ymlConfig.UString("token", os.Getenv("CDS_TOKEN"))),
 		apiURL: ymlConfig.UString("apiURL", os.Getenv("CDS_API_URL")),
 	}
+
+	settings.SetDocumentationPath("cds/queue")
+
 	return &settings
 }

--- a/modules/cds/queue/widget.go
+++ b/modules/cds/queue/widget.go
@@ -14,7 +14,6 @@ import (
 // Widget define wtf widget to register widget later
 type Widget struct {
 	view.MultiSourceWidget
-	view.KeyboardWidget
 	view.TextWidget
 
 	filters []string
@@ -30,16 +29,14 @@ type Widget struct {
 // NewWidget creates a new instance of the widget
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		KeyboardWidget:    view.NewKeyboardWidget(app, pages, settings.common),
 		MultiSourceWidget: view.NewMultiSourceWidget(settings.common, "workflow", "workflows"),
-		TextWidget:        view.NewTextWidget(app, settings.common),
+		TextWidget:        view.NewTextWidget(app, pages, settings.common),
 
 		settings: settings,
 	}
 
 	widget.initializeKeyboardControls()
 	widget.View.SetRegions(true)
-	widget.View.SetInputCapture(widget.InputCapture)
 	widget.SetDisplayFunction(widget.display)
 
 	widget.Unselect()
@@ -109,11 +106,6 @@ func (widget *Widget) Unselect() {
 // Refresh reloads the data
 func (widget *Widget) Refresh() {
 	widget.display()
-}
-
-// HelpText displays the widgets controls
-func (widget *Widget) HelpText() string {
-	return widget.KeyboardWidget.HelpText()
 }
 
 /* -------------------- Unexported Functions -------------------- */

--- a/modules/cds/queue/widget.go
+++ b/modules/cds/queue/widget.go
@@ -42,8 +42,6 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 	widget.Unselect()
 	widget.filters = []string{sdk.StatusWaiting, sdk.StatusBuilding}
 
-	widget.KeyboardWidget.SetView(widget.View)
-
 	widget.client = cdsclient.New(cdsclient.Config{
 		Host:                              settings.apiURL,
 		BuitinConsumerAuthenticationToken: settings.token,

--- a/modules/cds/queue/widget.go
+++ b/modules/cds/queue/widget.go
@@ -29,8 +29,8 @@ type Widget struct {
 // NewWidget creates a new instance of the widget
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		MultiSourceWidget: view.NewMultiSourceWidget(settings.common, "workflow", "workflows"),
-		TextWidget:        view.NewTextWidget(app, pages, settings.common),
+		MultiSourceWidget: view.NewMultiSourceWidget(settings.Common, "workflow", "workflows"),
+		TextWidget:        view.NewTextWidget(app, pages, settings.Common),
 
 		settings: settings,
 	}

--- a/modules/cds/status/keyboard.go
+++ b/modules/cds/status/keyboard.go
@@ -5,7 +5,7 @@ import (
 )
 
 func (widget *Widget) initializeKeyboardControls() {
-	widget.InitializeCommonControls(widget.Refresh)
+	widget.InitializeRefreshKeyboardControl(widget.Refresh)
 
 	widget.SetKeyboardChar("j", widget.Next, "Select next line")
 	widget.SetKeyboardChar("k", widget.Prev, "Select previous line")

--- a/modules/cds/status/settings.go
+++ b/modules/cds/status/settings.go
@@ -14,7 +14,8 @@ const (
 
 // Settings defines the configuration properties for this module
 type Settings struct {
-	common *cfg.Common
+	*cfg.Common
+
 	token  string `help:"Your CDS API token."`
 	apiURL string `help:"Your CDS API URL."`
 	uiURL  string
@@ -23,9 +24,13 @@ type Settings struct {
 // NewSettingsFromYAML creates a new settings instance from a YAML config block
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+
 		token:  ymlConfig.UString("token", ymlConfig.UString("token", os.Getenv("CDS_TOKEN"))),
 		apiURL: ymlConfig.UString("apiURL", os.Getenv("CDS_API_URL")),
 	}
+
+	settings.SetDocumentationPath("cds/status")
+
 	return &settings
 }

--- a/modules/cds/status/widget.go
+++ b/modules/cds/status/widget.go
@@ -14,7 +14,6 @@ import (
 // Widget define wtf widget to register widget later
 type Widget struct {
 	view.MultiSourceWidget
-	view.KeyboardWidget
 	view.TextWidget
 
 	filters []string
@@ -30,16 +29,14 @@ type Widget struct {
 // NewWidget creates a new instance of the widget
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		KeyboardWidget:    view.NewKeyboardWidget(app, pages, settings.common),
 		MultiSourceWidget: view.NewMultiSourceWidget(settings.common, "workflow", "workflows"),
-		TextWidget:        view.NewTextWidget(app, settings.common),
+		TextWidget:        view.NewTextWidget(app, pages, settings.common),
 
 		settings: settings,
 	}
 
 	widget.initializeKeyboardControls()
 	widget.View.SetRegions(true)
-	widget.View.SetInputCapture(widget.InputCapture)
 	widget.SetDisplayFunction(widget.display)
 
 	widget.Unselect()
@@ -109,11 +106,6 @@ func (widget *Widget) Unselect() {
 // Refresh reloads the data
 func (widget *Widget) Refresh() {
 	widget.display()
-}
-
-// HelpText displays the widgets controls
-func (widget *Widget) HelpText() string {
-	return widget.KeyboardWidget.HelpText()
 }
 
 /* -------------------- Unexported Functions -------------------- */

--- a/modules/cds/status/widget.go
+++ b/modules/cds/status/widget.go
@@ -42,8 +42,6 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 	widget.Unselect()
 	widget.filters = []string{sdk.StatusWaiting, sdk.StatusBuilding}
 
-	widget.KeyboardWidget.SetView(widget.View)
-
 	widget.client = cdsclient.New(cdsclient.Config{
 		Host:                              settings.apiURL,
 		BuitinConsumerAuthenticationToken: settings.token,

--- a/modules/cds/status/widget.go
+++ b/modules/cds/status/widget.go
@@ -29,8 +29,8 @@ type Widget struct {
 // NewWidget creates a new instance of the widget
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		MultiSourceWidget: view.NewMultiSourceWidget(settings.common, "workflow", "workflows"),
-		TextWidget:        view.NewTextWidget(app, pages, settings.common),
+		MultiSourceWidget: view.NewMultiSourceWidget(settings.Common, "workflow", "workflows"),
+		TextWidget:        view.NewTextWidget(app, pages, settings.Common),
 
 		settings: settings,
 	}

--- a/modules/circleci/settings.go
+++ b/modules/circleci/settings.go
@@ -13,7 +13,7 @@ const (
 )
 
 type Settings struct {
-	common *cfg.Common
+	*cfg.Common
 
 	apiKey         string `help:"Your CircleCI API token."`
 	numberOfBuilds int    `help:"The number of build, 10 by default"`
@@ -22,7 +22,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		apiKey:         ymlConfig.UString("apiKey", ymlConfig.UString("apikey", os.Getenv("WTF_CIRCLE_API_KEY"))),
 		numberOfBuilds: ymlConfig.UInt("numberOfBuilds", 10),

--- a/modules/circleci/widget.go
+++ b/modules/circleci/widget.go
@@ -16,7 +16,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, settings.common),
+		TextWidget: view.NewTextWidget(app, nil, settings.common),
 		Client:     NewClient(settings.apiKey),
 
 		settings: settings,

--- a/modules/circleci/widget.go
+++ b/modules/circleci/widget.go
@@ -16,7 +16,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, nil, settings.common),
+		TextWidget: view.NewTextWidget(app, nil, settings.Common),
 		Client:     NewClient(settings.apiKey),
 
 		settings: settings,

--- a/modules/clocks/settings.go
+++ b/modules/clocks/settings.go
@@ -13,7 +13,7 @@ const (
 
 // Settings defines the configuration properties for this module
 type Settings struct {
-	common *cfg.Common
+	*cfg.Common
 
 	dateFormat string  `help:"The format of the date string for all clocks." values:"Any valid Go date layout which is handled by Time.Format. Defaults to Jan 2."`
 	timeFormat string  `help:"The format of the time string for all clocks." values:"Any valid Go time layout which is handled by Time.Format. Defaults to 15:04 MST."`
@@ -24,7 +24,7 @@ type Settings struct {
 // NewSettingsFromYAML creates a new settings instance from a YAML config block
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		dateFormat: ymlConfig.UString("dateFormat", utils.SimpleDateFormat),
 		timeFormat: ymlConfig.UString("timeFormat", utils.SimpleTimeFormat),

--- a/modules/clocks/widget.go
+++ b/modules/clocks/widget.go
@@ -17,7 +17,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, nil, settings.common),
+		TextWidget: view.NewTextWidget(app, nil, settings.Common),
 
 		app:        app,
 		settings:   settings,

--- a/modules/clocks/widget.go
+++ b/modules/clocks/widget.go
@@ -17,7 +17,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, settings.common),
+		TextWidget: view.NewTextWidget(app, nil, settings.common),
 
 		app:        app,
 		settings:   settings,

--- a/modules/cmdrunner/settings.go
+++ b/modules/cmdrunner/settings.go
@@ -13,7 +13,7 @@ const (
 
 // Settings for the cmdrunner widget
 type Settings struct {
-	common *cfg.Common
+	*cfg.Common
 
 	args     []string `help:"The arguments to the command, with each item as an element in an array. Example: for curl -I cisco.com, the arguments array would be ['-I', 'cisco.com']."`
 	cmd      string   `help:"The terminal command to be run, withouth the arguments. Ie: ping, whoami, curl."`
@@ -29,7 +29,7 @@ type Settings struct {
 // NewSettingsFromYAML loads the cmdrunner portion of the WTF config
 func NewSettingsFromYAML(name string, moduleConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, moduleConfig, globalConfig),
+		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, moduleConfig, globalConfig),
 
 		args:     utils.ToStrs(moduleConfig.UList("args")),
 		cmd:      moduleConfig.UString("cmd"),

--- a/modules/cmdrunner/widget.go
+++ b/modules/cmdrunner/widget.go
@@ -29,7 +29,7 @@ type Widget struct {
 // NewWidget creates a new instance of the widget
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, settings.common),
+		TextWidget: view.NewTextWidget(app, nil, settings.common),
 
 		settings: settings,
 		buffer:   &bytes.Buffer{},

--- a/modules/cmdrunner/widget.go
+++ b/modules/cmdrunner/widget.go
@@ -29,7 +29,7 @@ type Widget struct {
 // NewWidget creates a new instance of the widget
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, nil, settings.common),
+		TextWidget: view.NewTextWidget(app, nil, settings.Common),
 
 		settings: settings,
 		buffer:   &bytes.Buffer{},

--- a/modules/cryptoexchanges/bittrex/settings.go
+++ b/modules/cryptoexchanges/bittrex/settings.go
@@ -63,5 +63,7 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 		settings.summary.currencies[key] = currency
 	}
 
+	settings.SetDocumentationPath("cryptocurrencies/bittrex")
+
 	return &settings
 }

--- a/modules/cryptoexchanges/bittrex/settings.go
+++ b/modules/cryptoexchanges/bittrex/settings.go
@@ -32,15 +32,16 @@ type summary struct {
 }
 
 type Settings struct {
+	*cfg.Common
+
 	colors
-	common *cfg.Common
 	summary
 }
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 	}
 
 	settings.colors.base.name = ymlConfig.UString("colors.base.name")

--- a/modules/cryptoexchanges/bittrex/widget.go
+++ b/modules/cryptoexchanges/bittrex/widget.go
@@ -31,7 +31,7 @@ type Widget struct {
 // NewWidget Make new instance of widget
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, settings.common),
+		TextWidget: view.NewTextWidget(app, nil, settings.common),
 
 		settings:    settings,
 		summaryList: summaryList{},

--- a/modules/cryptoexchanges/bittrex/widget.go
+++ b/modules/cryptoexchanges/bittrex/widget.go
@@ -31,7 +31,7 @@ type Widget struct {
 // NewWidget Make new instance of widget
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, nil, settings.common),
+		TextWidget: view.NewTextWidget(app, nil, settings.Common),
 
 		settings:    settings,
 		summaryList: summaryList{},

--- a/modules/cryptoexchanges/blockfolio/settings.go
+++ b/modules/cryptoexchanges/blockfolio/settings.go
@@ -34,5 +34,7 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 		displayHoldings: ymlConfig.UBool("displayHoldings", true),
 	}
 
+	settings.SetDocumentationPath("cryptocurrencies/blockfolio")
+
 	return &settings
 }

--- a/modules/cryptoexchanges/blockfolio/settings.go
+++ b/modules/cryptoexchanges/blockfolio/settings.go
@@ -17,8 +17,9 @@ type colors struct {
 }
 
 type Settings struct {
+	*cfg.Common
+
 	colors
-	common *cfg.Common
 
 	deviceToken     string
 	displayHoldings bool
@@ -27,7 +28,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		deviceToken:     ymlConfig.UString("device_token"),
 		displayHoldings: ymlConfig.UBool("displayHoldings", true),

--- a/modules/cryptoexchanges/blockfolio/widget.go
+++ b/modules/cryptoexchanges/blockfolio/widget.go
@@ -20,7 +20,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, settings.common),
+		TextWidget: view.NewTextWidget(app, nil, settings.common),
 
 		device_token: settings.deviceToken,
 		settings:     settings,

--- a/modules/cryptoexchanges/blockfolio/widget.go
+++ b/modules/cryptoexchanges/blockfolio/widget.go
@@ -20,7 +20,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, nil, settings.common),
+		TextWidget: view.NewTextWidget(app, nil, settings.Common),
 
 		device_token: settings.deviceToken,
 		settings:     settings,

--- a/modules/cryptoexchanges/cryptolive/price/settings.go
+++ b/modules/cryptoexchanges/cryptolive/price/settings.go
@@ -38,15 +38,16 @@ type currency struct {
 }
 
 type Settings struct {
+	*cfg.Common
+
 	colors
-	common     *cfg.Common
 	currencies map[string]*currency
 }
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 	}
 
 	settings.colors.from.name = ymlConfig.UString("colors.from.name")

--- a/modules/cryptoexchanges/cryptolive/settings.go
+++ b/modules/cryptoexchanges/cryptolive/settings.go
@@ -35,8 +35,9 @@ type colors struct {
 }
 
 type Settings struct {
+	*cfg.Common
+
 	colors
-	common *cfg.Common
 
 	currencies map[string]interface{}
 	top        map[string]interface{}
@@ -50,7 +51,7 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	top, _ := ymlConfig.Map("top")
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		currencies: currencies,
 		top:        top,

--- a/modules/cryptoexchanges/cryptolive/settings.go
+++ b/modules/cryptoexchanges/cryptolive/settings.go
@@ -73,5 +73,7 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	settings.colors.top.to.field = ymlConfig.UString("colors.top.to.field")
 	settings.colors.top.to.value = ymlConfig.UString("colors.top.to.value")
 
+	settings.SetDocumentationPath("cryptocurrencies/cryptolive")
+
 	return &settings
 }

--- a/modules/cryptoexchanges/cryptolive/toplist/settings.go
+++ b/modules/cryptoexchanges/cryptolive/toplist/settings.go
@@ -39,15 +39,16 @@ type currency struct {
 }
 
 type Settings struct {
+	*cfg.Common
+
 	colors
-	common *cfg.Common
-	top    map[string]*currency
+	top map[string]*currency
 }
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 	}
 
 	settings.colors.from.name = ymlConfig.UString("colors.from.name")

--- a/modules/cryptoexchanges/cryptolive/widget.go
+++ b/modules/cryptoexchanges/cryptolive/widget.go
@@ -22,7 +22,7 @@ type Widget struct {
 // NewWidget Make new instance of widget
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, nil, settings.common),
+		TextWidget: view.NewTextWidget(app, nil, settings.Common),
 
 		priceWidget:   price.NewWidget(settings.priceSettings),
 		toplistWidget: toplist.NewWidget(settings.toplistSettings),

--- a/modules/cryptoexchanges/cryptolive/widget.go
+++ b/modules/cryptoexchanges/cryptolive/widget.go
@@ -22,7 +22,7 @@ type Widget struct {
 // NewWidget Make new instance of widget
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, settings.common),
+		TextWidget: view.NewTextWidget(app, nil, settings.common),
 
 		priceWidget:   price.NewWidget(settings.priceSettings),
 		toplistWidget: toplist.NewWidget(settings.toplistSettings),

--- a/modules/datadog/keyboard.go
+++ b/modules/datadog/keyboard.go
@@ -5,7 +5,7 @@ import (
 )
 
 func (widget *Widget) initializeKeyboardControls() {
-	widget.InitializeCommonControls(widget.Refresh)
+	widget.InitializeRefreshKeyboardControl(widget.Refresh)
 
 	widget.SetKeyboardChar("j", widget.Next, "Select next item")
 	widget.SetKeyboardChar("k", widget.Prev, "Select previous item")

--- a/modules/datadog/settings.go
+++ b/modules/datadog/settings.go
@@ -13,7 +13,7 @@ const (
 )
 
 type Settings struct {
-	common *cfg.Common
+	*cfg.Common
 
 	apiKey         string        `help:"Your Datadog API key."`
 	applicationKey string        `help:"Your Datadog Application key."`
@@ -23,7 +23,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		apiKey:         ymlConfig.UString("apiKey", ymlConfig.UString("apikey", os.Getenv("WTF_DATADOG_API_KEY"))),
 		applicationKey: ymlConfig.UString("applicationKey", os.Getenv("WTF_DATADOG_APPLICATION_KEY")),

--- a/modules/datadog/widget.go
+++ b/modules/datadog/widget.go
@@ -19,7 +19,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		ScrollableWidget: view.NewScrollableWidget(app, pages, settings.common),
+		ScrollableWidget: view.NewScrollableWidget(app, pages, settings.Common),
 
 		settings: settings,
 	}
@@ -78,7 +78,7 @@ func (widget *Widget) content() (string, string, bool) {
 			" %s\n",
 			fmt.Sprintf(
 				"[%s]Triggered Monitors[white]",
-				widget.settings.common.Colors.Subheading,
+				widget.settings.Colors.Subheading,
 			),
 		)
 		for idx, triggeredMonitor := range triggeredMonitors {

--- a/modules/datadog/widget.go
+++ b/modules/datadog/widget.go
@@ -27,8 +27,6 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 	widget.SetRenderFunction(widget.Render)
 	widget.initializeKeyboardControls()
 
-	widget.KeyboardWidget.SetView(widget.View)
-
 	return &widget
 }
 

--- a/modules/datadog/widget.go
+++ b/modules/datadog/widget.go
@@ -10,7 +10,6 @@ import (
 )
 
 type Widget struct {
-	view.KeyboardWidget
 	view.ScrollableWidget
 
 	monitors []datadog.Monitor
@@ -20,15 +19,13 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		KeyboardWidget:   view.NewKeyboardWidget(app, pages, settings.common),
-		ScrollableWidget: view.NewScrollableWidget(app, settings.common),
+		ScrollableWidget: view.NewScrollableWidget(app, pages, settings.common),
 
 		settings: settings,
 	}
 
 	widget.SetRenderFunction(widget.Render)
 	widget.initializeKeyboardControls()
-	widget.View.SetInputCapture(widget.InputCapture)
 
 	widget.KeyboardWidget.SetView(widget.View)
 
@@ -64,10 +61,6 @@ func (widget *Widget) Refresh() {
 
 func (widget *Widget) Render() {
 	widget.Redraw(widget.content)
-}
-
-func (widget *Widget) HelpText() string {
-	return widget.KeyboardWidget.HelpText()
 }
 
 /* -------------------- Unexported Functions -------------------- */

--- a/modules/devto/keyboard.go
+++ b/modules/devto/keyboard.go
@@ -3,7 +3,7 @@ package devto
 import "github.com/gdamore/tcell"
 
 func (widget *Widget) initializeKeyboardControls() {
-	widget.InitializeCommonControls(widget.Refresh)
+	widget.InitializeRefreshKeyboardControl(widget.Refresh)
 
 	widget.SetKeyboardChar("d", widget.Next, "Select next item")
 	widget.SetKeyboardChar("a", widget.Prev, "Select previous item")

--- a/modules/devto/settings.go
+++ b/modules/devto/settings.go
@@ -13,7 +13,7 @@ const (
 
 // Settings defines the configuration options for this module
 type Settings struct {
-	common *cfg.Common
+	*cfg.Common
 
 	numberOfArticles int    `help:"Number of stories to show. Default is 10" optional:"true"`
 	contentTag       string `help:"List articles from a specific tag. Default is empty" optional:"true"`
@@ -24,7 +24,8 @@ type Settings struct {
 // NewSettingsFromYAML creates and returns an instance of Settings with configuration options populated
 func NewSettingsFromYAML(name string, yamlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := Settings{
-		common:           cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, yamlConfig, globalConfig),
+		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, yamlConfig, globalConfig),
+
 		numberOfArticles: yamlConfig.UInt("numberOfArticles", 10),
 		contentTag:       yamlConfig.UString("contentTag", ""),
 		contentUsername:  yamlConfig.UString("contentUsername", ""),

--- a/modules/devto/widget.go
+++ b/modules/devto/widget.go
@@ -30,8 +30,6 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 	widget.View.SetScrollable(true)
 	widget.initializeKeyboardControls()
 
-	widget.KeyboardWidget.SetView(widget.View)
-
 	return widget
 }
 

--- a/modules/devto/widget.go
+++ b/modules/devto/widget.go
@@ -21,7 +21,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := &Widget{
-		ScrollableWidget: view.NewScrollableWidget(app, pages, settings.common),
+		ScrollableWidget: view.NewScrollableWidget(app, pages, settings.Common),
 
 		settings: settings,
 	}

--- a/modules/devto/widget.go
+++ b/modules/devto/widget.go
@@ -12,8 +12,8 @@ import (
 )
 
 type Widget struct {
-	view.KeyboardWidget
 	view.ScrollableWidget
+
 	articles []devto.ListedArticle
 	settings *Settings
 	err      error
@@ -21,8 +21,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := &Widget{
-		KeyboardWidget:   view.NewKeyboardWidget(app, pages, settings.common),
-		ScrollableWidget: view.NewScrollableWidget(app, settings.common),
+		ScrollableWidget: view.NewScrollableWidget(app, pages, settings.common),
 
 		settings: settings,
 	}
@@ -30,7 +29,6 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 	widget.SetRenderFunction(widget.Render)
 	widget.View.SetScrollable(true)
 	widget.initializeKeyboardControls()
-	widget.View.SetInputCapture(widget.InputCapture)
 
 	widget.KeyboardWidget.SetView(widget.View)
 

--- a/modules/digitalclock/settings.go
+++ b/modules/digitalclock/settings.go
@@ -12,7 +12,7 @@ const (
 
 // Settings defines the configuration properties for this module
 type Settings struct {
-	common *cfg.Common
+	*cfg.Common
 
 	color      string `help:"The color of the clock."`
 	font       string `help:"The font of the clock." values:"bigfont or digitalfont"`
@@ -23,7 +23,7 @@ type Settings struct {
 // NewSettingsFromYAML creates a new settings instance from a YAML config block
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		color:      ymlConfig.UString("color"),
 		font:       ymlConfig.UString("font"),

--- a/modules/digitalclock/widget.go
+++ b/modules/digitalclock/widget.go
@@ -16,7 +16,7 @@ type Widget struct {
 // NewWidget creates a new widget using settings
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, nil, settings.common),
+		TextWidget: view.NewTextWidget(app, nil, settings.Common),
 
 		app:      app,
 		settings: settings,

--- a/modules/digitalclock/widget.go
+++ b/modules/digitalclock/widget.go
@@ -16,7 +16,7 @@ type Widget struct {
 // NewWidget creates a new widget using settings
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, settings.common),
+		TextWidget: view.NewTextWidget(app, nil, settings.common),
 
 		app:      app,
 		settings: settings,

--- a/modules/digitalocean/display.go
+++ b/modules/digitalocean/display.go
@@ -20,7 +20,7 @@ func (widget *Widget) content() (string, string, bool) {
 		return title, " no columns defined", false
 	}
 
-	str := fmt.Sprintf(" [::b][%s]", widget.settings.common.Colors.Subheading)
+	str := fmt.Sprintf(" [::b][%s]", widget.settings.Colors.Subheading)
 
 	for _, colName := range columnSet {
 		truncName := utils.Truncate(colName, maxColWidth, false)

--- a/modules/digitalocean/keyboard.go
+++ b/modules/digitalocean/keyboard.go
@@ -3,7 +3,7 @@ package digitalocean
 import "github.com/gdamore/tcell"
 
 func (widget *Widget) initializeKeyboardControls() {
-	widget.InitializeCommonControls(widget.Refresh)
+	widget.InitializeRefreshKeyboardControl(widget.Refresh)
 
 	widget.SetKeyboardChar("?", widget.showInfo, "Show info about the selected droplet")
 

--- a/modules/digitalocean/settings.go
+++ b/modules/digitalocean/settings.go
@@ -24,7 +24,7 @@ var defaultColumns = []interface{}{
 
 // Settings defines the configuration properties for this module
 type Settings struct {
-	common *cfg.Common
+	*cfg.Common
 
 	apiKey     string   `help:"Your DigitalOcean API key."`
 	columns    []string `help:"A list of the droplet properties to display."`
@@ -35,7 +35,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		apiKey:     ymlConfig.UString("apiKey", ymlConfig.UString("apikey", os.Getenv("WTF_DIGITALOCEAN_API_KEY"))),
 		columns:    utils.ToStrs(ymlConfig.UList("columns", defaultColumns)),

--- a/modules/digitalocean/widget.go
+++ b/modules/digitalocean/widget.go
@@ -30,7 +30,6 @@ func (t *tokenSource) Token() (*oauth2.Token, error) {
 
 // Widget is the container for droplet data
 type Widget struct {
-	view.KeyboardWidget
 	view.ScrollableWidget
 
 	app      *tview.Application
@@ -45,8 +44,7 @@ type Widget struct {
 // NewWidget creates a new instance of a widget
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		KeyboardWidget:   view.NewKeyboardWidget(app, pages, settings.common),
-		ScrollableWidget: view.NewScrollableWidget(app, settings.common),
+		ScrollableWidget: view.NewScrollableWidget(app, pages, settings.common),
 
 		app:      app,
 		pages:    pages,
@@ -54,7 +52,6 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 	}
 
 	widget.initializeKeyboardControls()
-	widget.View.SetInputCapture(widget.InputCapture)
 
 	widget.View.SetScrollable(true)
 
@@ -77,11 +74,6 @@ func (widget *Widget) Fetch() error {
 	var err error
 	widget.droplets, err = widget.dropletsFetch()
 	return err
-}
-
-// HelpText returns the help text for this widget
-func (widget *Widget) HelpText() string {
-	return widget.KeyboardWidget.HelpText()
 }
 
 // Next selects the next item in the list

--- a/modules/digitalocean/widget.go
+++ b/modules/digitalocean/widget.go
@@ -44,7 +44,7 @@ type Widget struct {
 // NewWidget creates a new instance of a widget
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		ScrollableWidget: view.NewScrollableWidget(app, pages, settings.common),
+		ScrollableWidget: view.NewScrollableWidget(app, pages, settings.Common),
 
 		app:      app,
 		pages:    pages,

--- a/modules/digitalocean/widget.go
+++ b/modules/digitalocean/widget.go
@@ -55,7 +55,6 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 
 	widget.View.SetScrollable(true)
 
-	widget.KeyboardWidget.SetView(widget.View)
 	widget.SetRenderFunction(widget.display)
 
 	widget.createClient()

--- a/modules/docker/client.go
+++ b/modules/docker/client.go
@@ -41,13 +41,13 @@ func (widget *Widget) getSystemInfo() string {
 	}{
 		{
 			name:  "name:",
-			value: fmt.Sprintf("[%s]%s", widget.settings.common.Colors.RowTheme.EvenForeground, info.Name),
+			value: fmt.Sprintf("[%s]%s", widget.settings.Colors.RowTheme.EvenForeground, info.Name),
 		}, {
 			name:  "version:",
-			value: fmt.Sprintf("[%s]%s", widget.settings.common.Colors.RowTheme.EvenForeground, info.ServerVersion),
+			value: fmt.Sprintf("[%s]%s", widget.settings.Colors.RowTheme.EvenForeground, info.ServerVersion),
 		}, {
 			name:  "root:",
-			value: fmt.Sprintf("[%s]%s", widget.settings.common.Colors.RowTheme.EvenForeground, info.DockerRootDir),
+			value: fmt.Sprintf("[%s]%s", widget.settings.Colors.RowTheme.EvenForeground, info.DockerRootDir),
 		},
 		{
 			name: "containers:",
@@ -57,15 +57,15 @@ func (widget *Widget) getSystemInfo() string {
 		},
 		{
 			name:  "images:",
-			value: fmt.Sprintf("[%s]%d", widget.settings.common.Colors.RowTheme.EvenForeground, info.Images),
+			value: fmt.Sprintf("[%s]%d", widget.settings.Colors.RowTheme.EvenForeground, info.Images),
 		},
 		{
 			name:  "volumes:",
-			value: fmt.Sprintf("[%s]%v", widget.settings.common.Colors.RowTheme.EvenForeground, len(diskUsage.Volumes)),
+			value: fmt.Sprintf("[%s]%v", widget.settings.Colors.RowTheme.EvenForeground, len(diskUsage.Volumes)),
 		},
 		{
 			name:  "memory limit:",
-			value: fmt.Sprintf("[%s]%s", widget.settings.common.Colors.RowTheme.EvenForeground, humanize.Bytes(uint64(info.MemTotal))),
+			value: fmt.Sprintf("[%s]%s", widget.settings.Colors.RowTheme.EvenForeground, humanize.Bytes(uint64(info.MemTotal))),
 		},
 		{
 			name: "disk usage:",
@@ -76,19 +76,19 @@ func (widget *Widget) getSystemInfo() string {
     [%s]* [::b]total:      [%s]%s[::-]
 `,
 				widget.settings.labelColor,
-				widget.settings.common.Colors.RowTheme.EvenForeground,
+				widget.settings.Colors.RowTheme.EvenForeground,
 				humanize.Bytes(uint64(duContainer)),
 
 				widget.settings.labelColor,
-				widget.settings.common.Colors.RowTheme.EvenForeground,
+				widget.settings.Colors.RowTheme.EvenForeground,
 				humanize.Bytes(uint64(duImg)),
 
 				widget.settings.labelColor,
-				widget.settings.common.Colors.RowTheme.EvenForeground,
+				widget.settings.Colors.RowTheme.EvenForeground,
 				humanize.Bytes(uint64(duVol)),
 
 				widget.settings.labelColor,
-				widget.settings.common.Colors.RowTheme.EvenForeground,
+				widget.settings.Colors.RowTheme.EvenForeground,
 				humanize.Bytes(uint64(duContainer+duImg+duVol))),
 		},
 	}

--- a/modules/docker/settings.go
+++ b/modules/docker/settings.go
@@ -12,14 +12,15 @@ const (
 
 // Settings defines the configuration options for this module
 type Settings struct {
-	common     *cfg.Common
+	*cfg.Common
+
 	labelColor string
 }
 
 // NewSettingsFromYAML creates and returns an instance of Settings with configuration options populated
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := Settings{
-		common:     cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+		Common:     cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 		labelColor: ymlConfig.UString("labelColor", "white"),
 	}
 

--- a/modules/docker/widget.go
+++ b/modules/docker/widget.go
@@ -18,7 +18,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, settings.common),
+		TextWidget: view.NewTextWidget(app, pages, settings.common),
 		settings:   settings,
 	}
 

--- a/modules/docker/widget.go
+++ b/modules/docker/widget.go
@@ -18,7 +18,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, pages, settings.common),
+		TextWidget: view.NewTextWidget(app, pages, settings.Common),
 		settings:   settings,
 	}
 
@@ -56,11 +56,11 @@ func (widget *Widget) refreshDisplayBuffer() {
 
 	widget.displayBuffer = ""
 
-	widget.displayBuffer += fmt.Sprintf("[%s] System[white]\n", widget.settings.common.Colors.Subheading)
+	widget.displayBuffer += fmt.Sprintf("[%s] System[white]\n", widget.settings.Colors.Subheading)
 	widget.displayBuffer += widget.getSystemInfo()
 
 	widget.displayBuffer += "\n"
 
-	widget.displayBuffer += fmt.Sprintf("[%s] Containers[white]\n", widget.settings.common.Colors.Subheading)
+	widget.displayBuffer += fmt.Sprintf("[%s] Containers[white]\n", widget.settings.Colors.Subheading)
 	widget.displayBuffer += widget.getContainerStates()
 }

--- a/modules/exchangerates/settings.go
+++ b/modules/exchangerates/settings.go
@@ -13,7 +13,7 @@ const (
 
 // Settings defines the configuration properties for this module
 type Settings struct {
-	common *cfg.Common
+	*cfg.Common
 
 	precision int `help:"How many decimal places to display." optional:"true"`
 
@@ -24,7 +24,7 @@ type Settings struct {
 // NewSettingsFromYAML creates a new settings instance from a YAML config block
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		precision: ymlConfig.UInt("precision", 7),
 

--- a/modules/exchangerates/widget.go
+++ b/modules/exchangerates/widget.go
@@ -20,7 +20,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		ScrollableWidget: view.NewScrollableWidget(app, settings.common),
+		ScrollableWidget: view.NewScrollableWidget(app, pages, settings.common),
 
 		settings: settings,
 	}

--- a/modules/exchangerates/widget.go
+++ b/modules/exchangerates/widget.go
@@ -20,7 +20,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		ScrollableWidget: view.NewScrollableWidget(app, pages, settings.common),
+		ScrollableWidget: view.NewScrollableWidget(app, pages, settings.Common),
 
 		settings: settings,
 	}

--- a/modules/feedreader/keyboard.go
+++ b/modules/feedreader/keyboard.go
@@ -3,7 +3,7 @@ package feedreader
 import "github.com/gdamore/tcell"
 
 func (widget *Widget) initializeKeyboardControls() {
-	widget.InitializeCommonControls(widget.Refresh)
+	widget.InitializeRefreshKeyboardControl(widget.Refresh)
 
 	widget.SetKeyboardChar("j", widget.Next, "Select next item")
 	widget.SetKeyboardChar("k", widget.Prev, "Select previous item")

--- a/modules/feedreader/settings.go
+++ b/modules/feedreader/settings.go
@@ -13,7 +13,7 @@ const (
 
 // Settings defines the configuration properties for this module
 type Settings struct {
-	common *cfg.Common
+	*cfg.Common
 
 	feeds     []string `help:"An array of RSS and Atom feed URLs"`
 	feedLimit int      `help:"The maximum number of stories to display for each feed"`
@@ -22,7 +22,7 @@ type Settings struct {
 // NewSettingsFromYAML creates a new settings instance from a YAML config block
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := &Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		feeds:     utils.ToStrs(ymlConfig.UList("feeds")),
 		feedLimit: ymlConfig.UInt("feedLimit", -1),

--- a/modules/feedreader/widget.go
+++ b/modules/feedreader/widget.go
@@ -75,8 +75,6 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 	widget.SetRenderFunction(widget.Render)
 	widget.initializeKeyboardControls()
 
-	widget.KeyboardWidget.SetView(widget.View)
-
 	return widget
 }
 

--- a/modules/feedreader/widget.go
+++ b/modules/feedreader/widget.go
@@ -65,7 +65,7 @@ func getShowText(feedItem *FeedItem, showType ShowType) string {
 // NewWidget creates a new instance of a widget
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := &Widget{
-		ScrollableWidget: view.NewScrollableWidget(app, pages, settings.common),
+		ScrollableWidget: view.NewScrollableWidget(app, pages, settings.Common),
 
 		parser:   gofeed.NewParser(),
 		settings: settings,
@@ -165,7 +165,7 @@ func (widget *Widget) content() (string, string, bool) {
 			// Grays out viewed items in the list, while preserving background highlighting when selected
 			rowColor = "gray"
 			if idx == widget.Selected {
-				rowColor = fmt.Sprintf("gray:%s", widget.settings.common.Colors.RowTheme.HighlightedBackground)
+				rowColor = fmt.Sprintf("gray:%s", widget.settings.Colors.RowTheme.HighlightedBackground)
 			}
 		}
 

--- a/modules/feedreader/widget.go
+++ b/modules/feedreader/widget.go
@@ -28,7 +28,6 @@ type FeedItem struct {
 
 // Widget is the container for RSS and Atom data
 type Widget struct {
-	view.KeyboardWidget
 	view.ScrollableWidget
 
 	stories  []*FeedItem
@@ -66,8 +65,7 @@ func getShowText(feedItem *FeedItem, showType ShowType) string {
 // NewWidget creates a new instance of a widget
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := &Widget{
-		KeyboardWidget:   view.NewKeyboardWidget(app, pages, settings.common),
-		ScrollableWidget: view.NewScrollableWidget(app, settings.common),
+		ScrollableWidget: view.NewScrollableWidget(app, pages, settings.common),
 
 		parser:   gofeed.NewParser(),
 		settings: settings,
@@ -76,7 +74,6 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 
 	widget.SetRenderFunction(widget.Render)
 	widget.initializeKeyboardControls()
-	widget.View.SetInputCapture(widget.InputCapture)
 
 	widget.KeyboardWidget.SetView(widget.View)
 

--- a/modules/finnhub/settings.go
+++ b/modules/finnhub/settings.go
@@ -15,7 +15,8 @@ const (
 
 // Settings defines the configuration properties for this module
 type Settings struct {
-	common  *cfg.Common
+	*cfg.Common
+
 	apiKey  string   `help:"Your finnhub API token."`
 	symbols []string `help:"An array of stocks symbols (i.e. AAPL, MSFT)"`
 }
@@ -24,7 +25,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		apiKey:  ymlConfig.UString("apiKey", ymlConfig.UString("apikey", os.Getenv("WTF_FINNHUB_API_KEY"))),
 		symbols: utils.ToStrs(ymlConfig.UList("symbols")),

--- a/modules/finnhub/widget.go
+++ b/modules/finnhub/widget.go
@@ -19,8 +19,8 @@ type Widget struct {
 // NewWidget ..
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, settings.common),
 		Client:     NewClient(settings.symbols, settings.apiKey),
+		TextWidget: view.NewTextWidget(app, nil, settings.common),
 
 		settings: settings,
 	}

--- a/modules/finnhub/widget.go
+++ b/modules/finnhub/widget.go
@@ -20,7 +20,7 @@ type Widget struct {
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
 		Client:     NewClient(settings.symbols, settings.apiKey),
-		TextWidget: view.NewTextWidget(app, nil, settings.common),
+		TextWidget: view.NewTextWidget(app, nil, settings.Common),
 
 		settings: settings,
 	}

--- a/modules/football/settings.go
+++ b/modules/football/settings.go
@@ -38,5 +38,7 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 
 	cfg.ModuleSecret(name, globalConfig, &settings.apiKey).Load()
 
+	settings.SetDocumentationPath("sports/football")
+
 	return &settings
 }

--- a/modules/football/settings.go
+++ b/modules/football/settings.go
@@ -13,7 +13,8 @@ const (
 )
 
 type Settings struct {
-	common        *cfg.Common
+	*cfg.Common
+
 	apiKey        string `help:"Your Football-data API token."`
 	league        string `help:"Name of the competition. For example PL"`
 	favTeam       string `help:"Teams to follow in mentioned league"`
@@ -25,7 +26,8 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common:        cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+
 		apiKey:        ymlConfig.UString("apiKey", ymlConfig.UString("apikey", os.Getenv("WTF_FOOTBALL_API_KEY"))),
 		league:        ymlConfig.UString("league", ymlConfig.UString("league", os.Getenv("WTF_FOOTBALL_LEAGUE"))),
 		favTeam:       ymlConfig.UString("favTeam", ymlConfig.UString("favTeam", os.Getenv("WTF_FOOTBALL_TEAM"))),

--- a/modules/football/widget.go
+++ b/modules/football/widget.go
@@ -51,7 +51,7 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 	}
 
 	widget = Widget{
-		TextWidget: view.NewTextWidget(app, pages, settings.common),
+		TextWidget: view.NewTextWidget(app, pages, settings.Common),
 		Client:     NewClient(settings.apiKey),
 		League:     leagueId,
 		settings:   settings,

--- a/modules/football/widget.go
+++ b/modules/football/widget.go
@@ -38,6 +38,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	var widget Widget
+
 	leagueId, err := getLeague(settings.league)
 	if err != nil {
 		widget = Widget{
@@ -45,14 +46,17 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 			Client:   NewClient(settings.apiKey),
 			settings: settings,
 		}
+
 		return &widget
 	}
+
 	widget = Widget{
-		TextWidget: view.NewTextWidget(app, settings.common),
+		TextWidget: view.NewTextWidget(app, pages, settings.common),
 		Client:     NewClient(settings.apiKey),
 		League:     leagueId,
 		settings:   settings,
 	}
+
 	return &widget
 }
 

--- a/modules/gcal/display.go
+++ b/modules/gcal/display.go
@@ -14,7 +14,7 @@ func (widget *Widget) display() {
 }
 
 func (widget *Widget) content() (string, string, bool) {
-	title := widget.settings.common.Title
+	title := widget.settings.Title
 	calEvents := widget.calEvents
 
 	if widget.err != nil {

--- a/modules/gcal/display_test.go
+++ b/modules/gcal/display_test.go
@@ -21,25 +21,25 @@ func Test_display_content(t *testing.T) {
 	}{
 		{
 			name:              "Event content without any events",
-			settings:          &Settings{common: &cfg.Common{}},
+			settings:          &Settings{Common: &cfg.Common{}},
 			events:            nil,
 			descriptionWanted: "No calendar events",
 		},
 		{
 			name:              "Event content with a single event, without end times displayed",
-			settings:          &Settings{common: &cfg.Common{}, showEndTime: false},
+			settings:          &Settings{Common: &cfg.Common{}, showEndTime: false},
 			events:            []*CalEvent{NewCalEvent(event)},
 			descriptionWanted: "[]Saturday, Apr 19\n  []01:00 []Foo[white]\n   \n",
 		},
 		{
 			name:              "Event content with a single event without showEndTime explictily set in settings",
-			settings:          &Settings{common: &cfg.Common{}},
+			settings:          &Settings{Common: &cfg.Common{}},
 			events:            []*CalEvent{NewCalEvent(event)},
 			descriptionWanted: "[]Saturday, Apr 19\n  []01:00 []Foo[white]\n   \n",
 		},
 		{
 			name:              "Event content with a single event with end times displayed",
-			settings:          &Settings{common: &cfg.Common{}, showEndTime: true},
+			settings:          &Settings{Common: &cfg.Common{}, showEndTime: true},
 			events:            []*CalEvent{NewCalEvent(event)},
 			descriptionWanted: "[]Saturday, Apr 19\n  []01:00-02:00 []Foo[white]\n   \n",
 		},

--- a/modules/gcal/settings.go
+++ b/modules/gcal/settings.go
@@ -23,7 +23,7 @@ type colors struct {
 // Settings defines the configuration options for this module
 type Settings struct {
 	colors
-	common *cfg.Common
+	*cfg.Common
 
 	conflictIcon          string `help:"The icon displayed beside calendar events that have conflicting times (they intersect or overlap in some way)." values:"Any displayable unicode character." optional:"true"`
 	currentIcon           string `help:"The icon displayed beside the current calendar event." values:"Any displayable unicode character." optional:"true"`
@@ -44,7 +44,7 @@ type Settings struct {
 // NewSettingsFromYAML creates and returns an instance of Settings with configuration options populated
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		conflictIcon:          ymlConfig.UString("conflictIcon", "🚨"),
 		currentIcon:           ymlConfig.UString("currentIcon", "🔸"),
@@ -62,8 +62,9 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 		calendarReadLevel:     ymlConfig.UString("calendarReadLevel", "writer"),
 	}
 
-	settings.colors.day = ymlConfig.UString("colors.day", settings.common.Colors.Subheading)
+	settings.colors.day = ymlConfig.UString("colors.day", settings.Colors.Subheading)
 	settings.colors.description = ymlConfig.UString("colors.description", "white")
+
 	// settings.colors.eventTime is a new feature introduced via issue #638. Prior to this, the color of the event
 	// time was (unintentionally) customized via settings.colors.description. To maintain backwards compatibility
 	// for users who might be already using this to set the color of the event time, we try to determine the default
@@ -72,6 +73,7 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	//
 	// PS: We should have a deprecation plan for supporting this backwards compatibility feature.
 	settings.colors.eventTime = ymlConfig.UString("colors.eventTime", settings.colors.description)
+
 	settings.colors.highlights = ymlConfig.UList("colors.highlights")
 	settings.colors.past = ymlConfig.UString("colors.past", "gray")
 	settings.colors.title = ymlConfig.UString("colors.title", "white")

--- a/modules/gcal/settings.go
+++ b/modules/gcal/settings.go
@@ -78,5 +78,7 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	settings.colors.past = ymlConfig.UString("colors.past", "gray")
 	settings.colors.title = ymlConfig.UString("colors.title", "white")
 
+	settings.SetDocumentationPath("google/gcal")
+
 	return &settings
 }

--- a/modules/gcal/widget.go
+++ b/modules/gcal/widget.go
@@ -16,7 +16,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, nil, settings.common),
+		TextWidget: view.NewTextWidget(app, nil, settings.Common),
 
 		app:      app,
 		settings: settings,

--- a/modules/gcal/widget.go
+++ b/modules/gcal/widget.go
@@ -16,7 +16,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, settings.common),
+		TextWidget: view.NewTextWidget(app, nil, settings.common),
 
 		app:      app,
 		settings: settings,

--- a/modules/gerrit/display.go
+++ b/modules/gerrit/display.go
@@ -22,14 +22,14 @@ func (widget *Widget) content() (string, string, bool) {
 	title = fmt.Sprintf("%s- %s", widget.CommonSettings().Title, widget.title(project))
 
 	_, _, width, _ := widget.View.GetRect()
-	str := widget.settings.common.PaginationMarker(len(widget.GerritProjects), widget.Idx, width) + "\n"
-	str += fmt.Sprintf(" [%s]Stats[white]\n", widget.settings.common.Colors.Subheading)
+	str := widget.settings.PaginationMarker(len(widget.GerritProjects), widget.Idx, width) + "\n"
+	str += fmt.Sprintf(" [%s]Stats[white]\n", widget.settings.Colors.Subheading)
 	str += widget.displayStats(project)
 	str += "\n"
-	str += fmt.Sprintf(" [%s]Open Incoming Reviews[white]\n", widget.settings.common.Colors.Subheading)
+	str += fmt.Sprintf(" [%s]Open Incoming Reviews[white]\n", widget.settings.Colors.Subheading)
 	str += widget.displayMyIncomingReviews(project, widget.settings.username)
 	str += "\n"
-	str += fmt.Sprintf(" [%s]My Outgoing Reviews[white]\n", widget.settings.common.Colors.Subheading)
+	str += fmt.Sprintf(" [%s]My Outgoing Reviews[white]\n", widget.settings.Colors.Subheading)
 	str += widget.displayMyOutgoingReviews(project, widget.settings.username)
 
 	return title, str, false
@@ -72,10 +72,10 @@ func (widget *Widget) displayStats(project *GerritProject) string {
 
 func (widget *Widget) rowColor(idx int) string {
 	if widget.View.HasFocus() && (idx == widget.selected) {
-		return widget.settings.common.DefaultFocusedRowColor()
+		return widget.settings.DefaultFocusedRowColor()
 	}
 
-	return widget.settings.common.RowColor(idx)
+	return widget.settings.RowColor(idx)
 }
 
 func (widget *Widget) title(project *GerritProject) string {

--- a/modules/gerrit/keyboard.go
+++ b/modules/gerrit/keyboard.go
@@ -5,7 +5,7 @@ import (
 )
 
 func (widget *Widget) initializeKeyboardControls() {
-	widget.InitializeCommonControls(widget.Refresh)
+	widget.InitializeRefreshKeyboardControl(widget.Refresh)
 
 	widget.SetKeyboardChar("h", widget.prevProject, "Select previous project")
 	widget.SetKeyboardChar("l", widget.nextProject, "Select next project")

--- a/modules/gerrit/settings.go
+++ b/modules/gerrit/settings.go
@@ -21,7 +21,7 @@ type colors struct {
 
 type Settings struct {
 	colors
-	common *cfg.Common
+	*cfg.Common
 
 	domain                  string        `help:"Your Gerrit corporate domain."`
 	password                string        `help:"Your Gerrit HTTP Password."`
@@ -32,7 +32,7 @@ type Settings struct {
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		domain:                  ymlConfig.UString("domain", ""),
 		password:                ymlConfig.UString("password", os.Getenv("WTF_GERRIT_PASSWORD")),

--- a/modules/gerrit/widget.go
+++ b/modules/gerrit/widget.go
@@ -40,8 +40,6 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 
 	widget.initializeKeyboardControls()
 
-	widget.KeyboardWidget.SetView(widget.View)
-
 	widget.unselect()
 
 	return &widget

--- a/modules/gerrit/widget.go
+++ b/modules/gerrit/widget.go
@@ -31,7 +31,7 @@ var (
 
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, nil, settings.common),
+		TextWidget: view.NewTextWidget(app, nil, settings.Common),
 
 		Idx: 0,
 

--- a/modules/gerrit/widget.go
+++ b/modules/gerrit/widget.go
@@ -13,7 +13,6 @@ import (
 )
 
 type Widget struct {
-	view.KeyboardWidget
 	view.TextWidget
 
 	gerrit *glb.Client
@@ -32,8 +31,7 @@ var (
 
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		KeyboardWidget: view.NewKeyboardWidget(app, pages, settings.common),
-		TextWidget:     view.NewTextWidget(app, settings.common),
+		TextWidget: view.NewTextWidget(app, nil, settings.common),
 
 		Idx: 0,
 
@@ -41,7 +39,6 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 	}
 
 	widget.initializeKeyboardControls()
-	widget.View.SetInputCapture(widget.InputCapture)
 
 	widget.KeyboardWidget.SetView(widget.View)
 
@@ -90,10 +87,6 @@ func (widget *Widget) Refresh() {
 	}
 
 	widget.display()
-}
-
-func (widget *Widget) HelpText() string {
-	return widget.KeyboardWidget.HelpText()
 }
 
 /* -------------------- Unexported Functions -------------------- */

--- a/modules/git/display.go
+++ b/modules/git/display.go
@@ -23,8 +23,8 @@ func (widget *Widget) content() (string, string, bool) {
 	)
 
 	_, _, width, _ := widget.View.GetRect()
-	str := widget.settings.common.PaginationMarker(len(widget.GitRepos), widget.Idx, width) + "\n"
-	str += fmt.Sprintf(" [%s]Branch[white]\n", widget.settings.common.Colors.Subheading)
+	str := widget.settings.PaginationMarker(len(widget.GitRepos), widget.Idx, width) + "\n"
+	str += fmt.Sprintf(" [%s]Branch[white]\n", widget.settings.Colors.Subheading)
 	str += fmt.Sprintf(" %s", repoData.Branch)
 	str += "\n"
 	str += widget.formatChanges(repoData.ChangedFiles)
@@ -35,7 +35,7 @@ func (widget *Widget) content() (string, string, bool) {
 }
 
 func (widget *Widget) formatChanges(data []string) string {
-	str := fmt.Sprintf(" [%s]Changed Files[white]\n", widget.settings.common.Colors.Subheading)
+	str := fmt.Sprintf(" [%s]Changed Files[white]\n", widget.settings.Colors.Subheading)
 
 	if len(data) == 1 {
 		str += " [grey]none[white]\n"
@@ -72,7 +72,7 @@ func (widget *Widget) formatChange(line string) string {
 }
 
 func (widget *Widget) formatCommits(data []string) string {
-	str := fmt.Sprintf(" [%s]Recent Commits[white]\n", widget.settings.common.Colors.Subheading)
+	str := fmt.Sprintf(" [%s]Recent Commits[white]\n", widget.settings.Colors.Subheading)
 
 	for _, line := range data {
 		str += widget.formatCommit(line)

--- a/modules/git/keyboard.go
+++ b/modules/git/keyboard.go
@@ -3,7 +3,7 @@ package git
 import "github.com/gdamore/tcell"
 
 func (widget *Widget) initializeKeyboardControls() {
-	widget.InitializeCommonControls(widget.Refresh)
+	widget.InitializeRefreshKeyboardControl(widget.Refresh)
 
 	widget.SetKeyboardChar("l", widget.NextSource, "Select next source")
 	widget.SetKeyboardChar("h", widget.PrevSource, "Select previous source")

--- a/modules/git/settings.go
+++ b/modules/git/settings.go
@@ -12,7 +12,7 @@ const (
 )
 
 type Settings struct {
-	common *cfg.Common
+	*cfg.Common
 
 	commitCount  int           `help:"The number of past commits to display." values:"A positive integer, 0..n." optional:"true"`
 	commitFormat string        `help:"The string format for the commit message." optional:"true"`
@@ -22,7 +22,7 @@ type Settings struct {
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		commitCount:  ymlConfig.UInt("commitCount", 10),
 		commitFormat: ymlConfig.UString("commitFormat", "[forestgreen]%h [white]%s [grey]%an on %cd[white]"),

--- a/modules/git/settings.go
+++ b/modules/git/settings.go
@@ -36,7 +36,3 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 func (widget *Widget) ConfigText() string {
 	return utils.HelpFromInterface(Settings{})
 }
-
-func (widget *Widget) HelpText() string {
-	return widget.KeyboardWidget.HelpText()
-}

--- a/modules/git/widget.go
+++ b/modules/git/widget.go
@@ -30,8 +30,8 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		MultiSourceWidget: view.NewMultiSourceWidget(settings.common, "repository", "repositories"),
-		TextWidget:        view.NewTextWidget(app, pages, settings.common),
+		MultiSourceWidget: view.NewMultiSourceWidget(settings.Common, "repository", "repositories"),
+		TextWidget:        view.NewTextWidget(app, pages, settings.Common),
 
 		app:      app,
 		pages:    pages,

--- a/modules/git/widget.go
+++ b/modules/git/widget.go
@@ -42,8 +42,6 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 
 	widget.SetDisplayFunction(widget.display)
 
-	widget.KeyboardWidget.SetView(widget.View)
-
 	return &widget
 }
 

--- a/modules/git/widget.go
+++ b/modules/git/widget.go
@@ -18,7 +18,6 @@ const (
 )
 
 type Widget struct {
-	view.KeyboardWidget
 	view.MultiSourceWidget
 	view.TextWidget
 
@@ -31,9 +30,8 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		KeyboardWidget:    view.NewKeyboardWidget(app, pages, settings.common),
 		MultiSourceWidget: view.NewMultiSourceWidget(settings.common, "repository", "repositories"),
-		TextWidget:        view.NewTextWidget(app, settings.common),
+		TextWidget:        view.NewTextWidget(app, pages, settings.common),
 
 		app:      app,
 		pages:    pages,
@@ -41,7 +39,6 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 	}
 
 	widget.initializeKeyboardControls()
-	widget.View.SetInputCapture(widget.InputCapture)
 
 	widget.SetDisplayFunction(widget.display)
 

--- a/modules/github/display.go
+++ b/modules/github/display.go
@@ -35,21 +35,21 @@ func (widget *Widget) content() (string, string, bool) {
 	}
 
 	_, _, width, _ := widget.View.GetRect()
-	str := widget.settings.common.PaginationMarker(len(widget.GithubRepos), widget.Idx, width)
+	str := widget.settings.PaginationMarker(len(widget.GithubRepos), widget.Idx, width)
 	if widget.settings.showStats {
-		str += fmt.Sprintf("\n [%s]Stats[white]\n", widget.settings.common.Colors.Subheading)
+		str += fmt.Sprintf("\n [%s]Stats[white]\n", widget.settings.Colors.Subheading)
 		str += widget.displayStats(repo)
 	}
 	if widget.settings.showOpenReviewRequests {
-		str += fmt.Sprintf("\n [%s]Open Review Requests[white]\n", widget.settings.common.Colors.Subheading)
+		str += fmt.Sprintf("\n [%s]Open Review Requests[white]\n", widget.settings.Colors.Subheading)
 		str += widget.displayMyReviewRequests(repo, username)
 	}
 	if widget.settings.showMyPullRequests {
-		str += fmt.Sprintf("\n [%s]My Pull Requests[white]\n", widget.settings.common.Colors.Subheading)
+		str += fmt.Sprintf("\n [%s]My Pull Requests[white]\n", widget.settings.Colors.Subheading)
 		str += widget.displayMyPullRequests(repo, username)
 	}
 	for _, customQuery := range widget.settings.customQueries {
-		str += fmt.Sprintf("\n [%s]%s[white]\n", widget.settings.common.Colors.Subheading, customQuery.title)
+		str += fmt.Sprintf("\n [%s]%s[white]\n", widget.settings.Colors.Subheading, customQuery.title)
 		str += widget.displayCustomQuery(repo, customQuery.filter, customQuery.perPage)
 	}
 
@@ -139,7 +139,7 @@ func (widget *Widget) displayStats(repo *Repo) string {
 func (widget *Widget) title(repo *Repo) string {
 	return fmt.Sprintf(
 		"[%s]%s - %s[white]",
-		widget.settings.common.Colors.TextTheme.Title,
+		widget.settings.Colors.TextTheme.Title,
 		repo.Owner,
 		repo.Name,
 	)

--- a/modules/github/keyboard.go
+++ b/modules/github/keyboard.go
@@ -5,7 +5,7 @@ import (
 )
 
 func (widget *Widget) initializeKeyboardControls() {
-	widget.InitializeCommonControls(widget.Refresh)
+	widget.InitializeRefreshKeyboardControl(widget.Refresh)
 
 	widget.SetKeyboardChar("j", widget.Next, "Select next item")
 	widget.SetKeyboardChar("k", widget.Prev, "Select previous item")

--- a/modules/github/settings.go
+++ b/modules/github/settings.go
@@ -14,7 +14,7 @@ const (
 
 // Settings defines the configuration properties for this module
 type Settings struct {
-	common *cfg.Common
+	*cfg.Common
 
 	apiKey                 string        `help:"Your GitHub API token."`
 	baseURL                string        `help:"Your GitHub Enterprise API URL." optional:"true"`
@@ -37,7 +37,7 @@ type customQuery struct {
 // NewSettingsFromYAML creates a new settings instance from a YAML config block
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		apiKey:                 ymlConfig.UString("apiKey", ymlConfig.UString("apikey", os.Getenv("WTF_GITHUB_TOKEN"))),
 		baseURL:                ymlConfig.UString("baseURL", os.Getenv("WTF_GITHUB_BASE_URL")),

--- a/modules/github/widget.go
+++ b/modules/github/widget.go
@@ -25,8 +25,8 @@ type Widget struct {
 // NewWidget creates a new instance of the widget
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		MultiSourceWidget: view.NewMultiSourceWidget(settings.common, "repository", "repositories"),
-		TextWidget:        view.NewTextWidget(app, pages, settings.common),
+		MultiSourceWidget: view.NewMultiSourceWidget(settings.Common, "repository", "repositories"),
+		TextWidget:        view.NewTextWidget(app, pages, settings.Common),
 
 		settings: settings,
 	}

--- a/modules/github/widget.go
+++ b/modules/github/widget.go
@@ -34,14 +34,13 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 	widget.GithubRepos = widget.buildRepoCollection(widget.settings.repositories)
 
 	widget.initializeKeyboardControls()
+
 	widget.View.SetRegions(true)
 	widget.SetDisplayFunction(widget.display)
 
 	widget.Unselect()
 
 	widget.Sources = widget.settings.repositories
-
-	widget.KeyboardWidget.SetView(widget.View)
 
 	return &widget
 }

--- a/modules/github/widget.go
+++ b/modules/github/widget.go
@@ -12,7 +12,6 @@ import (
 // Widget define wtf widget to register widget later
 type Widget struct {
 	view.MultiSourceWidget
-	view.KeyboardWidget
 	view.TextWidget
 
 	GithubRepos []*Repo
@@ -26,9 +25,8 @@ type Widget struct {
 // NewWidget creates a new instance of the widget
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		KeyboardWidget:    view.NewKeyboardWidget(app, pages, settings.common),
 		MultiSourceWidget: view.NewMultiSourceWidget(settings.common, "repository", "repositories"),
-		TextWidget:        view.NewTextWidget(app, settings.common),
+		TextWidget:        view.NewTextWidget(app, pages, settings.common),
 
 		settings: settings,
 	}
@@ -37,7 +35,6 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 
 	widget.initializeKeyboardControls()
 	widget.View.SetRegions(true)
-	widget.View.SetInputCapture(widget.InputCapture)
 	widget.SetDisplayFunction(widget.display)
 
 	widget.Unselect()
@@ -101,11 +98,6 @@ func (widget *Widget) Refresh() {
 	}
 
 	widget.display()
-}
-
-// HelpText displays the widgets controls
-func (widget *Widget) HelpText() string {
-	return widget.KeyboardWidget.HelpText()
 }
 
 /* -------------------- Unexported Functions -------------------- */

--- a/modules/gitlab/display.go
+++ b/modules/gitlab/display.go
@@ -39,20 +39,20 @@ func (widget *Widget) content() (string, string, bool) {
 	title := fmt.Sprintf("%s - %s", widget.CommonSettings().Title, widget.title(project))
 
 	_, _, width, _ := widget.View.GetRect()
-	str := widget.settings.common.PaginationMarker(len(widget.GitlabProjects), widget.Idx, width) + "\n"
-	str += fmt.Sprintf(" [%s]Stats[white]\n", widget.settings.common.Colors.Subheading)
+	str := widget.settings.PaginationMarker(len(widget.GitlabProjects), widget.Idx, width) + "\n"
+	str += fmt.Sprintf(" [%s]Stats[white]\n", widget.settings.Colors.Subheading)
 	str += widget.displayStats(project)
 	str += "\n"
-	str += fmt.Sprintf(" [%s]Open Assigned Merge Requests[white]\n", widget.settings.common.Colors.Subheading)
+	str += fmt.Sprintf(" [%s]Open Assigned Merge Requests[white]\n", widget.settings.Colors.Subheading)
 	str += widget.displayMyAssignedMergeRequests(project, widget.settings.username)
 	str += "\n"
-	str += fmt.Sprintf(" [%s]My Merge Requests[white]\n", widget.settings.common.Colors.Subheading)
+	str += fmt.Sprintf(" [%s]My Merge Requests[white]\n", widget.settings.Colors.Subheading)
 	str += widget.displayMyMergeRequests(project, widget.settings.username)
 	str += "\n"
-	str += fmt.Sprintf(" [%s]Open Assigned Issues[white]\n", widget.settings.common.Colors.Subheading)
+	str += fmt.Sprintf(" [%s]Open Assigned Issues[white]\n", widget.settings.Colors.Subheading)
 	str += widget.displayMyAssignedIssues(project, widget.settings.username)
 	str += "\n"
-	str += fmt.Sprintf(" [%s]My Issues[white]\n", widget.settings.common.Colors.Subheading)
+	str += fmt.Sprintf(" [%s]My Issues[white]\n", widget.settings.Colors.Subheading)
 	str += widget.displayMyIssues(project, widget.settings.username)
 
 	return title, str, false

--- a/modules/gitlab/keyboard.go
+++ b/modules/gitlab/keyboard.go
@@ -5,7 +5,7 @@ import (
 )
 
 func (widget *Widget) initializeKeyboardControls() {
-	widget.InitializeCommonControls(widget.Refresh)
+	widget.InitializeRefreshKeyboardControl(widget.Refresh)
 
 	widget.SetKeyboardChar("j", widget.Next, "Select next item")
 	widget.SetKeyboardChar("k", widget.Prev, "Select previous item")

--- a/modules/gitlab/settings.go
+++ b/modules/gitlab/settings.go
@@ -14,7 +14,7 @@ const (
 
 // Settings defines the configuration properties for this module
 type Settings struct {
-	common *cfg.Common
+	*cfg.Common
 
 	apiKey   string   `help:"A GitLab personal access token. Requires at least api access."`
 	domain   string   `help:"Your GitLab corporate domain."`
@@ -25,7 +25,7 @@ type Settings struct {
 // NewSettingsFromYAML creates a new settings instance from a YAML config block
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		apiKey:   ymlConfig.UString("apiKey", ymlConfig.UString("apikey", os.Getenv("WTF_GITLAB_TOKEN"))),
 		domain:   ymlConfig.UString("domain", "https://gitlab.com"),

--- a/modules/gitlab/widget.go
+++ b/modules/gitlab/widget.go
@@ -50,8 +50,6 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 
 	widget.Unselect()
 
-	widget.KeyboardWidget.SetView(widget.View)
-
 	return &widget
 }
 

--- a/modules/gitlab/widget.go
+++ b/modules/gitlab/widget.go
@@ -15,7 +15,6 @@ type ContentItem struct {
 
 type Widget struct {
 	view.MultiSourceWidget
-	view.KeyboardWidget
 	view.TextWidget
 
 	GitlabProjects []*GitlabProject
@@ -34,9 +33,8 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 	context, err := newContext(settings)
 
 	widget := Widget{
-		KeyboardWidget:    view.NewKeyboardWidget(app, pages, settings.common),
 		MultiSourceWidget: view.NewMultiSourceWidget(settings.common, "repository", "repositories"),
-		TextWidget:        view.NewTextWidget(app, settings.common),
+		TextWidget:        view.NewTextWidget(app, pages, settings.common),
 
 		context:  context,
 		settings: settings,
@@ -48,7 +46,6 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 
 	widget.initializeKeyboardControls()
 	widget.View.SetRegions(true)
-	widget.View.SetInputCapture(widget.InputCapture)
 	widget.SetDisplayFunction(widget.display)
 
 	widget.Unselect()
@@ -71,10 +68,6 @@ func (widget *Widget) Refresh() {
 	}
 
 	widget.display()
-}
-
-func (widget *Widget) HelpText() string {
-	return widget.KeyboardWidget.HelpText()
 }
 
 // SetItemCount sets the amount of PRs RRs and other PRs throughout the widgets display creation

--- a/modules/gitlab/widget.go
+++ b/modules/gitlab/widget.go
@@ -33,8 +33,8 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 	context, err := newContext(settings)
 
 	widget := Widget{
-		MultiSourceWidget: view.NewMultiSourceWidget(settings.common, "repository", "repositories"),
-		TextWidget:        view.NewTextWidget(app, pages, settings.common),
+		MultiSourceWidget: view.NewMultiSourceWidget(settings.Common, "repository", "repositories"),
+		TextWidget:        view.NewTextWidget(app, pages, settings.Common),
 
 		context:  context,
 		settings: settings,

--- a/modules/gitlabtodo/settings.go
+++ b/modules/gitlabtodo/settings.go
@@ -13,7 +13,7 @@ const (
 )
 
 type Settings struct {
-	common *cfg.Common
+	*cfg.Common
 
 	numberOfTodos int    `help:"Defines number of stories to be displayed. Default is 10" optional:"true"`
 	apiKey        string `help:"A GitLab personal access token. Requires at least api access."`
@@ -24,7 +24,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		numberOfTodos: ymlConfig.UInt("numberOfTodos", 10),
 		apiKey:        ymlConfig.UString("apiKey", os.Getenv("WTF_GITLAB_TOKEN")),

--- a/modules/gitlabtodo/widget.go
+++ b/modules/gitlabtodo/widget.go
@@ -10,7 +10,6 @@ import (
 )
 
 type Widget struct {
-	view.KeyboardWidget
 	view.ScrollableWidget
 
 	todos        []*gitlab.Todo
@@ -21,8 +20,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := &Widget{
-		KeyboardWidget:   view.NewKeyboardWidget(app, pages, settings.common),
-		ScrollableWidget: view.NewScrollableWidget(app, settings.common),
+		ScrollableWidget: view.NewScrollableWidget(app, pages, settings.common),
 
 		settings: settings,
 	}
@@ -31,7 +29,6 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 
 	widget.SetRenderFunction(widget.Render)
 	widget.initializeKeyboardControls()
-	widget.View.SetInputCapture(widget.InputCapture)
 
 	widget.KeyboardWidget.SetView(widget.View)
 

--- a/modules/gitlabtodo/widget.go
+++ b/modules/gitlabtodo/widget.go
@@ -20,7 +20,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := &Widget{
-		ScrollableWidget: view.NewScrollableWidget(app, pages, settings.common),
+		ScrollableWidget: view.NewScrollableWidget(app, pages, settings.Common),
 
 		settings: settings,
 	}

--- a/modules/gitlabtodo/widget.go
+++ b/modules/gitlabtodo/widget.go
@@ -30,8 +30,6 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 	widget.SetRenderFunction(widget.Render)
 	widget.initializeKeyboardControls()
 
-	widget.KeyboardWidget.SetView(widget.View)
-
 	return widget
 }
 

--- a/modules/gitter/keyboard.go
+++ b/modules/gitter/keyboard.go
@@ -3,7 +3,7 @@ package gitter
 import "github.com/gdamore/tcell"
 
 func (widget *Widget) initializeKeyboardControls() {
-	widget.InitializeCommonControls(widget.Refresh)
+	widget.InitializeRefreshKeyboardControl(widget.Refresh)
 
 	widget.SetKeyboardChar("j", widget.Next, "Select next item")
 	widget.SetKeyboardChar("k", widget.Prev, "Select previous item")

--- a/modules/gitter/settings.go
+++ b/modules/gitter/settings.go
@@ -13,7 +13,7 @@ const (
 )
 
 type Settings struct {
-	common *cfg.Common
+	*cfg.Common
 
 	apiToken         string `help:"Your Gitter Personal Access Token."`
 	numberOfMessages int    `help:"Maximum number of (newest) messages to be displayed. Default is 10" optional:"true"`
@@ -23,7 +23,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		apiToken:         ymlConfig.UString("apiToken", os.Getenv("WTF_GITTER_API_TOKEN")),
 		numberOfMessages: ymlConfig.UInt("numberOfMessages", 10),

--- a/modules/gitter/widget.go
+++ b/modules/gitter/widget.go
@@ -19,7 +19,7 @@ type Widget struct {
 // NewWidget creates a new instance of a widget
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		ScrollableWidget: view.NewScrollableWidget(app, pages, settings.common),
+		ScrollableWidget: view.NewScrollableWidget(app, pages, settings.Common),
 
 		settings: settings,
 	}

--- a/modules/gitter/widget.go
+++ b/modules/gitter/widget.go
@@ -10,7 +10,6 @@ import (
 
 // A Widget represents a Gitter widget
 type Widget struct {
-	view.KeyboardWidget
 	view.ScrollableWidget
 
 	messages []Message
@@ -20,15 +19,13 @@ type Widget struct {
 // NewWidget creates a new instance of a widget
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		KeyboardWidget:   view.NewKeyboardWidget(app, pages, settings.common),
-		ScrollableWidget: view.NewScrollableWidget(app, settings.common),
+		ScrollableWidget: view.NewScrollableWidget(app, pages, settings.common),
 
 		settings: settings,
 	}
 
 	widget.SetRenderFunction(widget.Refresh)
 	widget.initializeKeyboardControls()
-	widget.View.SetInputCapture(widget.InputCapture)
 
 	widget.KeyboardWidget.SetView(widget.View)
 
@@ -63,10 +60,6 @@ func (widget *Widget) Refresh() {
 	widget.SetItemCount(len(messages))
 
 	widget.display()
-}
-
-func (widget *Widget) HelpText() string {
-	return widget.KeyboardWidget.HelpText()
 }
 
 /* -------------------- Unexported Functions -------------------- */

--- a/modules/gitter/widget.go
+++ b/modules/gitter/widget.go
@@ -27,8 +27,6 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 	widget.SetRenderFunction(widget.Refresh)
 	widget.initializeKeyboardControls()
 
-	widget.KeyboardWidget.SetView(widget.View)
-
 	return &widget
 }
 

--- a/modules/googleanalytics/settings.go
+++ b/modules/googleanalytics/settings.go
@@ -30,5 +30,7 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 		enableRealtime: ymlConfig.UBool("enableRealtime", false),
 	}
 
+	settings.SetDocumentationPath("google/analytics")
+
 	return &settings
 }

--- a/modules/googleanalytics/settings.go
+++ b/modules/googleanalytics/settings.go
@@ -11,7 +11,7 @@ const (
 )
 
 type Settings struct {
-	common *cfg.Common
+	*cfg.Common
 
 	months         int
 	secretFile     string `help:"Your Google client secret JSON file." values:"A string representing a file path to the JSON secret file."`
@@ -22,7 +22,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		months:         ymlConfig.UInt("months"),
 		secretFile:     ymlConfig.UString("secretFile"),

--- a/modules/googleanalytics/widget.go
+++ b/modules/googleanalytics/widget.go
@@ -13,7 +13,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, nil, settings.common),
+		TextWidget: view.NewTextWidget(app, nil, settings.Common),
 
 		settings: settings,
 	}

--- a/modules/googleanalytics/widget.go
+++ b/modules/googleanalytics/widget.go
@@ -13,7 +13,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, settings.common),
+		TextWidget: view.NewTextWidget(app, nil, settings.common),
 
 		settings: settings,
 	}

--- a/modules/grafana/settings.go
+++ b/modules/grafana/settings.go
@@ -15,7 +15,7 @@ const (
 )
 
 type Settings struct {
-	common *cfg.Common
+	*cfg.Common
 
 	apiKey  string `help:"Your Grafana API token."`
 	baseURI string `help:"Base url of your grafana instance"`
@@ -24,7 +24,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		apiKey:  ymlConfig.UString("apiKey", os.Getenv("WTF_GRAFANA_API_KEY")),
 		baseURI: ymlConfig.UString("baseUri", ""),

--- a/modules/grafana/widget.go
+++ b/modules/grafana/widget.go
@@ -33,8 +33,6 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 	widget.initializeKeyboardControls()
 	widget.View.SetRegions(true)
 
-	widget.KeyboardWidget.SetView(widget.View)
-
 	return &widget
 }
 

--- a/modules/grafana/widget.go
+++ b/modules/grafana/widget.go
@@ -10,7 +10,6 @@ import (
 )
 
 type Widget struct {
-	view.KeyboardWidget
 	view.TextWidget
 
 	Client   *Client
@@ -23,8 +22,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		KeyboardWidget: view.NewKeyboardWidget(app, pages, settings.common),
-		TextWidget:     view.NewTextWidget(app, settings.common),
+		TextWidget: view.NewTextWidget(app, nil, settings.common),
 
 		Client:   NewClient(settings),
 		Selected: -1,
@@ -34,7 +32,6 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 
 	widget.initializeKeyboardControls()
 	widget.View.SetRegions(true)
-	widget.View.SetInputCapture(widget.InputCapture)
 
 	widget.KeyboardWidget.SetView(widget.View)
 
@@ -90,10 +87,6 @@ func (widget *Widget) Unselect() {
 }
 
 /* -------------------- Unexported Functions -------------------- */
-
-func (widget *Widget) HelpText() string {
-	return widget.KeyboardWidget.HelpText()
-}
 
 func (widget *Widget) openAlert() {
 	currentSelection := widget.View.GetHighlights()

--- a/modules/grafana/widget.go
+++ b/modules/grafana/widget.go
@@ -22,7 +22,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, nil, settings.common),
+		TextWidget: view.NewTextWidget(app, nil, settings.Common),
 
 		Client:   NewClient(settings),
 		Selected: -1,

--- a/modules/gspreadsheets/settings.go
+++ b/modules/gspreadsheets/settings.go
@@ -36,5 +36,7 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 
 	settings.colors.values = ymlConfig.UString("colors.values", "green")
 
+	settings.SetDocumentationPath("google/spreadsheet")
+
 	return &settings
 }

--- a/modules/gspreadsheets/settings.go
+++ b/modules/gspreadsheets/settings.go
@@ -16,7 +16,7 @@ type colors struct {
 
 type Settings struct {
 	colors
-	common *cfg.Common
+	*cfg.Common
 
 	cellAddresses []interface{}
 	cellNames     []interface{}
@@ -27,7 +27,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		cellNames:  ymlConfig.UList("cells.names"),
 		secretFile: ymlConfig.UString("secretFile"),

--- a/modules/gspreadsheets/widget.go
+++ b/modules/gspreadsheets/widget.go
@@ -19,7 +19,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, settings.common),
+		TextWidget: view.NewTextWidget(app, nil, settings.common),
 
 		settings: settings,
 	}

--- a/modules/gspreadsheets/widget.go
+++ b/modules/gspreadsheets/widget.go
@@ -19,7 +19,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, nil, settings.common),
+		TextWidget: view.NewTextWidget(app, nil, settings.Common),
 
 		settings: settings,
 	}

--- a/modules/hackernews/keyboard.go
+++ b/modules/hackernews/keyboard.go
@@ -3,7 +3,7 @@ package hackernews
 import "github.com/gdamore/tcell"
 
 func (widget *Widget) initializeKeyboardControls() {
-	widget.InitializeCommonControls(widget.Refresh)
+	widget.InitializeRefreshKeyboardControl(widget.Refresh)
 
 	widget.SetKeyboardChar("j", widget.Next, "Select next item")
 	widget.SetKeyboardChar("k", widget.Prev, "Select previous item")

--- a/modules/hackernews/settings.go
+++ b/modules/hackernews/settings.go
@@ -11,7 +11,7 @@ const (
 )
 
 type Settings struct {
-	common *cfg.Common
+	*cfg.Common
 
 	numberOfStories int    `help:"Defines number of stories to be displayed. Default is 10" optional:"true"`
 	storyType       string `help:"Category of story to see" values:"new, top, job, ask" optional:"true"`
@@ -20,7 +20,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		numberOfStories: ymlConfig.UInt("numberOfStories", 10),
 		storyType:       ymlConfig.UString("storyType", "top"),

--- a/modules/hackernews/widget.go
+++ b/modules/hackernews/widget.go
@@ -28,8 +28,6 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 	widget.SetRenderFunction(widget.Render)
 	widget.initializeKeyboardControls()
 
-	widget.KeyboardWidget.SetView(widget.View)
-
 	return widget
 }
 

--- a/modules/hackernews/widget.go
+++ b/modules/hackernews/widget.go
@@ -11,7 +11,6 @@ import (
 )
 
 type Widget struct {
-	view.KeyboardWidget
 	view.ScrollableWidget
 
 	stories  []Story
@@ -21,15 +20,13 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := &Widget{
-		KeyboardWidget:   view.NewKeyboardWidget(app, pages, settings.common),
-		ScrollableWidget: view.NewScrollableWidget(app, settings.common),
+		ScrollableWidget: view.NewScrollableWidget(app, pages, settings.common),
 
 		settings: settings,
 	}
 
 	widget.SetRenderFunction(widget.Render)
 	widget.initializeKeyboardControls()
-	widget.View.SetInputCapture(widget.InputCapture)
 
 	widget.KeyboardWidget.SetView(widget.View)
 

--- a/modules/hackernews/widget.go
+++ b/modules/hackernews/widget.go
@@ -20,7 +20,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := &Widget{
-		ScrollableWidget: view.NewScrollableWidget(app, pages, settings.common),
+		ScrollableWidget: view.NewScrollableWidget(app, pages, settings.Common),
 
 		settings: settings,
 	}

--- a/modules/hibp/settings.go
+++ b/modules/hibp/settings.go
@@ -23,7 +23,7 @@ type colors struct {
 // Settings defines the configuration properties for this module
 type Settings struct {
 	colors
-	common *cfg.Common
+	*cfg.Common
 
 	accounts []string `help:"A list of the accounts to check the HIBP database for."`
 	apiKey   string   `help:"Your HIBP API v3 API key"`
@@ -33,7 +33,7 @@ type Settings struct {
 // NewSettingsFromYAML creates a new settings instance from a YAML config block
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := &Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		apiKey:   ymlConfig.UString("apiKey", ymlConfig.UString("apikey", os.Getenv("WTF_HIBP_TOKEN"))),
 		accounts: utils.ToStrs(ymlConfig.UList("accounts")),
@@ -47,8 +47,8 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 
 	// HIBP data doesn't need to be reloaded very often so to be gentle on this API we
 	// enforce a minimum refresh interval
-	if settings.common.RefreshInterval < minRefreshInterval {
-		settings.common.RefreshInterval = minRefreshInterval
+	if settings.RefreshInterval < minRefreshInterval {
+		settings.RefreshInterval = minRefreshInterval
 	}
 
 	return settings

--- a/modules/hibp/widget.go
+++ b/modules/hibp/widget.go
@@ -19,7 +19,7 @@ type Widget struct {
 // NewWidget creates a new instance of a widget
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := &Widget{
-		TextWidget: view.NewTextWidget(app, settings.common),
+		TextWidget: view.NewTextWidget(app, nil, settings.common),
 
 		settings: settings,
 	}

--- a/modules/hibp/widget.go
+++ b/modules/hibp/widget.go
@@ -19,7 +19,7 @@ type Widget struct {
 // NewWidget creates a new instance of a widget
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := &Widget{
-		TextWidget: view.NewTextWidget(app, nil, settings.common),
+		TextWidget: view.NewTextWidget(app, nil, settings.Common),
 
 		settings: settings,
 	}

--- a/modules/ipaddresses/ipapi/settings.go
+++ b/modules/ipaddresses/ipapi/settings.go
@@ -17,13 +17,13 @@ type colors struct {
 
 type Settings struct {
 	colors
-	common *cfg.Common
+	*cfg.Common
 }
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 	}
 
 	settings.colors.name = ymlConfig.UString("colors.name", "red")

--- a/modules/ipaddresses/ipapi/settings.go
+++ b/modules/ipaddresses/ipapi/settings.go
@@ -29,5 +29,7 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	settings.colors.name = ymlConfig.UString("colors.name", "red")
 	settings.colors.value = ymlConfig.UString("colors.value", "white")
 
+	settings.SetDocumentationPath("ipaddress/ipapi")
+
 	return &settings
 }

--- a/modules/ipaddresses/ipapi/widget.go
+++ b/modules/ipaddresses/ipapi/widget.go
@@ -38,7 +38,7 @@ type ipinfo struct {
 // NewWidget constructor
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, settings.common),
+		TextWidget: view.NewTextWidget(app, nil, settings.common),
 
 		settings: settings,
 	}

--- a/modules/ipaddresses/ipapi/widget.go
+++ b/modules/ipaddresses/ipapi/widget.go
@@ -38,7 +38,7 @@ type ipinfo struct {
 // NewWidget constructor
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, nil, settings.common),
+		TextWidget: view.NewTextWidget(app, nil, settings.Common),
 
 		settings: settings,
 	}

--- a/modules/ipaddresses/ipinfo/settings.go
+++ b/modules/ipaddresses/ipinfo/settings.go
@@ -11,12 +11,12 @@ const (
 )
 
 type Settings struct {
-	common *cfg.Common
+	*cfg.Common
 }
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 	}
 
 	return &settings

--- a/modules/ipaddresses/ipinfo/settings.go
+++ b/modules/ipaddresses/ipinfo/settings.go
@@ -19,5 +19,7 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 	}
 
+	settings.SetDocumentationPath("ipaddress/ipinfo")
+
 	return &settings
 }

--- a/modules/ipaddresses/ipinfo/widget.go
+++ b/modules/ipaddresses/ipinfo/widget.go
@@ -32,7 +32,7 @@ type ipinfo struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, settings.common),
+		TextWidget: view.NewTextWidget(app, nil, settings.common),
 
 		settings: settings,
 	}

--- a/modules/ipaddresses/ipinfo/widget.go
+++ b/modules/ipaddresses/ipinfo/widget.go
@@ -32,7 +32,7 @@ type ipinfo struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, nil, settings.common),
+		TextWidget: view.NewTextWidget(app, nil, settings.Common),
 
 		settings: settings,
 	}
@@ -96,8 +96,8 @@ func (widget *Widget) setResult(info *ipinfo) {
 	resultBuffer := new(bytes.Buffer)
 
 	err := resultTemplate.Execute(resultBuffer, map[string]string{
-		"subheadingColor": widget.settings.common.Colors.Subheading,
-		"valueColor":      widget.settings.common.Colors.Text,
+		"subheadingColor": widget.settings.Colors.Subheading,
+		"valueColor":      widget.settings.Colors.Text,
 		"Ip":              info.Ip,
 		"Hostname":        info.Hostname,
 		"City":            info.City,

--- a/modules/jenkins/keyboard.go
+++ b/modules/jenkins/keyboard.go
@@ -3,7 +3,7 @@ package jenkins
 import "github.com/gdamore/tcell"
 
 func (widget *Widget) initializeKeyboardControls() {
-	widget.InitializeCommonControls(widget.Refresh)
+	widget.InitializeRefreshKeyboardControl(widget.Refresh)
 
 	widget.SetKeyboardChar("j", widget.Next, "Select next item")
 	widget.SetKeyboardChar("k", widget.Prev, "Select previous item")

--- a/modules/jenkins/settings.go
+++ b/modules/jenkins/settings.go
@@ -13,7 +13,7 @@ const (
 )
 
 type Settings struct {
-	common *cfg.Common
+	*cfg.Common
 
 	apiKey                  string `help:"Your Jenkins API key."`
 	jobNameRegex            string `help:"A regex that filters the jobs shown in the widget." optional:"true"`
@@ -26,7 +26,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		apiKey:                  ymlConfig.UString("apiKey", ymlConfig.UString("apikey", os.Getenv("WTF_JENKINS_API_KEY"))),
 		jobNameRegex:            ymlConfig.UString("jobNameRegex", ".*"),

--- a/modules/jenkins/widget.go
+++ b/modules/jenkins/widget.go
@@ -10,7 +10,6 @@ import (
 )
 
 type Widget struct {
-	view.KeyboardWidget
 	view.ScrollableWidget
 
 	settings *Settings
@@ -20,15 +19,13 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		KeyboardWidget:   view.NewKeyboardWidget(app, pages, settings.common),
-		ScrollableWidget: view.NewScrollableWidget(app, settings.common),
+		ScrollableWidget: view.NewScrollableWidget(app, pages, settings.common),
 
 		settings: settings,
 	}
 
 	widget.SetRenderFunction(widget.Render)
 	widget.initializeKeyboardControls()
-	widget.View.SetInputCapture(widget.InputCapture)
 
 	widget.KeyboardWidget.SetView(widget.View)
 

--- a/modules/jenkins/widget.go
+++ b/modules/jenkins/widget.go
@@ -19,7 +19,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		ScrollableWidget: view.NewScrollableWidget(app, pages, settings.common),
+		ScrollableWidget: view.NewScrollableWidget(app, pages, settings.Common),
 
 		settings: settings,
 	}

--- a/modules/jenkins/widget.go
+++ b/modules/jenkins/widget.go
@@ -27,8 +27,6 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 	widget.SetRenderFunction(widget.Render)
 	widget.initializeKeyboardControls()
 
-	widget.KeyboardWidget.SetView(widget.View)
-
 	return &widget
 }
 

--- a/modules/jira/keyboard.go
+++ b/modules/jira/keyboard.go
@@ -5,7 +5,7 @@ import (
 )
 
 func (widget *Widget) initializeKeyboardControls() {
-	widget.InitializeCommonControls(widget.Refresh)
+	widget.InitializeRefreshKeyboardControl(widget.Refresh)
 
 	widget.SetKeyboardChar("j", widget.Next, "Select next item")
 	widget.SetKeyboardChar("k", widget.Prev, "Select previous item")

--- a/modules/jira/settings.go
+++ b/modules/jira/settings.go
@@ -21,7 +21,7 @@ type colors struct {
 
 type Settings struct {
 	colors
-	common *cfg.Common
+	*cfg.Common
 
 	apiKey                  string   `help:"Your Jira API key (or password for basic auth)."`
 	domain                  string   `help:"Your Jira corporate domain."`
@@ -35,7 +35,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		apiKey:                  ymlConfig.UString("apiKey", ymlConfig.UString("apikey", os.Getenv("WTF_JIRA_API_KEY"))),
 		domain:                  ymlConfig.UString("domain"),

--- a/modules/jira/widget.go
+++ b/modules/jira/widget.go
@@ -18,7 +18,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		ScrollableWidget: view.NewScrollableWidget(app, pages, settings.common),
+		ScrollableWidget: view.NewScrollableWidget(app, pages, settings.Common),
 
 		settings: settings,
 	}
@@ -74,7 +74,7 @@ func (widget *Widget) content() (string, string, bool) {
 
 	title := widget.CommonSettings().Title
 
-	str := fmt.Sprintf(" [%s]Assigned Issues[white]\n", widget.settings.common.Colors.Subheading)
+	str := fmt.Sprintf(" [%s]Assigned Issues[white]\n", widget.settings.Colors.Subheading)
 
 	if widget.result == nil || len(widget.result.Issues) == 0 {
 		return title, "No results to display", false

--- a/modules/jira/widget.go
+++ b/modules/jira/widget.go
@@ -9,7 +9,6 @@ import (
 )
 
 type Widget struct {
-	view.KeyboardWidget
 	view.ScrollableWidget
 
 	result   *SearchResult
@@ -19,15 +18,13 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		KeyboardWidget:   view.NewKeyboardWidget(app, pages, settings.common),
-		ScrollableWidget: view.NewScrollableWidget(app, settings.common),
+		ScrollableWidget: view.NewScrollableWidget(app, pages, settings.common),
 
 		settings: settings,
 	}
 
 	widget.SetRenderFunction(widget.Render)
 	widget.initializeKeyboardControls()
-	widget.View.SetInputCapture(widget.InputCapture)
 
 	widget.KeyboardWidget.SetView(widget.View)
 

--- a/modules/jira/widget.go
+++ b/modules/jira/widget.go
@@ -26,8 +26,6 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 	widget.SetRenderFunction(widget.Render)
 	widget.initializeKeyboardControls()
 
-	widget.KeyboardWidget.SetView(widget.View)
-
 	return &widget
 }
 

--- a/modules/kubernetes/settings.go
+++ b/modules/kubernetes/settings.go
@@ -12,7 +12,7 @@ const (
 )
 
 type Settings struct {
-	common *cfg.Common
+	*cfg.Common
 
 	objects    []string `help:"Kubernetes objects to show. Options are: [nodes, pods, deployments]."`
 	title      string   `help:"Override the title of widget."`
@@ -24,7 +24,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, moduleConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, moduleConfig, globalConfig),
+		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, moduleConfig, globalConfig),
 
 		objects:    utils.ToStrs(moduleConfig.UList("objects")),
 		title:      moduleConfig.UString("title"),

--- a/modules/kubernetes/widget.go
+++ b/modules/kubernetes/widget.go
@@ -25,7 +25,7 @@ type Widget struct {
 // NewWidget creates a new instance of the widget
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, settings.common),
+		TextWidget: view.NewTextWidget(app, nil, settings.common),
 
 		objects:    settings.objects,
 		title:      settings.title,

--- a/modules/kubernetes/widget.go
+++ b/modules/kubernetes/widget.go
@@ -25,7 +25,7 @@ type Widget struct {
 // NewWidget creates a new instance of the widget
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, nil, settings.common),
+		TextWidget: view.NewTextWidget(app, nil, settings.Common),
 
 		objects:    settings.objects,
 		title:      settings.title,
@@ -58,7 +58,7 @@ func (widget *Widget) Refresh() {
 			widget.Redraw(func() (string, string, bool) { return title, "[red] Error getting node data [white]\n", true })
 			return
 		}
-		content += fmt.Sprintf("[%s]Nodes[white]\n", widget.settings.common.Colors.Subheading)
+		content += fmt.Sprintf("[%s]Nodes[white]\n", widget.settings.Colors.Subheading)
 		for _, node := range nodeList {
 			content += fmt.Sprintf("%s\n", node)
 		}
@@ -71,7 +71,7 @@ func (widget *Widget) Refresh() {
 			widget.Redraw(func() (string, string, bool) { return title, "[red] Error getting deployment data [white]\n", true })
 			return
 		}
-		content += fmt.Sprintf("[%s]Deployments[white]\n", widget.settings.common.Colors.Subheading)
+		content += fmt.Sprintf("[%s]Deployments[white]\n", widget.settings.Colors.Subheading)
 		for _, deployment := range deploymentList {
 			content += fmt.Sprintf("%s\n", deployment)
 		}
@@ -84,7 +84,7 @@ func (widget *Widget) Refresh() {
 			widget.Redraw(func() (string, string, bool) { return title, "[red] Error getting pod data [white]\n", false })
 			return
 		}
-		content += fmt.Sprintf("[%s]Pods[white]\n", widget.settings.common.Colors.Subheading)
+		content += fmt.Sprintf("[%s]Pods[white]\n", widget.settings.Colors.Subheading)
 		for _, pod := range podList {
 			content += fmt.Sprintf("%s\n", pod)
 		}

--- a/modules/logger/settings.go
+++ b/modules/logger/settings.go
@@ -11,12 +11,12 @@ const (
 )
 
 type Settings struct {
-	common *cfg.Common
+	*cfg.Common
 }
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 	}
 
 	return &settings

--- a/modules/logger/widget.go
+++ b/modules/logger/widget.go
@@ -24,7 +24,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, nil, settings.common),
+		TextWidget: view.NewTextWidget(app, nil, settings.Common),
 
 		app:      app,
 		filePath: log.LogFilePath(),

--- a/modules/logger/widget.go
+++ b/modules/logger/widget.go
@@ -24,7 +24,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, settings.common),
+		TextWidget: view.NewTextWidget(app, nil, settings.common),
 
 		app:      app,
 		filePath: log.LogFilePath(),

--- a/modules/mercurial/display.go
+++ b/modules/mercurial/display.go
@@ -18,13 +18,13 @@ func (widget *Widget) content() (string, string, bool) {
 
 	title := fmt.Sprintf(
 		"%s - %s[white]",
-		widget.settings.common.Colors.TextTheme.Title,
+		widget.settings.Colors.TextTheme.Title,
 		repoData.Repository,
 	)
 
 	_, _, width, _ := widget.View.GetRect()
-	str := widget.settings.common.PaginationMarker(len(widget.Data), widget.Idx, width) + "\n"
-	str += fmt.Sprintf(" [%s]Branch:Bookmark[white]\n", widget.settings.common.Colors.Subheading)
+	str := widget.settings.PaginationMarker(len(widget.Data), widget.Idx, width) + "\n"
+	str += fmt.Sprintf(" [%s]Branch:Bookmark[white]\n", widget.settings.Colors.Subheading)
 	str += fmt.Sprintf(" %s:%s\n", repoData.Branch, repoData.Bookmark)
 	str += "\n"
 	str += widget.formatChanges(repoData.ChangedFiles)
@@ -35,7 +35,7 @@ func (widget *Widget) content() (string, string, bool) {
 }
 
 func (widget *Widget) formatChanges(data []string) string {
-	str := fmt.Sprintf(" [%s]Changed Files[white]\n", widget.settings.common.Colors.Subheading)
+	str := fmt.Sprintf(" [%s]Changed Files[white]\n", widget.settings.Colors.Subheading)
 
 	if len(data) == 1 {
 		str += " [grey]none[white]\n"
@@ -72,7 +72,7 @@ func (widget *Widget) formatChange(line string) string {
 }
 
 func (widget *Widget) formatCommits(data []string) string {
-	str := fmt.Sprintf(" [%s]Recent Commits[white]\n", widget.settings.common.Colors.Subheading)
+	str := fmt.Sprintf(" [%s]Recent Commits[white]\n", widget.settings.Colors.Subheading)
 
 	for _, line := range data {
 		str += widget.formatCommit(line)

--- a/modules/mercurial/keyboard.go
+++ b/modules/mercurial/keyboard.go
@@ -3,7 +3,7 @@ package mercurial
 import "github.com/gdamore/tcell"
 
 func (widget *Widget) initializeKeyboardControls() {
-	widget.InitializeCommonControls(widget.Refresh)
+	widget.InitializeRefreshKeyboardControl(widget.Refresh)
 
 	widget.SetKeyboardChar("l", widget.NextSource, "Select next source")
 	widget.SetKeyboardChar("h", widget.PrevSource, "Select previous source")

--- a/modules/mercurial/settings.go
+++ b/modules/mercurial/settings.go
@@ -11,7 +11,7 @@ const (
 )
 
 type Settings struct {
-	common *cfg.Common
+	*cfg.Common
 
 	commitCount  int           `help:"The number of past commits to display." optional:"true"`
 	commitFormat string        `help:"The string format for the commit message." optional:"true"`
@@ -21,7 +21,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		commitCount:  ymlConfig.UInt("commitCount", 10),
 		commitFormat: ymlConfig.UString("commitFormat", "[forestgreen]{rev}:{phase} [white]{desc|firstline|strip} [grey]{author|person} {date|age}[white]"),

--- a/modules/mercurial/widget.go
+++ b/modules/mercurial/widget.go
@@ -15,7 +15,6 @@ const (
 
 // A Widget represents a Mercurial widget
 type Widget struct {
-	view.KeyboardWidget
 	view.MultiSourceWidget
 	view.TextWidget
 
@@ -28,9 +27,8 @@ type Widget struct {
 // NewWidget creates a new instance of a widget
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		KeyboardWidget:    view.NewKeyboardWidget(app, pages, settings.common),
 		MultiSourceWidget: view.NewMultiSourceWidget(settings.common, "repository", "repositories"),
-		TextWidget:        view.NewTextWidget(app, settings.common),
+		TextWidget:        view.NewTextWidget(app, pages, settings.common),
 
 		app:      app,
 		pages:    pages,
@@ -40,7 +38,6 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 	widget.SetDisplayFunction(widget.display)
 
 	widget.initializeKeyboardControls()
-	widget.View.SetInputCapture(widget.InputCapture)
 
 	widget.KeyboardWidget.SetView(widget.View)
 
@@ -80,10 +77,6 @@ func (widget *Widget) Refresh() {
 	widget.Data = widget.mercurialRepos(repoPaths)
 
 	widget.display()
-}
-
-func (widget *Widget) HelpText() string {
-	return widget.KeyboardWidget.HelpText()
 }
 
 /* -------------------- Unexported Functions -------------------- */

--- a/modules/mercurial/widget.go
+++ b/modules/mercurial/widget.go
@@ -27,8 +27,8 @@ type Widget struct {
 // NewWidget creates a new instance of a widget
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		MultiSourceWidget: view.NewMultiSourceWidget(settings.common, "repository", "repositories"),
-		TextWidget:        view.NewTextWidget(app, pages, settings.common),
+		MultiSourceWidget: view.NewMultiSourceWidget(settings.Common, "repository", "repositories"),
+		TextWidget:        view.NewTextWidget(app, pages, settings.Common),
 
 		app:      app,
 		pages:    pages,

--- a/modules/mercurial/widget.go
+++ b/modules/mercurial/widget.go
@@ -39,8 +39,6 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 
 	widget.initializeKeyboardControls()
 
-	widget.KeyboardWidget.SetView(widget.View)
-
 	return &widget
 }
 

--- a/modules/nbascore/keyboard.go
+++ b/modules/nbascore/keyboard.go
@@ -3,7 +3,7 @@ package nbascore
 import "github.com/gdamore/tcell"
 
 func (widget *Widget) initializeKeyboardControls() {
-	widget.InitializeCommonControls(widget.Refresh)
+	widget.InitializeRefreshKeyboardControl(widget.Refresh)
 
 	widget.SetKeyboardChar("l", widget.next, "Select next item")
 	widget.SetKeyboardChar("h", widget.prev, "Select previous item")

--- a/modules/nbascore/settings.go
+++ b/modules/nbascore/settings.go
@@ -11,12 +11,12 @@ const (
 )
 
 type Settings struct {
-	common *cfg.Common
+	*cfg.Common
 }
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 	}
 
 	return &settings

--- a/modules/nbascore/settings.go
+++ b/modules/nbascore/settings.go
@@ -19,5 +19,7 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 	}
 
+	settings.SetDocumentationPath("sports/nbascore")
+
 	return &settings
 }

--- a/modules/nbascore/widget.go
+++ b/modules/nbascore/widget.go
@@ -35,8 +35,6 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 
 	widget.View.SetScrollable(true)
 
-	widget.KeyboardWidget.SetView(widget.View)
-
 	return &widget
 }
 

--- a/modules/nbascore/widget.go
+++ b/modules/nbascore/widget.go
@@ -17,7 +17,6 @@ var offset = 0
 
 // A Widget represents an NBA Score  widget
 type Widget struct {
-	view.KeyboardWidget
 	view.TextWidget
 
 	language string
@@ -27,14 +26,12 @@ type Widget struct {
 // NewWidget creates a new instance of a widget
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		KeyboardWidget: view.NewKeyboardWidget(app, pages, settings.common),
-		TextWidget:     view.NewTextWidget(app, settings.common),
+		TextWidget: view.NewTextWidget(app, pages, settings.common),
 
 		settings: settings,
 	}
 
 	widget.initializeKeyboardControls()
-	widget.View.SetInputCapture(widget.InputCapture)
 
 	widget.View.SetScrollable(true)
 
@@ -45,10 +42,6 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 
 func (widget *Widget) Refresh() {
 	widget.Redraw(widget.nbascore)
-}
-
-func (widget *Widget) HelpText() string {
-	return widget.KeyboardWidget.HelpText()
 }
 
 func (widget *Widget) nbascore() (string, string, bool) {

--- a/modules/nbascore/widget.go
+++ b/modules/nbascore/widget.go
@@ -26,7 +26,7 @@ type Widget struct {
 // NewWidget creates a new instance of a widget
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, pages, settings.common),
+		TextWidget: view.NewTextWidget(app, pages, settings.Common),
 
 		settings: settings,
 	}
@@ -73,7 +73,7 @@ func (widget *Widget) nbascore() (string, string, bool) {
 		return title, err.Error(), true
 	}
 
-	allGame := fmt.Sprintf(" [%s]", widget.settings.common.Colors.Subheading) + (cur.Format(utils.FriendlyDateFormat) + "\n\n") + "[white]"
+	allGame := fmt.Sprintf(" [%s]", widget.settings.Colors.Subheading) + (cur.Format(utils.FriendlyDateFormat) + "\n\n") + "[white]"
 
 	for _, game := range result["games"].([]interface{}) {
 		vTeam, hTeam, vScore, hScore := "", "", "", ""

--- a/modules/newrelic/display.go
+++ b/modules/newrelic/display.go
@@ -39,7 +39,7 @@ func (widget *Widget) contentFrom(deploys []nr.ApplicationDeployment) string {
 		" %s\n",
 		fmt.Sprintf(
 			"[%s]Latest Deploys[white]",
-			widget.settings.common.Colors.Subheading,
+			widget.settings.Colors.Subheading,
 		),
 	)
 

--- a/modules/newrelic/settings.go
+++ b/modules/newrelic/settings.go
@@ -13,7 +13,7 @@ const (
 )
 
 type Settings struct {
-	common *cfg.Common
+	*cfg.Common
 
 	apiKey         string        `help:"Your New Relic API token."`
 	deployCount    int           `help:"The number of past deploys to display on screen." optional:"true"`
@@ -23,7 +23,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		apiKey:         ymlConfig.UString("apiKey", os.Getenv("WTF_NEW_RELIC_API_KEY")),
 		deployCount:    ymlConfig.UInt("deployCount", 5),

--- a/modules/newrelic/widget.go
+++ b/modules/newrelic/widget.go
@@ -9,7 +9,6 @@ import (
 )
 
 type Widget struct {
-	view.KeyboardWidget
 	view.MultiSourceWidget
 	view.TextWidget
 
@@ -20,15 +19,13 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		KeyboardWidget:    view.NewKeyboardWidget(app, pages, settings.common),
 		MultiSourceWidget: view.NewMultiSourceWidget(settings.common, "applicationID", "applicationIDs"),
-		TextWidget:        view.NewTextWidget(app, settings.common),
+		TextWidget:        view.NewTextWidget(app, pages, settings.common),
 
 		settings: settings,
 	}
 
 	widget.initializeKeyboardControls()
-	widget.View.SetInputCapture(widget.InputCapture)
 
 	for _, id := range utils.ToInts(widget.settings.applicationIDs) {
 		widget.Clients = append(widget.Clients, NewClient(widget.settings.apiKey, id))
@@ -52,10 +49,6 @@ func (widget *Widget) Refresh() {
 }
 
 /* -------------------- Unexported Functions -------------------- */
-
-func (widget *Widget) HelpText() string {
-	return widget.KeyboardWidget.HelpText()
-}
 
 /* -------------------- Unexported Functions -------------------- */
 

--- a/modules/newrelic/widget.go
+++ b/modules/newrelic/widget.go
@@ -37,8 +37,6 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 
 	widget.SetDisplayFunction(widget.Refresh)
 
-	widget.KeyboardWidget.SetView(widget.View)
-
 	return &widget
 }
 

--- a/modules/newrelic/widget.go
+++ b/modules/newrelic/widget.go
@@ -19,8 +19,8 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		MultiSourceWidget: view.NewMultiSourceWidget(settings.common, "applicationID", "applicationIDs"),
-		TextWidget:        view.NewTextWidget(app, pages, settings.common),
+		MultiSourceWidget: view.NewMultiSourceWidget(settings.Common, "applicationID", "applicationIDs"),
+		TextWidget:        view.NewTextWidget(app, pages, settings.Common),
 
 		settings: settings,
 	}

--- a/modules/opsgenie/settings.go
+++ b/modules/opsgenie/settings.go
@@ -13,7 +13,7 @@ const (
 )
 
 type Settings struct {
-	common *cfg.Common
+	*cfg.Common
 
 	apiKey                 string   `help:"Your OpsGenie API token."`
 	region                 string   `help:"Defines region to use. Possible options: us (by default), eu." optional:"true"`
@@ -25,7 +25,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		apiKey:                 ymlConfig.UString("apiKey", ymlConfig.UString("apikey", os.Getenv("WTF_OPS_GENIE_API_KEY"))),
 		region:                 ymlConfig.UString("region", "us"),

--- a/modules/opsgenie/widget.go
+++ b/modules/opsgenie/widget.go
@@ -17,7 +17,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, nil, settings.common),
+		TextWidget: view.NewTextWidget(app, nil, settings.Common),
 
 		settings: settings,
 	}

--- a/modules/opsgenie/widget.go
+++ b/modules/opsgenie/widget.go
@@ -17,7 +17,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, settings.common),
+		TextWidget: view.NewTextWidget(app, nil, settings.common),
 
 		settings: settings,
 	}

--- a/modules/pagerduty/settings.go
+++ b/modules/pagerduty/settings.go
@@ -14,7 +14,7 @@ const (
 
 // Settings defines the configuration properties for this module
 type Settings struct {
-	common *cfg.Common
+	*cfg.Common
 
 	apiKey           string        `help:"Your PagerDuty API key."`
 	escalationFilter []interface{} `help:"An array of schedule names you want to filter the OnCalls on."`
@@ -30,7 +30,7 @@ type Settings struct {
 // NewSettingsFromYAML creates a new settings instance from a YAML config block
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		apiKey:           ymlConfig.UString("apiKey", ymlConfig.UString("apikey", os.Getenv("WTF_PAGERDUTY_API_KEY"))),
 		escalationFilter: ymlConfig.UList("escalationFilter"),

--- a/modules/pagerduty/widget.go
+++ b/modules/pagerduty/widget.go
@@ -25,7 +25,7 @@ type Widget struct {
 // NewWidget creates and returns an instance of PagerDuty widget
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, nil, settings.common),
+		TextWidget: view.NewTextWidget(app, nil, settings.Common),
 
 		settings: settings,
 	}
@@ -79,11 +79,11 @@ func (widget *Widget) contentFrom(onCalls []pagerduty.OnCall, incidents []pagerd
 	// Incidents
 
 	if widget.settings.showIncidents {
-		str += fmt.Sprintf("[%s] Incidents[white]\n", widget.settings.common.Colors.Subheading)
+		str += fmt.Sprintf("[%s] Incidents[white]\n", widget.settings.Colors.Subheading)
 
 		if len(incidents) > 0 {
 			for _, incident := range incidents {
-				str += fmt.Sprintf("\n [%s]%s[white]\n", widget.settings.common.Colors.Label, tview.Escape(incident.Summary))
+				str += fmt.Sprintf("\n [%s]%s[white]\n", widget.settings.Colors.Label, tview.Escape(incident.Summary))
 				str += fmt.Sprintf("     Status: %s\n", incident.Status)
 				str += fmt.Sprintf("    Service: %s\n", incident.Service.Summary)
 				str += fmt.Sprintf(" Escalation: %s\n", incident.EscalationPolicy.Summary)
@@ -121,13 +121,13 @@ func (widget *Widget) contentFrom(onCalls []pagerduty.OnCall, incidents []pagerd
 	sort.Strings(keys)
 
 	if len(keys) > 0 {
-		str += fmt.Sprintf("[%s] Schedules[white]\n", widget.settings.common.Colors.Subheading)
+		str += fmt.Sprintf("[%s] Schedules[white]\n", widget.settings.Colors.Subheading)
 
 		// Print out policies, and escalation order of users
 		for _, key := range keys {
 			str += fmt.Sprintf(
 				"\n [%s]%s\n",
-				widget.settings.common.Colors.Label,
+				widget.settings.Colors.Label,
 				key,
 			)
 
@@ -137,7 +137,7 @@ func (widget *Widget) contentFrom(onCalls []pagerduty.OnCall, incidents []pagerd
 			for _, onCall := range values {
 				str += fmt.Sprintf(
 					" [%s]%d - %s\n",
-					widget.settings.common.Colors.Text,
+					widget.settings.Colors.Text,
 					onCall.EscalationLevel,
 					widget.userSummary(onCall),
 				)

--- a/modules/pagerduty/widget.go
+++ b/modules/pagerduty/widget.go
@@ -25,7 +25,7 @@ type Widget struct {
 // NewWidget creates and returns an instance of PagerDuty widget
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, settings.common),
+		TextWidget: view.NewTextWidget(app, nil, settings.common),
 
 		settings: settings,
 	}

--- a/modules/pihole/keyboard.go
+++ b/modules/pihole/keyboard.go
@@ -1,7 +1,7 @@
 package pihole
 
 func (widget *Widget) initializeKeyboardControls() {
-	widget.InitializeCommonControls(widget.Refresh)
+	widget.InitializeRefreshKeyboardControl(widget.Refresh)
 
 	widget.SetKeyboardChar("d", widget.disable, "disable Pi-hole")
 	widget.SetKeyboardChar("e", widget.enable, "enable Pi-hole")

--- a/modules/pihole/settings.go
+++ b/modules/pihole/settings.go
@@ -11,7 +11,8 @@ const (
 )
 
 type Settings struct {
-	common         *cfg.Common
+	*cfg.Common
+
 	wrapText       bool
 	apiUrl         string
 	token          string
@@ -24,7 +25,8 @@ type Settings struct {
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := Settings{
-		common:         cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+
 		apiUrl:         ymlConfig.UString("apiUrl"),
 		token:          ymlConfig.UString("token"),
 		showSummary:    ymlConfig.UBool("showSummary", true),

--- a/modules/pihole/widget.go
+++ b/modules/pihole/widget.go
@@ -18,11 +18,11 @@ type Widget struct {
 //func NewWidget(app *tview.Application, settings *Settings) *Widget {
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, nil, settings.common),
+		TextWidget: view.NewTextWidget(app, nil, settings.Common),
 		settings:   settings,
 	}
 
-	widget.settings.common.RefreshInterval = 30
+	widget.settings.RefreshInterval = 30
 	widget.initializeKeyboardControls()
 	widget.SetDisplayFunction(widget.Refresh)
 	widget.View.SetWordWrap(true)

--- a/modules/pihole/widget.go
+++ b/modules/pihole/widget.go
@@ -8,7 +8,6 @@ import (
 )
 
 type Widget struct {
-	view.KeyboardWidget
 	view.MultiSourceWidget
 	view.TextWidget
 
@@ -19,13 +18,11 @@ type Widget struct {
 //func NewWidget(app *tview.Application, settings *Settings) *Widget {
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		KeyboardWidget: view.NewKeyboardWidget(app, pages, settings.common),
-		TextWidget:     view.NewTextWidget(app, settings.common),
-		settings:       settings,
+		TextWidget: view.NewTextWidget(app, nil, settings.common),
+		settings:   settings,
 	}
 
 	widget.settings.common.RefreshInterval = 30
-	widget.View.SetInputCapture(widget.InputCapture)
 	widget.initializeKeyboardControls()
 	widget.SetDisplayFunction(widget.Refresh)
 	widget.View.SetWordWrap(true)
@@ -44,10 +41,6 @@ func (widget *Widget) Refresh() {
 	}
 
 	widget.Redraw(widget.content)
-}
-
-func (widget *Widget) HelpText() string {
-	return widget.KeyboardWidget.HelpText()
 }
 
 /* -------------------- Unexported Functions -------------------- */

--- a/modules/pihole/widget.go
+++ b/modules/pihole/widget.go
@@ -28,8 +28,6 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 	widget.View.SetWordWrap(true)
 	widget.View.SetWrap(settings.wrapText)
 
-	widget.KeyboardWidget.SetView(widget.View)
-
 	return &widget
 }
 

--- a/modules/pocket/keyboard.go
+++ b/modules/pocket/keyboard.go
@@ -3,8 +3,8 @@ package pocket
 import "github.com/gdamore/tcell"
 
 func (widget *Widget) initializeKeyboardControls() {
+	widget.InitializeRefreshKeyboardControl(widget.Refresh)
 
-	widget.InitializeCommonControls(widget.Refresh)
 	widget.SetKeyboardChar("a", widget.toggleLink, "Toggle Link")
 	widget.SetKeyboardChar("t", widget.toggleView, "Toggle view (links ,archived links)")
 	widget.SetKeyboardKey(tcell.KeyDown, widget.Next, "Select Next Link")

--- a/modules/pocket/settings.go
+++ b/modules/pocket/settings.go
@@ -11,7 +11,8 @@ const (
 )
 
 type Settings struct {
-	common      *cfg.Common
+	*cfg.Common
+
 	consumerKey string
 	requestKey  *string
 	accessToken *string
@@ -19,7 +20,7 @@ type Settings struct {
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := Settings{
-		common:      cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+		Common:      cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 		consumerKey: ymlConfig.UString("consumerKey"),
 	}
 

--- a/modules/pocket/widget.go
+++ b/modules/pocket/widget.go
@@ -33,7 +33,6 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 	widget.SetRenderFunction(widget.Render)
 	widget.View.SetScrollable(true)
 	widget.View.SetRegions(true)
-	widget.KeyboardWidget.SetView(widget.View)
 	widget.initializeKeyboardControls()
 	widget.Selected = -1
 	widget.SetItemCount(0)

--- a/modules/pocket/widget.go
+++ b/modules/pocket/widget.go
@@ -23,7 +23,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		ScrollableWidget: view.NewScrollableWidget(app, nil, settings.common),
+		ScrollableWidget: view.NewScrollableWidget(app, nil, settings.Common),
 		settings:         settings,
 		client:           NewClient(settings.consumerKey, "http://localhost"),
 		archivedView:     false,
@@ -199,11 +199,11 @@ func (widget *Widget) toggleLink() {
 }
 
 func (widget *Widget) formatItem(item Item, isSelected bool) string {
-	foreColor, backColor := widget.settings.common.Colors.RowTheme.EvenForeground, widget.settings.common.Colors.RowTheme.EvenBackground
+	foreColor, backColor := widget.settings.Colors.RowTheme.EvenForeground, widget.settings.Colors.RowTheme.EvenBackground
 	text := item.ResolvedTitle
 	if isSelected {
-		foreColor = widget.settings.common.Colors.RowTheme.HighlightedForeground
-		backColor = widget.settings.common.Colors.RowTheme.HighlightedBackground
+		foreColor = widget.settings.Colors.RowTheme.HighlightedForeground
+		backColor = widget.settings.Colors.RowTheme.HighlightedBackground
 
 	}
 

--- a/modules/pocket/widget.go
+++ b/modules/pocket/widget.go
@@ -14,7 +14,6 @@ import (
 
 type Widget struct {
 	view.ScrollableWidget
-	view.KeyboardWidget
 
 	settings     *Settings
 	client       *Client
@@ -24,15 +23,13 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		KeyboardWidget:   view.NewKeyboardWidget(app, pages, settings.common),
-		ScrollableWidget: view.NewScrollableWidget(app, settings.common),
+		ScrollableWidget: view.NewScrollableWidget(app, nil, settings.common),
 		settings:         settings,
 		client:           NewClient(settings.consumerKey, "http://localhost"),
 		archivedView:     false,
 	}
 
 	widget.CommonSettings()
-	widget.View.SetInputCapture(widget.InputCapture)
 	widget.SetRenderFunction(widget.Render)
 	widget.View.SetScrollable(true)
 	widget.View.SetRegions(true)

--- a/modules/power/settings.go
+++ b/modules/power/settings.go
@@ -11,12 +11,12 @@ const (
 )
 
 type Settings struct {
-	common *cfg.Common
+	*cfg.Common
 }
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 	}
 
 	return &settings

--- a/modules/power/widget.go
+++ b/modules/power/widget.go
@@ -17,7 +17,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, nil, settings.common),
+		TextWidget: view.NewTextWidget(app, nil, settings.Common),
 
 		Battery: NewBattery(),
 

--- a/modules/power/widget.go
+++ b/modules/power/widget.go
@@ -17,7 +17,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, settings.common),
+		TextWidget: view.NewTextWidget(app, nil, settings.common),
 
 		Battery: NewBattery(),
 

--- a/modules/resourceusage/settings.go
+++ b/modules/resourceusage/settings.go
@@ -11,7 +11,8 @@ const (
 )
 
 type Settings struct {
-	common      *cfg.Common
+	*cfg.Common
+
 	cpuCombined bool
 	showCPU     bool
 	showMem     bool
@@ -20,7 +21,8 @@ type Settings struct {
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := Settings{
-		common:      cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+
 		cpuCombined: ymlConfig.UBool("cpuCombined", false),
 		showCPU:     ymlConfig.UBool("showCPU", true),
 		showMem:     ymlConfig.UBool("showMem", true),

--- a/modules/resourceusage/widget.go
+++ b/modules/resourceusage/widget.go
@@ -23,7 +23,7 @@ type Widget struct {
 // NewWidget Make new instance of widget
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		BarGraph: view.NewBarGraph(app, settings.common.Name, settings.common),
+		BarGraph: view.NewBarGraph(app, settings.Name, settings.Common),
 
 		app:      app,
 		settings: settings,

--- a/modules/rollbar/keyboard.go
+++ b/modules/rollbar/keyboard.go
@@ -3,7 +3,7 @@ package rollbar
 import "github.com/gdamore/tcell"
 
 func (widget *Widget) initializeKeyboardControls() {
-	widget.InitializeCommonControls(widget.Refresh)
+	widget.InitializeRefreshKeyboardControl(widget.Refresh)
 
 	widget.SetKeyboardChar("j", widget.Next, "Select next item")
 	widget.SetKeyboardChar("k", widget.Prev, "Select previous item")

--- a/modules/rollbar/settings.go
+++ b/modules/rollbar/settings.go
@@ -11,7 +11,7 @@ const (
 )
 
 type Settings struct {
-	common *cfg.Common
+	*cfg.Common
 
 	accessToken    string `help:"Your Rollbar project access token (Only needs read capabilities)."`
 	activeOnly     bool   `help:"Only show items that are active." optional:"true"`
@@ -24,7 +24,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		accessToken:    ymlConfig.UString("accessToken"),
 		activeOnly:     ymlConfig.UBool("activeOnly", false),

--- a/modules/rollbar/widget.go
+++ b/modules/rollbar/widget.go
@@ -10,7 +10,6 @@ import (
 
 // A Widget represents a Rollbar widget
 type Widget struct {
-	view.KeyboardWidget
 	view.ScrollableWidget
 
 	items    *Result
@@ -21,15 +20,13 @@ type Widget struct {
 // NewWidget creates a new instance of a widget
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		KeyboardWidget:   view.NewKeyboardWidget(app, pages, settings.common),
-		ScrollableWidget: view.NewScrollableWidget(app, settings.common),
+		ScrollableWidget: view.NewScrollableWidget(app, pages, settings.common),
 
 		settings: settings,
 	}
 
 	widget.SetRenderFunction(widget.Render)
 	widget.initializeKeyboardControls()
-	widget.View.SetInputCapture(widget.InputCapture)
 
 	widget.KeyboardWidget.SetView(widget.View)
 

--- a/modules/rollbar/widget.go
+++ b/modules/rollbar/widget.go
@@ -28,8 +28,6 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 	widget.SetRenderFunction(widget.Render)
 	widget.initializeKeyboardControls()
 
-	widget.KeyboardWidget.SetView(widget.View)
-
 	return &widget
 }
 

--- a/modules/rollbar/widget.go
+++ b/modules/rollbar/widget.go
@@ -20,7 +20,7 @@ type Widget struct {
 // NewWidget creates a new instance of a widget
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		ScrollableWidget: view.NewScrollableWidget(app, pages, settings.common),
+		ScrollableWidget: view.NewScrollableWidget(app, pages, settings.Common),
 
 		settings: settings,
 	}

--- a/modules/security/firewall.go
+++ b/modules/security/firewall.go
@@ -82,7 +82,6 @@ func firewallStateWindows() string {
 
 	fwStat := utils.ExecuteCommand(cmd)
 	fwStat = strings.TrimSpace(fwStat) // Always sanitize PowerShell output:  "3\r\n"
-	//fmt.Printf("%d %q\n", len(fwStat), fwStat)
 
 	switch fwStat {
 	case "3":

--- a/modules/security/settings.go
+++ b/modules/security/settings.go
@@ -11,12 +11,12 @@ const (
 )
 
 type Settings struct {
-	common *cfg.Common
+	*cfg.Common
 }
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 	}
 
 	return &settings

--- a/modules/security/widget.go
+++ b/modules/security/widget.go
@@ -16,7 +16,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, settings.common),
+		TextWidget: view.NewTextWidget(app, nil, settings.common),
 
 		settings: settings,
 	}

--- a/modules/security/widget.go
+++ b/modules/security/widget.go
@@ -16,7 +16,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, nil, settings.common),
+		TextWidget: view.NewTextWidget(app, nil, settings.Common),
 
 		settings: settings,
 	}
@@ -40,21 +40,21 @@ func (widget *Widget) Refresh() {
 func (widget *Widget) content() (string, string, bool) {
 	data := NewSecurityData()
 	data.Fetch()
-	str := fmt.Sprintf(" [%s]WiFi[white]\n", widget.settings.common.Colors.Subheading)
+	str := fmt.Sprintf(" [%s]WiFi[white]\n", widget.settings.Colors.Subheading)
 	str += fmt.Sprintf(" %8s: %s\n", "Network", data.WifiName)
 	str += fmt.Sprintf(" %8s: %s\n", "Crypto", data.WifiEncryption)
 	str += "\n"
 
-	str += fmt.Sprintf(" [%s]Firewall[white]\n", widget.settings.common.Colors.Subheading)
+	str += fmt.Sprintf(" [%s]Firewall[white]\n", widget.settings.Colors.Subheading)
 	str += fmt.Sprintf(" %8s: %4s\n", "Status", data.FirewallEnabled)
 	str += fmt.Sprintf(" %8s: %4s\n", "Stealth", data.FirewallStealth)
 	str += "\n"
 
-	str += fmt.Sprintf(" [%s]Users[white]\n", widget.settings.common.Colors.Subheading)
+	str += fmt.Sprintf(" [%s]Users[white]\n", widget.settings.Colors.Subheading)
 	str += fmt.Sprintf("  %s", strings.Join(data.LoggedInUsers, "\n  "))
 	str += "\n\n"
 
-	str += fmt.Sprintf(" [%s]DNS[white]\n", widget.settings.common.Colors.Subheading)
+	str += fmt.Sprintf(" [%s]DNS[white]\n", widget.settings.Colors.Subheading)
 	str += fmt.Sprintf("  %12s\n", data.DnsAt(0))
 	str += fmt.Sprintf("  %12s\n", data.DnsAt(1))
 	str += "\n"

--- a/modules/spacex/settings.go
+++ b/modules/spacex/settings.go
@@ -10,13 +10,13 @@ const (
 )
 
 type Settings struct {
-	common *cfg.Common
+	*cfg.Common
 }
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	spacex := ymlConfig.UString("spacex")
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, spacex, defaultFocusable, ymlConfig, globalConfig),
+		Common: cfg.NewCommonSettingsFromModule(name, spacex, defaultFocusable, ymlConfig, globalConfig),
 	}
 	return &settings
 }

--- a/modules/spacex/widget.go
+++ b/modules/spacex/widget.go
@@ -17,7 +17,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := &Widget{
-		TextWidget: view.NewTextWidget(app, settings.common),
+		TextWidget: view.NewTextWidget(app, nil, settings.common),
 		settings:   settings,
 	}
 	return widget

--- a/modules/spacex/widget.go
+++ b/modules/spacex/widget.go
@@ -17,7 +17,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := &Widget{
-		TextWidget: view.NewTextWidget(app, nil, settings.common),
+		TextWidget: view.NewTextWidget(app, nil, settings.Common),
 		settings:   settings,
 	}
 	return widget
@@ -46,19 +46,19 @@ func (widget *Widget) content() (string, string, bool) {
 		handleError(widget, err)
 	} else {
 
-		str = fmt.Sprintf("[%s]Mission[white]\n", widget.settings.common.Colors.Subheading)
+		str = fmt.Sprintf("[%s]Mission[white]\n", widget.settings.Colors.Subheading)
 		str += fmt.Sprintf("%s: %s\n", "Name", launch.MissionName)
 		str += fmt.Sprintf("%s: %s\n", "Date", wtf.UnixTime(launch.LaunchDate).Format(time.RFC822))
 		str += fmt.Sprintf("%s: %s\n", "Site", launch.LaunchSite.Name)
 		str += "\n"
 
-		str += fmt.Sprintf("[%s]Links[white]\n", widget.settings.common.Colors.Subheading)
+		str += fmt.Sprintf("[%s]Links[white]\n", widget.settings.Colors.Subheading)
 		str += fmt.Sprintf("%s: %s\n", "YouTube", launch.Links.YouTubeLink)
 		str += fmt.Sprintf("%s: %s\n", "Reddit", launch.Links.RedditLink)
 
 		if widget.CommonSettings().Height >= 2 {
 			str += "\n"
-			str += fmt.Sprintf("[%s]Details[white]\n", widget.settings.common.Colors.Subheading)
+			str += fmt.Sprintf("[%s]Details[white]\n", widget.settings.Colors.Subheading)
 			str += fmt.Sprintf("%s: %s\n", "RocketName", launch.Rocket.Name)
 			str += fmt.Sprintf("%s: %s\n", "Details", launch.Details)
 		}

--- a/modules/spotify/keyboard.go
+++ b/modules/spotify/keyboard.go
@@ -7,7 +7,7 @@ import (
 )
 
 func (widget *Widget) initializeKeyboardControls() {
-	widget.InitializeCommonControls(widget.Refresh)
+	widget.InitializeRefreshKeyboardControl(widget.Refresh)
 
 	widget.SetKeyboardChar("l", widget.next, "Select next item")
 	widget.SetKeyboardChar("h", widget.previous, "Select previous item")

--- a/modules/spotify/settings.go
+++ b/modules/spotify/settings.go
@@ -17,12 +17,12 @@ type colors struct {
 
 type Settings struct {
 	colors
-	common *cfg.Common
+	*cfg.Common
 }
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 	}
 
 	settings.colors.label = ymlConfig.UString("colors.label", "green")

--- a/modules/spotify/widget.go
+++ b/modules/spotify/widget.go
@@ -11,7 +11,6 @@ import (
 
 // A Widget represents a Spotify widget
 type Widget struct {
-	view.KeyboardWidget
 	view.TextWidget
 
 	client   spotigopher.SpotifyClient
@@ -22,8 +21,7 @@ type Widget struct {
 // NewWidget creates a new instance of a widget
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		KeyboardWidget: view.NewKeyboardWidget(app, pages, settings.common),
-		TextWidget:     view.NewTextWidget(app, settings.common),
+		TextWidget: view.NewTextWidget(app, pages, settings.common),
 
 		Info:   spotigopher.Info{},
 		client: spotigopher.NewClient(),
@@ -34,7 +32,6 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 	widget.settings.common.RefreshInterval = 5
 
 	widget.initializeKeyboardControls()
-	widget.View.SetInputCapture(widget.InputCapture)
 
 	widget.View.SetWrap(true)
 	widget.View.SetWordWrap(true)
@@ -52,10 +49,6 @@ func (w *Widget) refreshSpotifyInfos() error {
 
 func (w *Widget) Refresh() {
 	w.Redraw(w.createOutput)
-}
-
-func (widget *Widget) HelpText() string {
-	return widget.KeyboardWidget.HelpText()
 }
 
 func (w *Widget) createOutput() (string, string, bool) {

--- a/modules/spotify/widget.go
+++ b/modules/spotify/widget.go
@@ -21,7 +21,7 @@ type Widget struct {
 // NewWidget creates a new instance of a widget
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, pages, settings.common),
+		TextWidget: view.NewTextWidget(app, pages, settings.Common),
 
 		Info:   spotigopher.Info{},
 		client: spotigopher.NewClient(),
@@ -29,7 +29,7 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 		settings: settings,
 	}
 
-	widget.settings.common.RefreshInterval = 5
+	widget.settings.RefreshInterval = 5
 
 	widget.initializeKeyboardControls()
 

--- a/modules/spotify/widget.go
+++ b/modules/spotify/widget.go
@@ -36,8 +36,6 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 	widget.View.SetWrap(true)
 	widget.View.SetWordWrap(true)
 
-	widget.KeyboardWidget.SetView(widget.View)
-
 	return &widget
 }
 

--- a/modules/spotifyweb/keyboard.go
+++ b/modules/spotifyweb/keyboard.go
@@ -7,7 +7,7 @@ import (
 )
 
 func (widget *Widget) initializeKeyboardControls() {
-	widget.InitializeCommonControls(widget.Refresh)
+	widget.InitializeRefreshKeyboardControl(widget.Refresh)
 
 	widget.SetKeyboardChar("h", widget.selectPrevious, "Select previous item")
 	widget.SetKeyboardChar("l", widget.selectNext, "Select next item")

--- a/modules/spotifyweb/settings.go
+++ b/modules/spotifyweb/settings.go
@@ -13,7 +13,7 @@ const (
 )
 
 type Settings struct {
-	common *cfg.Common
+	*cfg.Common
 
 	callbackPort string
 	clientID     string
@@ -23,7 +23,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		callbackPort: ymlConfig.UString("callbackPort", "8080"),
 		clientID:     ymlConfig.UString("clientID", os.Getenv("SPOTIFY_ID")),

--- a/modules/spotifyweb/widget.go
+++ b/modules/spotifyweb/widget.go
@@ -32,7 +32,6 @@ type Info struct {
 
 // Widget is the struct used by all WTF widgets to transfer to the main widget controller
 type Widget struct {
-	view.KeyboardWidget
 	view.TextWidget
 
 	Info
@@ -72,8 +71,7 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 	var playerState *spotify.PlayerState
 
 	widget := Widget{
-		KeyboardWidget: view.NewKeyboardWidget(app, pages, settings.common),
-		TextWidget:     view.NewTextWidget(app, settings.common),
+		TextWidget: view.NewTextWidget(app, pages, settings.common),
 
 		Info: Info{},
 
@@ -124,7 +122,6 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 	widget.settings.common.RefreshInterval = 5
 
 	widget.initializeKeyboardControls()
-	widget.View.SetInputCapture(widget.InputCapture)
 
 	widget.View.SetWrap(true)
 	widget.View.SetWordWrap(true)
@@ -163,10 +160,6 @@ func (w *Widget) refreshSpotifyInfos() error {
 // Refresh refreshes the current view of the widget
 func (w *Widget) Refresh() {
 	w.Redraw(w.createOutput)
-}
-
-func (widget *Widget) HelpText() string {
-	return widget.KeyboardWidget.HelpText()
 }
 
 func (w *Widget) createOutput() (string, string, bool) {

--- a/modules/spotifyweb/widget.go
+++ b/modules/spotifyweb/widget.go
@@ -126,8 +126,6 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 	widget.View.SetWrap(true)
 	widget.View.SetWordWrap(true)
 
-	widget.KeyboardWidget.SetView(widget.View)
-
 	return &widget
 }
 

--- a/modules/spotifyweb/widget.go
+++ b/modules/spotifyweb/widget.go
@@ -71,7 +71,7 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 	var playerState *spotify.PlayerState
 
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, pages, settings.common),
+		TextWidget: view.NewTextWidget(app, pages, settings.Common),
 
 		Info: Info{},
 
@@ -119,7 +119,7 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 	// If inconvenient, I'll remove this option and save the URL in a file or some other method.
 	utils.OpenFile(`"` + authURL + `"`)
 
-	widget.settings.common.RefreshInterval = 5
+	widget.settings.RefreshInterval = 5
 
 	widget.initializeKeyboardControls()
 

--- a/modules/status/settings.go
+++ b/modules/status/settings.go
@@ -11,12 +11,12 @@ const (
 )
 
 type Settings struct {
-	common *cfg.Common
+	*cfg.Common
 }
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 	}
 
 	return &settings

--- a/modules/status/widget.go
+++ b/modules/status/widget.go
@@ -15,7 +15,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, nil, settings.common),
+		TextWidget: view.NewTextWidget(app, nil, settings.Common),
 
 		CurrentIcon: 0,
 

--- a/modules/status/widget.go
+++ b/modules/status/widget.go
@@ -15,7 +15,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, settings.common),
+		TextWidget: view.NewTextWidget(app, nil, settings.common),
 
 		CurrentIcon: 0,
 

--- a/modules/subreddit/keyboard.go
+++ b/modules/subreddit/keyboard.go
@@ -3,7 +3,7 @@ package subreddit
 import "github.com/gdamore/tcell"
 
 func (widget *Widget) initializeKeyboardControls() {
-	widget.InitializeCommonControls(widget.Refresh)
+	widget.InitializeRefreshKeyboardControl(widget.Refresh)
 
 	widget.SetKeyboardChar("j", widget.Next, "Select next item")
 	widget.SetKeyboardChar("k", widget.Prev, "Select previous item")

--- a/modules/subreddit/settings.go
+++ b/modules/subreddit/settings.go
@@ -11,7 +11,7 @@ const (
 
 // Settings contains the settings for the subreddit view
 type Settings struct {
-	common *cfg.Common
+	*cfg.Common
 
 	subreddit     string `help:"Subreddit to look at" optional:"false"`
 	numberOfPosts int    `help:"Number of posts to show. Default is 10." optional:"true"`
@@ -23,7 +23,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	subreddit := ymlConfig.UString("subreddit")
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, subreddit, defaultFocusable, ymlConfig, globalConfig),
+		Common: cfg.NewCommonSettingsFromModule(name, subreddit, defaultFocusable, ymlConfig, globalConfig),
 
 		numberOfPosts: ymlConfig.UInt("numberOfPosts", 10),
 		sortOrder:     ymlConfig.UString("sortOrder", "hot"),

--- a/modules/subreddit/widget.go
+++ b/modules/subreddit/widget.go
@@ -18,7 +18,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := &Widget{
-		ScrollableWidget: view.NewScrollableWidget(app, pages, settings.common),
+		ScrollableWidget: view.NewScrollableWidget(app, pages, settings.Common),
 
 		settings: settings,
 	}

--- a/modules/subreddit/widget.go
+++ b/modules/subreddit/widget.go
@@ -9,7 +9,6 @@ import (
 )
 
 type Widget struct {
-	view.KeyboardWidget
 	view.ScrollableWidget
 
 	settings *Settings
@@ -19,15 +18,13 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := &Widget{
-		KeyboardWidget:   view.NewKeyboardWidget(app, pages, settings.common),
-		ScrollableWidget: view.NewScrollableWidget(app, settings.common),
+		ScrollableWidget: view.NewScrollableWidget(app, pages, settings.common),
 
 		settings: settings,
 	}
 
 	widget.SetRenderFunction(widget.Render)
 	widget.initializeKeyboardControls()
-	widget.View.SetInputCapture(widget.InputCapture)
 
 	widget.KeyboardWidget.SetView(widget.View)
 

--- a/modules/subreddit/widget.go
+++ b/modules/subreddit/widget.go
@@ -26,8 +26,6 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 	widget.SetRenderFunction(widget.Render)
 	widget.initializeKeyboardControls()
 
-	widget.KeyboardWidget.SetView(widget.View)
-
 	return widget
 
 }

--- a/modules/system/settings.go
+++ b/modules/system/settings.go
@@ -11,12 +11,12 @@ const (
 )
 
 type Settings struct {
-	common *cfg.Common
+	*cfg.Common
 }
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 	}
 
 	return &settings

--- a/modules/system/widget.go
+++ b/modules/system/widget.go
@@ -21,7 +21,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, date, version string, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, nil, settings.common),
+		TextWidget: view.NewTextWidget(app, nil, settings.Common),
 
 		Date: date,
 

--- a/modules/system/widget.go
+++ b/modules/system/widget.go
@@ -21,7 +21,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, date, version string, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, settings.common),
+		TextWidget: view.NewTextWidget(app, nil, settings.common),
 
 		Date: date,
 

--- a/modules/textfile/keyboard.go
+++ b/modules/textfile/keyboard.go
@@ -6,7 +6,7 @@ import (
 )
 
 func (widget *Widget) initializeKeyboardControls() {
-	widget.InitializeCommonControls(nil)
+	widget.InitializeRefreshKeyboardControl(nil)
 
 	widget.SetKeyboardChar("l", widget.NextSource, "Select next file")
 	widget.SetKeyboardChar("h", widget.PrevSource, "Select previous file")

--- a/modules/textfile/settings.go
+++ b/modules/textfile/settings.go
@@ -12,7 +12,7 @@ const (
 
 // Settings defines the configuration properties for this module
 type Settings struct {
-	common *cfg.Common
+	*cfg.Common
 
 	filePaths   []interface{}
 	format      bool
@@ -24,7 +24,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		filePaths:   ymlConfig.UList("filePaths"),
 		format:      ymlConfig.UBool("format", false),

--- a/modules/textfile/widget.go
+++ b/modules/textfile/widget.go
@@ -22,7 +22,6 @@ const (
 )
 
 type Widget struct {
-	view.KeyboardWidget
 	view.MultiSourceWidget
 	view.TextWidget
 
@@ -32,9 +31,8 @@ type Widget struct {
 // NewWidget creates a new instance of a widget
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		KeyboardWidget:    view.NewKeyboardWidget(app, pages, settings.common),
 		MultiSourceWidget: view.NewMultiSourceWidget(settings.common, "filePath", "filePaths"),
-		TextWidget:        view.NewTextWidget(app, settings.common),
+		TextWidget:        view.NewTextWidget(app, pages, settings.common),
 
 		settings: settings,
 	}
@@ -43,7 +41,6 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 	widget.settings.common.RefreshInterval = 0
 
 	widget.initializeKeyboardControls()
-	widget.View.SetInputCapture(widget.InputCapture)
 
 	widget.SetDisplayFunction(widget.Refresh)
 	widget.View.SetWordWrap(true)
@@ -62,10 +59,6 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 // text files that first time. After that, the watcher takes over
 func (widget *Widget) Refresh() {
 	widget.Redraw(widget.content)
-}
-
-func (widget *Widget) HelpText() string {
-	return widget.KeyboardWidget.HelpText()
 }
 
 /* -------------------- Unexported Functions -------------------- */

--- a/modules/textfile/widget.go
+++ b/modules/textfile/widget.go
@@ -46,8 +46,6 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 	widget.View.SetWordWrap(true)
 	widget.View.SetWrap(settings.wrapText)
 
-	widget.KeyboardWidget.SetView(widget.View)
-
 	go widget.watchForFileChanges()
 
 	return &widget

--- a/modules/textfile/widget.go
+++ b/modules/textfile/widget.go
@@ -31,14 +31,14 @@ type Widget struct {
 // NewWidget creates a new instance of a widget
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		MultiSourceWidget: view.NewMultiSourceWidget(settings.common, "filePath", "filePaths"),
-		TextWidget:        view.NewTextWidget(app, pages, settings.common),
+		MultiSourceWidget: view.NewMultiSourceWidget(settings.Common, "filePath", "filePaths"),
+		TextWidget:        view.NewTextWidget(app, pages, settings.Common),
 
 		settings: settings,
 	}
 
 	// Don't use a timer for this widget, watch for filesystem changes instead
-	widget.settings.common.RefreshInterval = 0
+	widget.settings.RefreshInterval = 0
 
 	widget.initializeKeyboardControls()
 
@@ -64,12 +64,12 @@ func (widget *Widget) Refresh() {
 func (widget *Widget) content() (string, string, bool) {
 	title := fmt.Sprintf(
 		"[%s]%s[white]",
-		widget.settings.common.Colors.TextTheme.Title,
+		widget.settings.Colors.TextTheme.Title,
 		widget.CurrentSource(),
 	)
 
 	_, _, width, _ := widget.View.GetRect()
-	text := widget.settings.common.PaginationMarker(len(widget.Sources), widget.Idx, width) + "\n"
+	text := widget.settings.PaginationMarker(len(widget.Sources), widget.Idx, width) + "\n"
 
 	if widget.settings.format {
 		text += widget.formattedText()

--- a/modules/todo/display.go
+++ b/modules/todo/display.go
@@ -15,8 +15,8 @@ func (widget *Widget) display() {
 func (widget *Widget) content() (string, string, bool) {
 	str := ""
 	newList := checklist.NewChecklist(
-		widget.settings.common.Sigils.Checkbox.Checked,
-		widget.settings.common.Sigils.Checkbox.Unchecked,
+		widget.settings.Sigils.Checkbox.Checked,
+		widget.settings.Sigils.Checkbox.Unchecked,
 	)
 
 	offset := 0
@@ -45,7 +45,7 @@ func (widget *Widget) formattedItemLine(idx int, currItem *checklist.ChecklistIt
 	rowColor := widget.RowColor(idx)
 
 	if currItem.Checked {
-		rowColor = widget.settings.common.Colors.CheckboxTheme.Checked
+		rowColor = widget.settings.Colors.CheckboxTheme.Checked
 	}
 
 	if widget.View.HasFocus() && (currItem == selectedItem) {

--- a/modules/todo/keyboard.go
+++ b/modules/todo/keyboard.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (widget *Widget) initializeKeyboardControls() {
-	widget.InitializeCommonControls(widget.Refresh)
+	widget.InitializeRefreshKeyboardControl(widget.Refresh)
 
 	widget.SetKeyboardChar("j", widget.Next, "Select next item")
 	widget.SetKeyboardChar("k", widget.Prev, "Select previous item")

--- a/modules/todo/settings.go
+++ b/modules/todo/settings.go
@@ -12,7 +12,7 @@ const (
 
 // Settings defines the configuration properties for this module
 type Settings struct {
-	common *cfg.Common
+	*cfg.Common
 
 	filePath  string
 	checked   string
@@ -24,7 +24,7 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	common := cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig)
 
 	settings := Settings{
-		common: common,
+		Common: common,
 
 		filePath:  ymlConfig.UString("filename"),
 		checked:   ymlConfig.UString("checkedIcon", common.Checkbox.Checked),

--- a/modules/todo/widget.go
+++ b/modules/todo/widget.go
@@ -22,7 +22,6 @@ const (
 
 // A Widget represents a Todo widget
 type Widget struct {
-	view.KeyboardWidget
 	view.ScrollableWidget
 
 	app      *tview.Application
@@ -35,8 +34,7 @@ type Widget struct {
 // NewWidget creates a new instance of a widget
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		KeyboardWidget:   view.NewKeyboardWidget(app, pages, settings.common),
-		ScrollableWidget: view.NewScrollableWidget(app, settings.common),
+		ScrollableWidget: view.NewScrollableWidget(app, pages, settings.common),
 
 		app:      app,
 		settings: settings,
@@ -48,7 +46,6 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 	widget.init()
 
 	widget.initializeKeyboardControls()
-	widget.View.SetInputCapture(widget.InputCapture)
 
 	widget.View.SetRegions(true)
 	widget.View.SetScrollable(true)
@@ -60,11 +57,6 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 }
 
 /* -------------------- Exported Functions -------------------- */
-
-// HelpText returns the help text for this widget
-func (widget *Widget) HelpText() string {
-	return widget.KeyboardWidget.HelpText()
-}
 
 // SelectedItem returns the currently-selected checklist item or nil if no item is selected
 func (widget *Widget) SelectedItem() *checklist.ChecklistItem {

--- a/modules/todo/widget.go
+++ b/modules/todo/widget.go
@@ -34,12 +34,12 @@ type Widget struct {
 // NewWidget creates a new instance of a widget
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		ScrollableWidget: view.NewScrollableWidget(app, pages, settings.common),
+		ScrollableWidget: view.NewScrollableWidget(app, pages, settings.Common),
 
 		app:      app,
 		settings: settings,
 		filePath: settings.filePath,
-		list:     checklist.NewChecklist(settings.common.Sigils.Checkbox.Checked, settings.common.Sigils.Checkbox.Unchecked),
+		list:     checklist.NewChecklist(settings.Sigils.Checkbox.Checked, settings.Sigils.Checkbox.Unchecked),
 		pages:    pages,
 	}
 
@@ -219,8 +219,8 @@ func (widget *Widget) modalFocus(form *tview.Form) {
 }
 
 func (widget *Widget) modalForm(lbl, text string) *tview.Form {
-	form := tview.NewForm().SetFieldBackgroundColor(wtf.ColorFor(widget.settings.common.Colors.Background))
-	form.SetButtonsAlign(tview.AlignCenter).SetButtonTextColor(wtf.ColorFor(widget.settings.common.Colors.Text))
+	form := tview.NewForm().SetFieldBackgroundColor(wtf.ColorFor(widget.settings.Colors.Background))
+	form.SetButtonsAlign(tview.AlignCenter).SetButtonTextColor(wtf.ColorFor(widget.settings.Colors.Text))
 
 	form.AddInputField(lbl, text, 60, nil, nil)
 

--- a/modules/todo/widget.go
+++ b/modules/todo/widget.go
@@ -50,7 +50,6 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 	widget.View.SetRegions(true)
 	widget.View.SetScrollable(true)
 
-	widget.KeyboardWidget.SetView(widget.View)
 	widget.SetRenderFunction(widget.display)
 
 	return &widget

--- a/modules/todo_plus/display.go
+++ b/modules/todo_plus/display.go
@@ -20,7 +20,7 @@ func (widget *Widget) content() (string, string, bool) {
 
 	title := fmt.Sprintf(
 		"[%s]%s[white]",
-		widget.settings.common.Colors.TextTheme.Title,
+		widget.settings.Colors.TextTheme.Title,
 		proj.Name)
 
 	str := ""

--- a/modules/todo_plus/keyboard.go
+++ b/modules/todo_plus/keyboard.go
@@ -3,7 +3,7 @@ package todo_plus
 import "github.com/gdamore/tcell"
 
 func (widget *Widget) initializeKeyboardControls() {
-	widget.InitializeCommonControls(widget.Refresh)
+	widget.InitializeRefreshKeyboardControl(widget.Refresh)
 
 	widget.SetKeyboardChar("d", widget.Delete, "Delete item")
 	widget.SetKeyboardChar("j", widget.Prev, "Select previous item")

--- a/modules/todo_plus/settings.go
+++ b/modules/todo_plus/settings.go
@@ -13,7 +13,7 @@ const (
 )
 
 type Settings struct {
-	common *cfg.Common
+	*cfg.Common
 
 	backendType     string
 	backendSettings *config.Config
@@ -24,7 +24,7 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	backend, _ := ymlConfig.Get("backendSettings")
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		backendType:     ymlConfig.UString("backendType"),
 		backendSettings: backend,
@@ -41,7 +41,7 @@ func FromTodoist(name string, ymlConfig *config.Config, globalConfig *config.Con
 	_ = backend.Set(".projects", projects)
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		backendType:     "todoist",
 		backendSettings: backend,
@@ -71,7 +71,7 @@ func FromTrello(name string, ymlConfig *config.Config, globalConfig *config.Conf
 	_ = backend.Set(".lists", lists)
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		backendType:     "trello",
 		backendSettings: backend,

--- a/modules/todo_plus/widget.go
+++ b/modules/todo_plus/widget.go
@@ -21,8 +21,8 @@ type Widget struct {
 // NewWidget creates a new instance of a widget
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		MultiSourceWidget: view.NewMultiSourceWidget(settings.common, "project", "projects"),
-		ScrollableWidget:  view.NewScrollableWidget(app, pages, settings.common),
+		MultiSourceWidget: view.NewMultiSourceWidget(settings.Common, "project", "projects"),
+		ScrollableWidget:  view.NewScrollableWidget(app, pages, settings.Common),
 
 		settings: settings,
 	}

--- a/modules/todo_plus/widget.go
+++ b/modules/todo_plus/widget.go
@@ -10,7 +10,6 @@ import (
 
 // A Widget represents a Todoist widget
 type Widget struct {
-	view.KeyboardWidget
 	view.MultiSourceWidget
 	view.ScrollableWidget
 
@@ -22,9 +21,8 @@ type Widget struct {
 // NewWidget creates a new instance of a widget
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		KeyboardWidget:    view.NewKeyboardWidget(app, pages, settings.common),
 		MultiSourceWidget: view.NewMultiSourceWidget(settings.common, "project", "projects"),
-		ScrollableWidget:  view.NewScrollableWidget(app, settings.common),
+		ScrollableWidget:  view.NewScrollableWidget(app, pages, settings.common),
 
 		settings: settings,
 	}
@@ -35,7 +33,6 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 
 	widget.SetRenderFunction(widget.display)
 	widget.initializeKeyboardControls()
-	widget.View.SetInputCapture(widget.InputCapture)
 	widget.SetDisplayFunction(widget.display)
 
 	widget.KeyboardWidget.SetView(widget.View)
@@ -81,10 +78,6 @@ func (widget *Widget) Refresh() {
 	widget.Sources = widget.backend.Sources()
 	widget.SetItemCount(len(widget.CurrentProject().Tasks))
 	widget.display()
-}
-
-func (widget *Widget) HelpText() string {
-	return widget.KeyboardWidget.HelpText()
 }
 
 func (widget *Widget) NextSource() {

--- a/modules/todo_plus/widget.go
+++ b/modules/todo_plus/widget.go
@@ -35,8 +35,6 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 	widget.initializeKeyboardControls()
 	widget.SetDisplayFunction(widget.display)
 
-	widget.KeyboardWidget.SetView(widget.View)
-
 	return &widget
 }
 

--- a/modules/transmission/keyboard.go
+++ b/modules/transmission/keyboard.go
@@ -3,7 +3,7 @@ package transmission
 import "github.com/gdamore/tcell"
 
 func (widget *Widget) initializeKeyboardControls() {
-	widget.InitializeCommonControls(nil)
+	widget.InitializeRefreshKeyboardControl(nil)
 
 	widget.SetKeyboardChar("j", widget.Prev, "Select previous item")
 	widget.SetKeyboardChar("k", widget.Next, "Select next item")

--- a/modules/transmission/settings.go
+++ b/modules/transmission/settings.go
@@ -12,7 +12,7 @@ const (
 
 // Settings defines the configuration properties for this module
 type Settings struct {
-	common *cfg.Common
+	*cfg.Common
 
 	host         string `help:"The address of the machine the Transmission daemon is running on"`
 	https        bool   `help:"Whether or not to connect to the host via HTTPS"`
@@ -26,7 +26,7 @@ type Settings struct {
 // NewSettingsFromYAML creates a new settings instance from a YAML config block
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		host:         ymlConfig.UString("host"),
 		https:        ymlConfig.UBool("https", false),

--- a/modules/transmission/widget.go
+++ b/modules/transmission/widget.go
@@ -31,8 +31,6 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 	widget.SetRenderFunction(widget.display)
 	widget.initializeKeyboardControls()
 
-	widget.KeyboardWidget.SetView(widget.View)
-
 	go buildClient(&widget)
 
 	return &widget

--- a/modules/transmission/widget.go
+++ b/modules/transmission/widget.go
@@ -11,7 +11,6 @@ import (
 
 // Widget is the container for transmission data
 type Widget struct {
-	view.KeyboardWidget
 	view.ScrollableWidget
 
 	client   *transmissionrpc.Client
@@ -24,15 +23,13 @@ type Widget struct {
 // NewWidget creates a new instance of a widget
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		KeyboardWidget:   view.NewKeyboardWidget(app, pages, settings.common),
-		ScrollableWidget: view.NewScrollableWidget(app, settings.common),
+		ScrollableWidget: view.NewScrollableWidget(app, pages, settings.common),
 
 		settings: settings,
 	}
 
 	widget.SetRenderFunction(widget.display)
 	widget.initializeKeyboardControls()
-	widget.View.SetInputCapture(widget.InputCapture)
 
 	widget.KeyboardWidget.SetView(widget.View)
 
@@ -86,11 +83,6 @@ func (widget *Widget) Refresh() {
 	widget.mu.Unlock()
 
 	widget.display()
-}
-
-// HelpText returns the help text for this widget
-func (widget *Widget) HelpText() string {
-	return widget.KeyboardWidget.HelpText()
 }
 
 // Next selects the next item in the list

--- a/modules/transmission/widget.go
+++ b/modules/transmission/widget.go
@@ -23,7 +23,7 @@ type Widget struct {
 // NewWidget creates a new instance of a widget
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		ScrollableWidget: view.NewScrollableWidget(app, pages, settings.common),
+		ScrollableWidget: view.NewScrollableWidget(app, pages, settings.Common),
 
 		settings: settings,
 	}

--- a/modules/travisci/keyboard.go
+++ b/modules/travisci/keyboard.go
@@ -3,7 +3,7 @@ package travisci
 import "github.com/gdamore/tcell"
 
 func (widget *Widget) initializeKeyboardControls() {
-	widget.InitializeCommonControls(widget.Refresh)
+	widget.InitializeRefreshKeyboardControl(widget.Refresh)
 
 	widget.SetKeyboardChar("j", widget.Next, "Select next item")
 	widget.SetKeyboardChar("k", widget.Prev, "Select previous item")

--- a/modules/travisci/settings.go
+++ b/modules/travisci/settings.go
@@ -13,7 +13,7 @@ const (
 )
 
 type Settings struct {
-	common *cfg.Common
+	*cfg.Common
 
 	apiKey  string
 	baseURL string `help:"Your TravisCI Enterprise API URL." optional:"true"`
@@ -25,7 +25,7 @@ type Settings struct {
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		apiKey:  ymlConfig.UString("apiKey", ymlConfig.UString("apikey", os.Getenv("WTF_TRAVIS_API_TOKEN"))),
 		baseURL: ymlConfig.UString("baseURL", ymlConfig.UString("baseURL", os.Getenv("WTF_TRAVIS_BASE_URL"))),

--- a/modules/travisci/widget.go
+++ b/modules/travisci/widget.go
@@ -10,7 +10,6 @@ import (
 )
 
 type Widget struct {
-	view.KeyboardWidget
 	view.ScrollableWidget
 
 	builds   *Builds
@@ -20,15 +19,13 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		KeyboardWidget:   view.NewKeyboardWidget(app, pages, settings.common),
-		ScrollableWidget: view.NewScrollableWidget(app, settings.common),
+		ScrollableWidget: view.NewScrollableWidget(app, pages, settings.common),
 
 		settings: settings,
 	}
 
 	widget.SetRenderFunction(widget.Render)
 	widget.initializeKeyboardControls()
-	widget.View.SetInputCapture(widget.InputCapture)
 
 	widget.KeyboardWidget.SetView(widget.View)
 

--- a/modules/travisci/widget.go
+++ b/modules/travisci/widget.go
@@ -19,7 +19,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		ScrollableWidget: view.NewScrollableWidget(app, pages, settings.common),
+		ScrollableWidget: view.NewScrollableWidget(app, pages, settings.Common),
 
 		settings: settings,
 	}

--- a/modules/travisci/widget.go
+++ b/modules/travisci/widget.go
@@ -27,8 +27,6 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 	widget.SetRenderFunction(widget.Render)
 	widget.initializeKeyboardControls()
 
-	widget.KeyboardWidget.SetView(widget.View)
-
 	return &widget
 }
 

--- a/modules/twitch/keyboard.go
+++ b/modules/twitch/keyboard.go
@@ -3,7 +3,7 @@ package twitch
 import "github.com/gdamore/tcell"
 
 func (widget *Widget) initializeKeyboardControls() {
-	widget.InitializeCommonControls(widget.Refresh)
+	widget.InitializeRefreshKeyboardControl(widget.Refresh)
 
 	widget.SetKeyboardChar("j", widget.Next, "Select next item")
 	widget.SetKeyboardChar("k", widget.Prev, "Select previous item")

--- a/modules/twitch/settings.go
+++ b/modules/twitch/settings.go
@@ -13,7 +13,7 @@ const (
 )
 
 type Settings struct {
-	common *cfg.Common
+	*cfg.Common
 
 	numberOfResults int      `help:"Number of results to show. Default is 10." optional:"true"`
 	clientId        string   `help:"Client Id (default is env var TWITCH_CLIENT_ID)"`
@@ -33,7 +33,8 @@ func defaultLanguage() []interface{} {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	twitch := ymlConfig.UString("twitch")
 	settings := Settings{
-		common:          cfg.NewCommonSettingsFromModule(name, twitch, defaultFocusable, ymlConfig, globalConfig),
+		Common: cfg.NewCommonSettingsFromModule(name, twitch, defaultFocusable, ymlConfig, globalConfig),
+
 		numberOfResults: ymlConfig.UInt("numberOfResults", 10),
 		clientId:        ymlConfig.UString("clientId", os.Getenv("TWITCH_CLIENT_ID")),
 		languages:       utils.ToStrs(ymlConfig.UList("languages", defaultLanguage())),

--- a/modules/twitch/widget.go
+++ b/modules/twitch/widget.go
@@ -29,7 +29,7 @@ type Stream struct {
 
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := &Widget{
-		ScrollableWidget: view.NewScrollableWidget(app, pages, settings.common),
+		ScrollableWidget: view.NewScrollableWidget(app, pages, settings.Common),
 		settings:         settings,
 		twitch:           NewClient(settings.clientId),
 	}

--- a/modules/twitch/widget.go
+++ b/modules/twitch/widget.go
@@ -11,7 +11,6 @@ import (
 )
 
 type Widget struct {
-	view.KeyboardWidget
 	view.ScrollableWidget
 
 	settings   *Settings
@@ -30,15 +29,13 @@ type Stream struct {
 
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := &Widget{
-		KeyboardWidget:   view.NewKeyboardWidget(app, pages, settings.common),
-		ScrollableWidget: view.NewScrollableWidget(app, settings.common),
+		ScrollableWidget: view.NewScrollableWidget(app, pages, settings.common),
 		settings:         settings,
 		twitch:           NewClient(settings.clientId),
 	}
 
 	widget.SetRenderFunction(widget.Render)
 	widget.initializeKeyboardControls()
-	widget.View.SetInputCapture(widget.InputCapture)
 	widget.KeyboardWidget.SetView(widget.View)
 
 	return widget

--- a/modules/twitch/widget.go
+++ b/modules/twitch/widget.go
@@ -36,7 +36,6 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 
 	widget.SetRenderFunction(widget.Render)
 	widget.initializeKeyboardControls()
-	widget.KeyboardWidget.SetView(widget.View)
 
 	return widget
 }

--- a/modules/twitter/keyboard.go
+++ b/modules/twitter/keyboard.go
@@ -6,7 +6,7 @@ import (
 )
 
 func (widget *Widget) initializeKeyboardControls() {
-	widget.InitializeCommonControls(widget.Refresh)
+	widget.InitializeRefreshKeyboardControl(widget.Refresh)
 
 	widget.SetKeyboardChar("l", widget.NextSource, "Select next source")
 	widget.SetKeyboardChar("h", widget.PrevSource, "Select previous source")

--- a/modules/twitter/settings.go
+++ b/modules/twitter/settings.go
@@ -33,5 +33,7 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 		screenNames:    ymlConfig.UList("screenName"),
 	}
 
+	settings.SetDocumentationPath("twitter/tweets")
+
 	return &settings
 }

--- a/modules/twitter/settings.go
+++ b/modules/twitter/settings.go
@@ -13,7 +13,7 @@ const (
 )
 
 type Settings struct {
-	common *cfg.Common
+	*cfg.Common
 
 	bearerToken    string
 	consumerKey    string
@@ -24,7 +24,7 @@ type Settings struct {
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		bearerToken:    ymlConfig.UString("bearerToken", os.Getenv("WTF_TWITTER_BEARER_TOKEN")),
 		consumerKey:    ymlConfig.UString("consumerKey", os.Getenv("WTF_TWITTER_CONSUMER_KEY")),

--- a/modules/twitter/widget.go
+++ b/modules/twitter/widget.go
@@ -12,7 +12,6 @@ import (
 )
 
 type Widget struct {
-	view.KeyboardWidget
 	view.MultiSourceWidget
 	view.TextWidget
 
@@ -23,16 +22,14 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		KeyboardWidget:    view.NewKeyboardWidget(app, pages, settings.common),
 		MultiSourceWidget: view.NewMultiSourceWidget(settings.common, "screenName", "screenNames"),
-		TextWidget:        view.NewTextWidget(app, settings.common),
+		TextWidget:        view.NewTextWidget(app, pages, settings.common),
 
 		idx:      0,
 		settings: settings,
 	}
 
 	widget.initializeKeyboardControls()
-	widget.View.SetInputCapture(widget.InputCapture)
 
 	widget.SetDisplayFunction(widget.Refresh)
 
@@ -52,10 +49,6 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 // Refresh is called on the interval and refreshes the data
 func (widget *Widget) Refresh() {
 	widget.Redraw(widget.content)
-}
-
-func (widget *Widget) HelpText() string {
-	return widget.KeyboardWidget.HelpText()
 }
 
 /* -------------------- Unexported Functions -------------------- */

--- a/modules/twitter/widget.go
+++ b/modules/twitter/widget.go
@@ -39,8 +39,6 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 	widget.View.SetWrap(true)
 	widget.View.SetWordWrap(true)
 
-	widget.KeyboardWidget.SetView(widget.View)
-
 	return &widget
 }
 

--- a/modules/twitter/widget.go
+++ b/modules/twitter/widget.go
@@ -22,8 +22,8 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		MultiSourceWidget: view.NewMultiSourceWidget(settings.common, "screenName", "screenNames"),
-		TextWidget:        view.NewTextWidget(app, pages, settings.common),
+		MultiSourceWidget: view.NewMultiSourceWidget(settings.Common, "screenName", "screenNames"),
+		TextWidget:        view.NewTextWidget(app, pages, settings.Common),
 
 		idx:      0,
 		settings: settings,
@@ -63,7 +63,7 @@ func (widget *Widget) content() (string, string, bool) {
 	}
 
 	_, _, width, _ := widget.View.GetRect()
-	str := widget.settings.common.PaginationMarker(len(widget.Sources), widget.Idx, width-2) + "\n"
+	str := widget.settings.PaginationMarker(len(widget.Sources), widget.Idx, width-2) + "\n"
 	for _, tweet := range tweets {
 		str += widget.format(tweet)
 	}

--- a/modules/twitterstats/settings.go
+++ b/modules/twitterstats/settings.go
@@ -32,5 +32,7 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 		screenNames: ymlConfig.UList("screenNames"),
 	}
 
+	settings.SetDocumentationPath("twitter/stats")
+
 	return &settings
 }

--- a/modules/twitterstats/settings.go
+++ b/modules/twitterstats/settings.go
@@ -13,7 +13,7 @@ const (
 )
 
 type Settings struct {
-	common *cfg.Common
+	*cfg.Common
 
 	bearerToken    string
 	consumerKey    string
@@ -23,7 +23,7 @@ type Settings struct {
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		bearerToken:    ymlConfig.UString("bearerToken", os.Getenv("WTF_TWITTER_BEARER_TOKEN")),
 		consumerKey:    ymlConfig.UString("consumerKey", os.Getenv("WTF_TWITTER_CONSUMER_KEY")),

--- a/modules/twitterstats/widget.go
+++ b/modules/twitterstats/widget.go
@@ -16,7 +16,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, settings.common),
+		TextWidget: view.NewTextWidget(app, nil, settings.common),
 
 		client:   NewClient(settings),
 		settings: settings,

--- a/modules/twitterstats/widget.go
+++ b/modules/twitterstats/widget.go
@@ -16,7 +16,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, nil, settings.common),
+		TextWidget: view.NewTextWidget(app, nil, settings.Common),
 
 		client:   NewClient(settings),
 		settings: settings,
@@ -37,7 +37,7 @@ func (widget *Widget) content() (string, string, bool) {
 	// Add header row
 	str := fmt.Sprintf(
 		"[%s]%-12s %10s %8s[white]\n",
-		widget.settings.common.Colors.Subheading,
+		widget.settings.Colors.Subheading,
 		"Username",
 		"Followers",
 		"Tweets",

--- a/modules/unknown/settings.go
+++ b/modules/unknown/settings.go
@@ -11,12 +11,12 @@ const (
 )
 
 type Settings struct {
-	common *cfg.Common
+	*cfg.Common
 }
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 	}
 
 	return &settings

--- a/modules/unknown/widget.go
+++ b/modules/unknown/widget.go
@@ -15,7 +15,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, nil, settings.common),
+		TextWidget: view.NewTextWidget(app, nil, settings.Common),
 
 		settings: settings,
 	}

--- a/modules/unknown/widget.go
+++ b/modules/unknown/widget.go
@@ -15,7 +15,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, settings.common),
+		TextWidget: view.NewTextWidget(app, nil, settings.common),
 
 		settings: settings,
 	}

--- a/modules/uptimerobot/settings.go
+++ b/modules/uptimerobot/settings.go
@@ -13,7 +13,7 @@ const (
 )
 
 type Settings struct {
-	common *cfg.Common
+	*cfg.Common
 
 	apiKey        string `help:"An UptimeRobot API key."`
 	uptimePeriods string `help:"The periods over which to display uptime (in days, dash-separated)." optional:"true"`
@@ -23,7 +23,7 @@ type Settings struct {
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		apiKey:        ymlConfig.UString("apiKey", os.Getenv("WTF_UPTIMEROBOT_APIKEY")),
 		uptimePeriods: ymlConfig.UString("uptimePeriods", "30"),

--- a/modules/uptimerobot/widget.go
+++ b/modules/uptimerobot/widget.go
@@ -23,7 +23,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := &Widget{
-		ScrollableWidget: view.NewScrollableWidget(app, pages, settings.common),
+		ScrollableWidget: view.NewScrollableWidget(app, pages, settings.Common),
 
 		settings: settings,
 	}

--- a/modules/uptimerobot/widget.go
+++ b/modules/uptimerobot/widget.go
@@ -14,7 +14,6 @@ import (
 )
 
 type Widget struct {
-	view.KeyboardWidget
 	view.ScrollableWidget
 
 	monitors []Monitor
@@ -24,15 +23,13 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := &Widget{
-		KeyboardWidget:   view.NewKeyboardWidget(app, pages, settings.common),
-		ScrollableWidget: view.NewScrollableWidget(app, settings.common),
+		ScrollableWidget: view.NewScrollableWidget(app, pages, settings.common),
 
 		settings: settings,
 	}
 
 	widget.SetRenderFunction(widget.Render)
 	widget.initializeKeyboardControls()
-	widget.View.SetInputCapture(widget.InputCapture)
 
 	widget.KeyboardWidget.SetView(widget.View)
 

--- a/modules/uptimerobot/widget.go
+++ b/modules/uptimerobot/widget.go
@@ -31,8 +31,6 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 	widget.SetRenderFunction(widget.Render)
 	widget.initializeKeyboardControls()
 
-	widget.KeyboardWidget.SetView(widget.View)
-
 	return widget
 }
 

--- a/modules/victorops/settings.go
+++ b/modules/victorops/settings.go
@@ -13,7 +13,7 @@ const (
 )
 
 type Settings struct {
-	common *cfg.Common
+	*cfg.Common
 
 	apiID  string
 	apiKey string
@@ -22,7 +22,7 @@ type Settings struct {
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		apiID:  ymlConfig.UString("apiID", os.Getenv("WTF_VICTOROPS_API_ID")),
 		apiKey: ymlConfig.UString("apiKey", ymlConfig.UString("apikey", os.Getenv("WTF_VICTOROPS_API_KEY"))),

--- a/modules/victorops/widget.go
+++ b/modules/victorops/widget.go
@@ -19,7 +19,7 @@ type Widget struct {
 // NewWidget creates a new widget
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, nil, settings.common),
+		TextWidget: view.NewTextWidget(app, nil, settings.Common),
 		settings:   settings,
 	}
 

--- a/modules/victorops/widget.go
+++ b/modules/victorops/widget.go
@@ -19,7 +19,7 @@ type Widget struct {
 // NewWidget creates a new widget
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, settings.common),
+		TextWidget: view.NewTextWidget(app, nil, settings.common),
 		settings:   settings,
 	}
 

--- a/modules/weatherservices/arpansagovau/settings.go
+++ b/modules/weatherservices/arpansagovau/settings.go
@@ -11,15 +11,18 @@ const (
 )
 
 type Settings struct {
-	common *cfg.Common
-	city   string
+	*cfg.Common
+
+	city string
 }
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 		city:   ymlConfig.UString("locationid"),
 	}
+
+	settings.SetDocumentationPath("weather_services/arpansagovau")
 
 	return &settings
 }

--- a/modules/weatherservices/arpansagovau/widget.go
+++ b/modules/weatherservices/arpansagovau/widget.go
@@ -18,7 +18,7 @@ type Widget struct {
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	locationData, err := GetLocationData(settings.city)
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, nil, settings.common),
+		TextWidget: view.NewTextWidget(app, nil, settings.Common),
 
 		location:  locationData,
 		lastError: err,

--- a/modules/weatherservices/arpansagovau/widget.go
+++ b/modules/weatherservices/arpansagovau/widget.go
@@ -9,6 +9,7 @@ import (
 
 type Widget struct {
 	view.TextWidget
+
 	location  *location
 	lastError error
 	settings  *Settings
@@ -17,10 +18,11 @@ type Widget struct {
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	locationData, err := GetLocationData(settings.city)
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, settings.common),
-		location:   locationData,
-		lastError:  err,
-		settings:   settings,
+		TextWidget: view.NewTextWidget(app, nil, settings.common),
+
+		location:  locationData,
+		lastError: err,
+		settings:  settings,
 	}
 
 	widget.View.SetWrap(true)
@@ -42,7 +44,6 @@ func (widget *Widget) content() (string, string, bool) {
 }
 
 func (widget *Widget) Refresh() {
-
 	widget.Redraw(widget.content)
 }
 

--- a/modules/weatherservices/prettyweather/settings.go
+++ b/modules/weatherservices/prettyweather/settings.go
@@ -11,7 +11,7 @@ const (
 )
 
 type Settings struct {
-	common *cfg.Common
+	*cfg.Common
 
 	city     string
 	unit     string
@@ -21,13 +21,15 @@ type Settings struct {
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		city:     ymlConfig.UString("city", "Barcelona"),
 		language: ymlConfig.UString("language", "en"),
 		unit:     ymlConfig.UString("unit", "m"),
 		view:     ymlConfig.UString("view", "0"),
 	}
+
+	settings.SetDocumentationPath("weather_services/prettyweather")
 
 	return &settings
 }

--- a/modules/weatherservices/prettyweather/widget.go
+++ b/modules/weatherservices/prettyweather/widget.go
@@ -19,7 +19,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, settings.common),
+		TextWidget: view.NewTextWidget(app, nil, settings.common),
 
 		settings: settings,
 	}

--- a/modules/weatherservices/prettyweather/widget.go
+++ b/modules/weatherservices/prettyweather/widget.go
@@ -19,7 +19,7 @@ type Widget struct {
 
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
 	widget := Widget{
-		TextWidget: view.NewTextWidget(app, nil, settings.common),
+		TextWidget: view.NewTextWidget(app, nil, settings.Common),
 
 		settings: settings,
 	}

--- a/modules/weatherservices/weather/display.go
+++ b/modules/weatherservices/weather/display.go
@@ -38,7 +38,7 @@ func (widget *Widget) content() (string, string, bool) {
 	} else {
 		title = widget.buildTitle(cityData)
 		_, _, width, _ := widget.View.GetRect()
-		content = widget.settings.common.PaginationMarker(len(widget.Data), widget.Idx, width) + "\n"
+		content = widget.settings.PaginationMarker(len(widget.Data), widget.Idx, width) + "\n"
 		content += widget.description(cityData) + "\n\n"
 		content += widget.temperatures(cityData) + "\n"
 		content += widget.sunInfo(cityData)

--- a/modules/weatherservices/weather/keyboard.go
+++ b/modules/weatherservices/weather/keyboard.go
@@ -3,7 +3,7 @@ package weather
 import "github.com/gdamore/tcell"
 
 func (widget *Widget) initializeKeyboardControls() {
-	widget.InitializeCommonControls(widget.Refresh)
+	widget.InitializeRefreshKeyboardControl(widget.Refresh)
 
 	widget.SetKeyboardChar("h", widget.PrevSource, "Select previous city")
 	widget.SetKeyboardChar("l", widget.NextSource, "Select next city")

--- a/modules/weatherservices/weather/settings.go
+++ b/modules/weatherservices/weather/settings.go
@@ -18,7 +18,7 @@ type colors struct {
 
 type Settings struct {
 	colors
-	common *cfg.Common
+	*cfg.Common
 
 	apiKey   string
 	cityIDs  []interface{}
@@ -29,7 +29,7 @@ type Settings struct {
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		apiKey:   ymlConfig.UString("apiKey", ymlConfig.UString("apikey", os.Getenv("WTF_OWM_API_KEY"))),
 		cityIDs:  ymlConfig.UList("cityids"),
@@ -37,6 +37,8 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 		tempUnit: ymlConfig.UString("tempUnit", "C"),
 		useEmoji: ymlConfig.UBool("useEmoji", true),
 	}
+
+	settings.SetDocumentationPath("weather_services/weather/")
 
 	settings.colors.current = ymlConfig.UString("colors.current", "green")
 

--- a/modules/weatherservices/weather/widget.go
+++ b/modules/weatherservices/weather/widget.go
@@ -33,8 +33,6 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 
 	widget.SetDisplayFunction(widget.display)
 
-	widget.KeyboardWidget.SetView(widget.View)
-
 	return &widget
 }
 

--- a/modules/weatherservices/weather/widget.go
+++ b/modules/weatherservices/weather/widget.go
@@ -22,8 +22,8 @@ type Widget struct {
 // NewWidget creates and returns a new instance of the weather Widget
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		MultiSourceWidget: view.NewMultiSourceWidget(settings.common, "cityid", "cityids"),
-		TextWidget:        view.NewTextWidget(app, pages, settings.common),
+		MultiSourceWidget: view.NewMultiSourceWidget(settings.Common, "cityid", "cityids"),
+		TextWidget:        view.NewTextWidget(app, pages, settings.Common),
 
 		pages:    pages,
 		settings: settings,

--- a/modules/weatherservices/weather/widget.go
+++ b/modules/weatherservices/weather/widget.go
@@ -9,7 +9,6 @@ import (
 
 // Widget is the container for weather data.
 type Widget struct {
-	view.KeyboardWidget
 	view.MultiSourceWidget
 	view.TextWidget
 
@@ -23,16 +22,14 @@ type Widget struct {
 // NewWidget creates and returns a new instance of the weather Widget
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		KeyboardWidget:    view.NewKeyboardWidget(app, pages, settings.common),
 		MultiSourceWidget: view.NewMultiSourceWidget(settings.common, "cityid", "cityids"),
-		TextWidget:        view.NewTextWidget(app, settings.common),
+		TextWidget:        view.NewTextWidget(app, pages, settings.common),
 
 		pages:    pages,
 		settings: settings,
 	}
 
 	widget.initializeKeyboardControls()
-	widget.View.SetInputCapture(widget.InputCapture)
 
 	widget.SetDisplayFunction(widget.display)
 
@@ -67,10 +64,6 @@ func (widget *Widget) Refresh() {
 	}
 
 	widget.display()
-}
-
-func (widget *Widget) HelpText() string {
-	return widget.KeyboardWidget.HelpText()
 }
 
 /* -------------------- Unexported Functions -------------------- */

--- a/modules/zendesk/keyboard.go
+++ b/modules/zendesk/keyboard.go
@@ -3,7 +3,7 @@ package zendesk
 import "github.com/gdamore/tcell"
 
 func (widget *Widget) initializeKeyboardControls() {
-	widget.InitializeCommonControls(widget.Refresh)
+	widget.InitializeRefreshKeyboardControl(widget.Refresh)
 
 	widget.SetKeyboardChar("j", widget.Next, "Select next item")
 	widget.SetKeyboardChar("k", widget.Prev, "Select previous item")

--- a/modules/zendesk/settings.go
+++ b/modules/zendesk/settings.go
@@ -13,7 +13,7 @@ const (
 )
 
 type Settings struct {
-	common *cfg.Common
+	*cfg.Common
 
 	apiKey    string
 	status    string
@@ -23,7 +23,7 @@ type Settings struct {
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := Settings{
-		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		apiKey:    ymlConfig.UString("apiKey", ymlConfig.UString("apikey", os.Getenv("ZENDESK_API"))),
 		status:    ymlConfig.UString("status"),

--- a/modules/zendesk/widget.go
+++ b/modules/zendesk/widget.go
@@ -10,7 +10,6 @@ import (
 
 // A Widget represents a Zendesk widget
 type Widget struct {
-	view.KeyboardWidget
 	view.ScrollableWidget
 
 	result   *TicketArray
@@ -21,16 +20,14 @@ type Widget struct {
 // NewWidget creates a new instance of a widget
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		KeyboardWidget:   view.NewKeyboardWidget(app, pages, settings.common),
-		ScrollableWidget: view.NewScrollableWidget(app, settings.common),
+		ScrollableWidget: view.NewScrollableWidget(app, pages, settings.common),
 
 		settings: settings,
 	}
 
 	widget.SetRenderFunction(widget.Render)
-	widget.initializeKeyboardControls()
-	widget.View.SetInputCapture(widget.InputCapture)
 
+	widget.initializeKeyboardControls()
 	widget.KeyboardWidget.SetView(widget.View)
 
 	return &widget

--- a/modules/zendesk/widget.go
+++ b/modules/zendesk/widget.go
@@ -28,7 +28,6 @@ func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *
 	widget.SetRenderFunction(widget.Render)
 
 	widget.initializeKeyboardControls()
-	widget.KeyboardWidget.SetView(widget.View)
 
 	return &widget
 }

--- a/modules/zendesk/widget.go
+++ b/modules/zendesk/widget.go
@@ -20,7 +20,7 @@ type Widget struct {
 // NewWidget creates a new instance of a widget
 func NewWidget(app *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
-		ScrollableWidget: view.NewScrollableWidget(app, pages, settings.common),
+		ScrollableWidget: view.NewScrollableWidget(app, pages, settings.Common),
 
 		settings: settings,
 	}
@@ -68,9 +68,9 @@ func (widget *Widget) content() (string, string, bool) {
 }
 
 func (widget *Widget) format(ticket Ticket, idx int) string {
-	textColor := widget.settings.common.Colors.Background
+	textColor := widget.settings.Colors.Background
 	if idx == widget.GetSelected() {
-		textColor = widget.settings.common.Colors.BorderTheme.Focused
+		textColor = widget.settings.Colors.BorderTheme.Focused
 	}
 
 	requesterName := widget.parseRequester(ticket)

--- a/view/bargraph.go
+++ b/view/bargraph.go
@@ -16,6 +16,8 @@ type BarGraph struct {
 	starChar string
 
 	Base
+	KeyboardWidget
+
 	View *tview.TextView
 }
 
@@ -30,7 +32,8 @@ type Bar struct {
 // NewBarGraph creates and returns an instance of BarGraph
 func NewBarGraph(app *tview.Application, name string, commonSettings *cfg.Common) BarGraph {
 	widget := BarGraph{
-		Base: NewBase(app, commonSettings),
+		Base:           NewBase(app, commonSettings),
+		KeyboardWidget: NewKeyboardWidget(app, nil, commonSettings),
 
 		maxStars: commonSettings.Config.UInt("graphStars", 20),
 		starChar: commonSettings.Config.UString("graphIcon", "|"),

--- a/view/bargraph.go
+++ b/view/bargraph.go
@@ -15,8 +15,8 @@ type BarGraph struct {
 	maxStars int
 	starChar string
 
-	Base
-	KeyboardWidget
+	*Base
+	*KeyboardWidget
 
 	View *tview.TextView
 }

--- a/view/base.go
+++ b/view/base.go
@@ -25,8 +25,8 @@ type Base struct {
 
 // NewBase creates and returns an instance of the Base module, the lowest-level
 // primitive module from which all others are derived
-func NewBase(app *tview.Application, commonSettings *cfg.Common) Base {
-	base := Base{
+func NewBase(app *tview.Application, commonSettings *cfg.Common) *Base {
+	base := &Base{
 		commonSettings: commonSettings,
 
 		app:             app,

--- a/view/base.go
+++ b/view/base.go
@@ -23,20 +23,24 @@ type Base struct {
 	enabledMutex    *sync.Mutex
 }
 
+// NewBase creates and returns an instance of the Base module, the lowest-level
+// primitive module from which all others are derived
 func NewBase(app *tview.Application, commonSettings *cfg.Common) Base {
 	base := Base{
-		commonSettings:  commonSettings,
+		commonSettings: commonSettings,
+
 		app:             app,
 		bordered:        commonSettings.Bordered,
 		enabled:         commonSettings.Enabled,
+		enabledMutex:    &sync.Mutex{},
 		focusChar:       commonSettings.FocusChar(),
 		focusable:       commonSettings.Focusable,
 		name:            commonSettings.Name,
 		quitChan:        make(chan bool),
 		refreshInterval: commonSettings.RefreshInterval,
 		refreshing:      false,
-		enabledMutex:    &sync.Mutex{},
 	}
+
 	return base
 }
 
@@ -106,10 +110,6 @@ func (base *Base) Focusable() bool {
 
 func (base *Base) FocusChar() string {
 	return base.focusChar
-}
-
-func (base *Base) HelpText() string {
-	return fmt.Sprintf("\n  There is no help available for widget %s", base.commonSettings.Module.Type)
 }
 
 func (base *Base) Name() string {

--- a/view/keyboard_widget.go
+++ b/view/keyboard_widget.go
@@ -32,8 +32,8 @@ type KeyboardWidget struct {
 }
 
 // NewKeyboardWidget creates and returns a new instance of KeyboardWidget
-func NewKeyboardWidget(app *tview.Application, pages *tview.Pages, settings *cfg.Common) KeyboardWidget {
-	keyWidget := KeyboardWidget{
+func NewKeyboardWidget(app *tview.Application, pages *tview.Pages, settings *cfg.Common) *KeyboardWidget {
+	keyWidget := &KeyboardWidget{
 		app:      app,
 		pages:    pages,
 		settings: settings,
@@ -49,6 +49,17 @@ func NewKeyboardWidget(app *tview.Application, pages *tview.Pages, settings *cfg
 }
 
 /* -------------------- Exported Functions --------------------- */
+
+// AssignedChars returns a list of all the text characters assigned to an operation
+func (widget *KeyboardWidget) AssignedChars() []string {
+	chars := []string{}
+
+	for char := range widget.charMap {
+		chars = append(chars, char)
+	}
+
+	return chars
+}
 
 // HelpText returns the help text and keyboard command info for this widget
 func (widget *KeyboardWidget) HelpText() string {

--- a/view/keyboard_widget.go
+++ b/view/keyboard_widget.go
@@ -113,7 +113,12 @@ func (widget *KeyboardWidget) InputCapture(event *tcell.EventKey) *tcell.EventKe
 
 // LaunchDocumentation opens the module docs in a browser
 func (widget *KeyboardWidget) LaunchDocumentation() {
-	url := "https://wtfutil.com/modules/" + widget.settings.Name
+	path := widget.settings.DocPath
+	if path == "" {
+		path = widget.settings.Type
+	}
+
+	url := "https://wtfutil.com/modules/" + path
 	utils.OpenFile(url)
 }
 

--- a/view/keyboard_widget.go
+++ b/view/keyboard_widget.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gdamore/tcell"
 	"github.com/rivo/tview"
 	"github.com/wtfutil/wtf/cfg"
+	"github.com/wtfutil/wtf/utils"
 )
 
 type helpItem struct {
@@ -80,6 +81,7 @@ func (widget *KeyboardWidget) SetKeyboardKey(key tcell.Key, fn func(), helpText 
 // all widgets that accept keyboard input
 func (widget *KeyboardWidget) InitializeCommonControls(refreshFunc func()) {
 	widget.SetKeyboardChar("/", widget.ShowHelp, "Show/hide this help prompt")
+	widget.SetKeyboardChar("\\", widget.OpenDocs, "Open the docs in a browser")
 
 	if refreshFunc != nil {
 		widget.SetKeyboardChar("r", refreshFunc, "Refresh widget")
@@ -127,10 +129,18 @@ func (widget *KeyboardWidget) HelpText() string {
 	return str
 }
 
+// OpenDocs opens the module docs in a browser
+func (widget *KeyboardWidget) OpenDocs() {
+	url := "https://wtfutil.com/modules/" + widget.settings.Name
+	utils.OpenFile(url)
+}
+
+// SetView assigns the passed-in tview.TextView view to this widget
 func (widget *KeyboardWidget) SetView(view *tview.TextView) {
 	widget.view = view
 }
 
+// ShowHelp displays the modal help dialog for a module
 func (widget *KeyboardWidget) ShowHelp() {
 	closeFunc := func() {
 		widget.pages.RemovePage("help")

--- a/view/keyboard_widget_test.go
+++ b/view/keyboard_widget_test.go
@@ -174,18 +174,26 @@ func Test_InputCapture(t *testing.T) {
 	}
 }
 
-func Test_InitializeCommonControls(t *testing.T) {
+func Test_initializeCommonKeyboardControls(t *testing.T) {
 	t.Run("nil refreshFunc", func(t *testing.T) {
 		keyWid := testKeyboardWidget()
-		keyWid.InitializeCommonControls(nil)
 
 		assert.NotNil(t, keyWid.charMap["/"])
+		assert.NotNil(t, keyWid.charMap["\\"])
+	})
+}
+
+func Test_InitializeRefreshKeyboardControl(t *testing.T) {
+	t.Run("nil refreshFunc", func(t *testing.T) {
+		keyWid := testKeyboardWidget()
+		keyWid.InitializeRefreshKeyboardControl(nil)
+
 		assert.Nil(t, keyWid.charMap["r"])
 	})
 
 	t.Run("non-nil refreshFunc", func(t *testing.T) {
 		keyWid := testKeyboardWidget()
-		keyWid.InitializeCommonControls(func() {})
+		keyWid.InitializeRefreshKeyboardControl(func() {})
 
 		assert.NotNil(t, keyWid.charMap["r"])
 	})

--- a/view/keyboard_widget_test.go
+++ b/view/keyboard_widget_test.go
@@ -11,7 +11,7 @@ import (
 
 func test() {}
 
-func testKeyboardWidget() KeyboardWidget {
+func testKeyboardWidget() *KeyboardWidget {
 	keyWid := NewKeyboardWidget(
 		tview.NewApplication(),
 		tview.NewPages(),
@@ -118,25 +118,25 @@ func Test_SetKeyboardKey(t *testing.T) {
 func Test_InputCapture(t *testing.T) {
 	tests := []struct {
 		name     string
-		before   func(keyWid KeyboardWidget) KeyboardWidget
+		before   func(keyWid *KeyboardWidget) *KeyboardWidget
 		event    *tcell.EventKey
 		expected *tcell.EventKey
 	}{
 		{
 			name:     "with nil event",
-			before:   func(keyWid KeyboardWidget) KeyboardWidget { return keyWid },
+			before:   func(keyWid *KeyboardWidget) *KeyboardWidget { return keyWid },
 			event:    nil,
 			expected: nil,
 		},
 		{
 			name:     "with undefined event",
-			before:   func(keyWid KeyboardWidget) KeyboardWidget { return keyWid },
+			before:   func(keyWid *KeyboardWidget) *KeyboardWidget { return keyWid },
 			event:    tcell.NewEventKey(tcell.KeyRune, 'a', tcell.ModNone),
 			expected: tcell.NewEventKey(tcell.KeyRune, 'a', tcell.ModNone),
 		},
 		{
 			name: "with defined event and char handler",
-			before: func(keyWid KeyboardWidget) KeyboardWidget {
+			before: func(keyWid *KeyboardWidget) *KeyboardWidget {
 				keyWid.SetKeyboardChar("a", test, "help")
 				return keyWid
 			},
@@ -145,7 +145,7 @@ func Test_InputCapture(t *testing.T) {
 		},
 		{
 			name: "with defined event and key handler",
-			before: func(keyWid KeyboardWidget) KeyboardWidget {
+			before: func(keyWid *KeyboardWidget) *KeyboardWidget {
 				keyWid.SetKeyboardKey(tcell.KeyRune, test, "help")
 				return keyWid
 			},

--- a/view/scrollable_widget.go
+++ b/view/scrollable_widget.go
@@ -15,9 +15,9 @@ type ScrollableWidget struct {
 	RenderFunction func()
 }
 
-func NewScrollableWidget(app *tview.Application, commonSettings *cfg.Common) ScrollableWidget {
+func NewScrollableWidget(app *tview.Application, pages *tview.Pages, commonSettings *cfg.Common) ScrollableWidget {
 	widget := ScrollableWidget{
-		TextWidget: NewTextWidget(app, commonSettings),
+		TextWidget: NewTextWidget(app, pages, commonSettings),
 	}
 
 	widget.Unselect()
@@ -84,7 +84,7 @@ func (widget *ScrollableWidget) Unselect() {
 func (widget *ScrollableWidget) Redraw(data func() (string, string, bool)) {
 	widget.TextWidget.Redraw(data)
 
-	widget.app.QueueUpdateDraw(func() {
+	widget.Base.app.QueueUpdateDraw(func() {
 		widget.View.Highlight(strconv.Itoa(widget.Selected)).ScrollToHighlight()
 	})
 }

--- a/view/text_widget.go
+++ b/view/text_widget.go
@@ -11,36 +11,39 @@ import (
 // TextWidget defines the data necessary to make a text widget
 type TextWidget struct {
 	Base
+	KeyboardWidget
+
 	View *tview.TextView
 }
 
 // NewTextWidget creates and returns an instance of TextWidget
-func NewTextWidget(app *tview.Application, commonSettings *cfg.Common) TextWidget {
+func NewTextWidget(app *tview.Application, pages *tview.Pages, commonSettings *cfg.Common) TextWidget {
 	widget := TextWidget{
-		Base: NewBase(app, commonSettings),
+		Base:           NewBase(app, commonSettings),
+		KeyboardWidget: NewKeyboardWidget(app, pages, commonSettings),
 	}
 
 	widget.View = widget.createView(widget.bordered)
+	widget.View.SetInputCapture(widget.InputCapture)
 
 	return widget
 }
 
 /* -------------------- Exported Functions -------------------- */
 
+// TextView returns the tview.TextView instance
 func (widget *TextWidget) TextView() *tview.TextView {
 	return widget.View
 }
 
 func (widget *TextWidget) Redraw(data func() (string, string, bool)) {
-	widget.app.QueueUpdateDraw(func() {
+	widget.Base.app.QueueUpdateDraw(func() {
 		title, content, wrap := data()
 
 		widget.View.Clear()
 		widget.View.SetWrap(wrap)
 		widget.View.SetTitle(widget.ContextualTitle(title))
-		// widget.View.SetText(strings.TrimSpace(content))
 		widget.View.SetText(strings.TrimRight(content, "\n"))
-		// widget.View.SetText(content)
 	})
 }
 

--- a/view/text_widget.go
+++ b/view/text_widget.go
@@ -10,8 +10,8 @@ import (
 
 // TextWidget defines the data necessary to make a text widget
 type TextWidget struct {
-	Base
-	KeyboardWidget
+	*Base
+	*KeyboardWidget
 
 	View *tview.TextView
 }
@@ -24,7 +24,9 @@ func NewTextWidget(app *tview.Application, pages *tview.Pages, commonSettings *c
 	}
 
 	widget.View = widget.createView(widget.bordered)
-	widget.View.SetInputCapture(widget.InputCapture)
+	widget.View.SetInputCapture(widget.KeyboardWidget.InputCapture)
+
+	widget.KeyboardWidget.SetView(widget.View)
 
 	return widget
 }

--- a/view/text_widget_test.go
+++ b/view/text_widget_test.go
@@ -10,6 +10,7 @@ import (
 func testTextWidget() TextWidget {
 	txtWid := NewTextWidget(
 		tview.NewApplication(),
+		tview.NewPages(),
 		&cfg.Common{
 			Module: cfg.Module{
 				Name: "test widget",


### PR DESCRIPTION
This PR adds a common keyboard shortcut ("\\") that opens a module's site documentation in the browser.

For instance, pressing "\\" while in the GitHub module will open https://wtfutil.com/modules/github/.

It also necessitated a complete refactor of the keyboard handling, for the better. Every widget is now a `KeyboardWidget`  and keyboard access is controlled by whether or not the widget is focusable. If a widget is focusable, it will automatically accept keyboard events (even if it does nothing with them).

This has the added advantage of simplifying the boilerplate code necessary to create a new module.