### PR TITLE
[CircleCI] Close the response body

### DIFF
--- a/modules/circleci/client.go
+++ b/modules/circleci/client.go
@@ -60,6 +60,7 @@ func (client *Client) circleRequest(path string) (*http.Response, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
 		return nil, fmt.Errorf(resp.Status)


### PR DESCRIPTION
To avoid leaks, similar to what was done in another module: https://github.com/wtfutil/wtf/blob/cde904ff08897c0702de54d1dce0e5d21572bc0c/modules/bamboohr/request.go#L21.