### PR TITLE
Use HealthChecks API URL from settings when retrieving secret

### DIFF
--- a/modules/healthchecks/settings.go
+++ b/modules/healthchecks/settings.go
@@ -32,7 +32,7 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	}
 
 	cfg.ModuleSecret(name, globalConfig, &settings.apiKey).
-		Service("https://hc-ping.com/").Load()
+		Service(settings.apiURL).Load()
 
 	return &settings
 }


### PR DESCRIPTION
This allows one to use the secret store with a self-hosted HealthChecks instance.

Without this, you are required to always save the secret against a specific URL: "https://hc-ping.com/".
