### PR TITLE
1088 - Add strings.Replace to prevent line breaks

### DIFF
--- a/modules/feedreader/widget.go
+++ b/modules/feedreader/widget.go
@@ -51,13 +51,14 @@ func rotateShowType(showtype ShowType) ShowType {
 }
 
 func getShowText(feedItem *FeedItem, showType ShowType) string {
-	returnValue := feedItem.item.Title
+	title := strings.Replace(feedItem.item.Title, "\n", " ", -1)
+	returnValue := title
 	switch showType {
 	case SHOW_LINK:
 		returnValue = feedItem.item.Link
 	case SHOW_CONTENT:
 		text, _ := html2text.FromString(feedItem.item.Content, html2text.Options{PrettyTables: true})
-		returnValue = strings.TrimSpace(feedItem.item.Title + "\n" + strings.TrimSpace(text))
+		returnValue = strings.TrimSpace(title + "\n" + strings.TrimSpace(text))
 	}
 	return returnValue
 }

--- a/modules/feedreader/widget.go
+++ b/modules/feedreader/widget.go
@@ -2,6 +2,7 @@ package feedreader
 
 import (
 	"fmt"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -51,7 +52,8 @@ func rotateShowType(showtype ShowType) ShowType {
 }
 
 func getShowText(feedItem *FeedItem, showType ShowType) string {
-	title := strings.Replace(feedItem.item.Title, "\n", " ", -1)
+	space := regexp.MustCompile(`\s+`)
+	title := space.ReplaceAllString(feedItem.item.Title, " ")
 	returnValue := title
 	switch showType {
 	case SHOW_LINK:


### PR DESCRIPTION
Hey 👋,

I discovered gofeed doesn't check for line breaks within each item title. Also, I searched for how to implement multiline titles in Medium but I didn't have luck because it is a little weird to use it, but some people apply it.

Then, my solution was to replace all line breaks '\n' before it is presented on the widget.

I ran all tests as well.