### PR TITLE
Add support for user-configuration language tag specification.

### DIFF
--- a/modules/github/display.go
+++ b/modules/github/display.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 
 	ghb "github.com/google/go-github/v32/github"
-	"golang.org/x/text/language"
-	"golang.org/x/text/message"
 )
 
 func (widget *Widget) display() {
@@ -124,13 +122,16 @@ func (widget *Widget) displayMyReviewRequests(repo *Repo, username string) strin
 }
 
 func (widget *Widget) displayStats(repo *Repo) string {
-	prntr := message.NewPrinter(language.English)
+	locPrinter, err := widget.settings.LocalizedPrinter()
+	if err != nil {
+		return err.Error()
+	}
 
 	str := fmt.Sprintf(
 		" PRs: %s  Issues: %s  Stars: %s\n",
-		prntr.Sprintf("%d", repo.PullRequestCount()),
-		prntr.Sprintf("%d", repo.IssueCount()),
-		prntr.Sprintf("%d", repo.StarCount()),
+		locPrinter.Sprintf("%d", repo.PullRequestCount()),
+		locPrinter.Sprintf("%d", repo.IssueCount()),
+		locPrinter.Sprintf("%d", repo.StarCount()),
 	)
 
 	return str

--- a/modules/twitch/widget.go
+++ b/modules/twitch/widget.go
@@ -105,12 +105,14 @@ func (widget *Widget) content() (string, string, bool) {
 	}
 	var str string
 
+	locPrinter, _ := widget.settings.LocalizedPrinter()
+
 	for idx, stream := range widget.topStreams {
 		row := fmt.Sprintf(
 			"[%s]%2d. [red]%s [white]%s",
 			widget.RowColor(idx),
 			idx+1,
-			utils.PrettyNumber(float64(stream.ViewerCount)),
+			utils.PrettyNumber(locPrinter, float64(stream.ViewerCount)),
 			stream.Streamer,
 		)
 		str += utils.HighlightableHelper(widget.View, row, idx, len(stream.Streamer))

--- a/utils/text.go
+++ b/utils/text.go
@@ -5,7 +5,6 @@ import (
 	"math"
 	"strings"
 
-	"golang.org/x/text/language"
 	"golang.org/x/text/message"
 
 	"github.com/rivo/tview"
@@ -78,12 +77,10 @@ func Truncate(src string, maxLen int, withEllipse bool) string {
 }
 
 // PrettyNumber formats number as string with 1000 delimiters and, if necessary, rounds it to 2 decimals
-func PrettyNumber(number float64) string {
-	p := message.NewPrinter(language.English)
-
+func PrettyNumber(prtr *message.Printer, number float64) string {
 	if number == math.Trunc(number) {
-		return p.Sprintf("%.0f", number)
+		return prtr.Sprintf("%.0f", number)
 	}
 
-	return p.Sprintf("%.2f", number)
+	return prtr.Sprintf("%.2f", number)
 }

--- a/utils/text_test.go
+++ b/utils/text_test.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/rivo/tview"
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/text/language"
+	"golang.org/x/text/message"
 )
 
 func Test_CenterText(t *testing.T) {
@@ -45,15 +47,17 @@ func Test_Truncate(t *testing.T) {
 }
 
 func Test_PrettyNumber(t *testing.T) {
-	assert.Equal(t, "1,000,000", PrettyNumber(1000000))
-	assert.Equal(t, "1,000,000.99", PrettyNumber(1000000.99))
-	assert.Equal(t, "1,000,000", PrettyNumber(1000000.00))
-	assert.Equal(t, "100,000", PrettyNumber(100000))
-	assert.Equal(t, "100,000.01", PrettyNumber(100000.009))
-	assert.Equal(t, "10,000", PrettyNumber(10000))
-	assert.Equal(t, "1,000", PrettyNumber(1000))
-	assert.Equal(t, "1,000", PrettyNumber(1000))
-	assert.Equal(t, "100", PrettyNumber(100))
-	assert.Equal(t, "0", PrettyNumber(0))
-	assert.Equal(t, "0.10", PrettyNumber(0.1))
+	locPrinter := message.NewPrinter(language.English)
+
+	assert.Equal(t, "1,000,000", PrettyNumber(locPrinter, 1000000))
+	assert.Equal(t, "1,000,000.99", PrettyNumber(locPrinter, 1000000.99))
+	assert.Equal(t, "1,000,000", PrettyNumber(locPrinter, 1000000.00))
+	assert.Equal(t, "100,000", PrettyNumber(locPrinter, 100000))
+	assert.Equal(t, "100,000.01", PrettyNumber(locPrinter, 100000.009))
+	assert.Equal(t, "10,000", PrettyNumber(locPrinter, 10000))
+	assert.Equal(t, "1,000", PrettyNumber(locPrinter, 1000))
+	assert.Equal(t, "1,000", PrettyNumber(locPrinter, 1000))
+	assert.Equal(t, "100", PrettyNumber(locPrinter, 100))
+	assert.Equal(t, "0", PrettyNumber(locPrinter, 0))
+	assert.Equal(t, "0.10", PrettyNumber(locPrinter, 0.1))
 }


### PR DESCRIPTION
Adds a new top-level configuration key called "language":

```yaml
wtf:
  langauge: "ja-JP"
```

Users can now define which BCP 47 language tag to use to format any
text or numbers that currently support localization. Defaults to
"en-CA".

Acceptible values: any BCP 47 language tag recognized by the Go
"language" package.

Good luck to you figuring out what that cannonical list is. After a
morning of trying to suss it out, I have no idea.

Example:

To use in a module, something like:

```go
    prntr, err := widget.settings.LocalizedPrinter()
    if err != nil {
        return err.Error()
    }

    prntr.Printf("%d\n", 12345678)  // => 12,345,678
```

Signed-off-by: Chris Cummer <chriscummer@me.com>