### PR TITLE
Enhance Kubernetes module with Replica Count (Deployments)

### DIFF
--- a/modules/kubernetes/widget.go
+++ b/modules/kubernetes/widget.go
@@ -164,9 +164,9 @@ func (client *clientInstance) getDeployments(namespaces []string) ([]string, err
 			for _, deployment := range deployments.Items {
 				var deployString string
 				if len(namespaces) == 1 {
-					deployString = fmt.Sprintf("%-50s", deployment.ObjectMeta.Name)
+					deployString = fmt.Sprintf("%-50s (%d/%d)", deployment.ObjectMeta.Name, deployment.Status.ReadyReplicas, deployment.Status.Replicas)
 				} else {
-					deployString = fmt.Sprintf("%-20s %-50s", deployment.ObjectMeta.Namespace, deployment.ObjectMeta.Name)
+					deployString = fmt.Sprintf("%-20s %-50s (%d/%d)", deployment.ObjectMeta.Namespace, deployment.ObjectMeta.Name, deployment.Status.ReadyReplicas, deployment.Status.Replicas)
 				}
 				deploymentList = append(deploymentList, deployString)
 			}
@@ -178,7 +178,7 @@ func (client *clientInstance) getDeployments(namespaces []string) ([]string, err
 		}
 
 		for _, deployment := range deployments.Items {
-			deployString := fmt.Sprintf("%-20s %-50s", deployment.ObjectMeta.Namespace, deployment.ObjectMeta.Name)
+			deployString := fmt.Sprintf("%-20s %-50s (%d/%d)", deployment.ObjectMeta.Namespace, deployment.ObjectMeta.Name, deployment.Status.ReadyReplicas, deployment.Status.Replicas)
 			deploymentList = append(deploymentList, deployString)
 		}
 	}


### PR DESCRIPTION
Hey,

first of all, `wtf` is really an awesome tool! Thank you for your work on wtf!

This commit adds the ReadyReplicas and Total Replicas count, the information is useful if you want to look over a new (rolling) release of your application in k8s and want to know how many pods are ready/started from k8s. Otherwise, the `deployments` option of this module is not that useful.

Signed-off-by: Lukas Kämmerling <lukas.kaemmerling@hetzner-cloud.de>

Sample screenshot:
![Bildschirmfoto 2021-03-18 um 07 34 56](https://user-images.githubusercontent.com/4281581/111583351-8e8ae200-87bc-11eb-8b2b-111c617f3b0d.png)
