### PR TITLE
Fix for potential runtime panic

### DIFF
--- a/modules/healthchecks/widget.go
+++ b/modules/healthchecks/widget.go
@@ -165,13 +165,14 @@ func (widget *Widget) getExistingChecks() ([]Checks, error) {
 	req.Header.Set("X-Api-Key", widget.settings.apiKey)
 	resp, err := http.DefaultClient.Do(req)
 
+	if err != nil {
+		return nil, err
+	}
+
 	if resp.StatusCode != 200 {
 		return nil, fmt.Errorf(resp.Status)
 	}
 
-	if err != nil {
-		return nil, err
-	}
 	defer func() { _ = resp.Body.Close() }()
 
 	var health Health


### PR DESCRIPTION
Switch error checking around, so we don't check the StatusCode before
handling client errors.