### PR TITLE
minor modules/git improvements through more config options

### DIFF
--- a/modules/git/display.go
+++ b/modules/git/display.go
@@ -18,7 +18,7 @@ func (widget *Widget) content() (string, string, bool) {
 
 	widgetTitle := ""
 	if widget.settings.lastFolderTitle {
-		pathParts := strings.Split(repoData.Repository,"/")
+		pathParts := strings.Split(repoData.Repository, "/")
 		widgetTitle += pathParts[len(pathParts)-1]
 
 	} else {

--- a/modules/git/settings.go
+++ b/modules/git/settings.go
@@ -1,7 +1,6 @@
 package git
 
 import (
-	"fmt"
 	"github.com/olebedev/config"
 	"github.com/wtfutil/wtf/cfg"
 	"github.com/wtfutil/wtf/utils"
@@ -16,7 +15,7 @@ type Settings struct {
 	*cfg.Common
 
 	commitCount      int           `help:"The number of past commits to display." values:"A positive integer, 0..n." optional:"true"`
-	sections         []string      `help:"Sections to show" optional:"true" default:"["branch","files","commits"]"`
+	sections         []interface{} `help:"Sections to show" optional:"true" default:"["branch","files","commits"]"`
 	showModuleName   bool          `help:"Whether to show 'Git - ' before information in title" optional:"true" default:"true"`
 	branchInTitle    bool          `help:"Whether to show branch name in title instead of the widget body itself" optional:"true" default:"false"`
 	showFilesIfEmpty bool          `help:"Whether to show Changed Files section if no changed files" optional:"true" default:"true"`
@@ -27,16 +26,11 @@ type Settings struct {
 }
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
-	yml_sections := ymlConfig.UList("sections")
-	sections := make([]string, len(yml_sections))
-	for i, v := range yml_sections {
-		sections[i] = fmt.Sprint(v)
-	}
 	settings := Settings{
 		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		commitCount:      ymlConfig.UInt("commitCount", 10),
-		sections:         sections,
+		sections:         ymlConfig.UList("sections"),
 		showModuleName:   ymlConfig.UBool("showModuleName", true),
 		branchInTitle:    ymlConfig.UBool("branchInTitle", false),
 		showFilesIfEmpty: ymlConfig.UBool("showFilesIfEmpty", true),
@@ -46,10 +40,9 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 		repositories:     ymlConfig.UList("repositories"),
 	}
 	if len(settings.sections) == 0 {
-		settings.sections = make([]string, 3)
-		settings.sections[0] = "branch"
-		settings.sections[1] = "files"
-		settings.sections[2] = "commits"
+		for _, v := range []string{"branch", "files", "commits"} {
+			settings.sections = append(settings.sections, v)
+		}
 	}
 
 	return &settings

--- a/modules/git/settings.go
+++ b/modules/git/settings.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"fmt"
 	"github.com/olebedev/config"
 	"github.com/wtfutil/wtf/cfg"
 	"github.com/wtfutil/wtf/utils"
@@ -15,19 +16,40 @@ type Settings struct {
 	*cfg.Common
 
 	commitCount  int           `help:"The number of past commits to display." values:"A positive integer, 0..n." optional:"true"`
+	sections []string `help:"Sections to show" optional:"true" default:"["branch","files","commits"]"`
+	showModuleName bool `help:"Whether to show 'Git - ' before information in title" optional:"true" default:"true"`
+	branchInTitle bool `help:"Whether to show branch name in title instead of the widget body itself" optional:"true" default:"false"`
+	showFilesIfEmpty bool `help:"Whether to show Changed Files section if no changed files" optional:"true" default:"true"`
+	lastFolderTitle bool `help:"Whether to show only last part of directory path instead of full path" optional:"true" default:"false"`
 	commitFormat string        `help:"The string format for the commit message." optional:"true"`
 	dateFormat   string        `help:"The string format for the date/time in the commit message." optional:"true"`
 	repositories []interface{} `help:"Defines which git repositories to watch." values:"A list of zero or more local file paths pointing to valid git repositories."`
 }
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
+	yml_sections := ymlConfig.UList("sections")
+	sections := make([]string, len(yml_sections))
+	for i, v := range yml_sections {
+		sections[i] = fmt.Sprint(v)
+	}
 	settings := Settings{
 		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		commitCount:  ymlConfig.UInt("commitCount", 10),
+		sections: sections,
+		showModuleName: ymlConfig.UBool("showModuleName", true),
+		branchInTitle: ymlConfig.UBool("branchInTitle", false),
+		showFilesIfEmpty: ymlConfig.UBool("showFilesIfEmpty", true),
+		lastFolderTitle: ymlConfig.UBool("lastFolderTitle", false),
 		commitFormat: ymlConfig.UString("commitFormat", "[forestgreen]%h [white]%s [grey]%an on %cd[white]"),
 		dateFormat:   ymlConfig.UString("dateFormat", "%b %d, %Y"),
 		repositories: ymlConfig.UList("repositories"),
+	}
+	if len(settings.sections) == 0 {
+		settings.sections = make([]string, 3)
+		settings.sections[0] = "branch"
+		settings.sections[1] = "files"
+		settings.sections[2] = "commits"
 	}
 
 	return &settings

--- a/modules/git/settings.go
+++ b/modules/git/settings.go
@@ -15,7 +15,7 @@ type Settings struct {
 	*cfg.Common
 
 	commitCount      int           `help:"The number of past commits to display." values:"A positive integer, 0..n." optional:"true"`
-	sections         []interface{} `help:"Sections to show" optional:"true" default:"["branch","files","commits"]"`
+	sections         []interface{} `help:"Sections to show" optional:"true"`
 	showModuleName   bool          `help:"Whether to show 'Git - ' before information in title" optional:"true" default:"true"`
 	branchInTitle    bool          `help:"Whether to show branch name in title instead of the widget body itself" optional:"true" default:"false"`
 	showFilesIfEmpty bool          `help:"Whether to show Changed Files section if no changed files" optional:"true" default:"true"`

--- a/modules/git/settings.go
+++ b/modules/git/settings.go
@@ -15,15 +15,15 @@ const (
 type Settings struct {
 	*cfg.Common
 
-	commitCount  int           `help:"The number of past commits to display." values:"A positive integer, 0..n." optional:"true"`
-	sections []string `help:"Sections to show" optional:"true" default:"["branch","files","commits"]"`
-	showModuleName bool `help:"Whether to show 'Git - ' before information in title" optional:"true" default:"true"`
-	branchInTitle bool `help:"Whether to show branch name in title instead of the widget body itself" optional:"true" default:"false"`
-	showFilesIfEmpty bool `help:"Whether to show Changed Files section if no changed files" optional:"true" default:"true"`
-	lastFolderTitle bool `help:"Whether to show only last part of directory path instead of full path" optional:"true" default:"false"`
-	commitFormat string        `help:"The string format for the commit message." optional:"true"`
-	dateFormat   string        `help:"The string format for the date/time in the commit message." optional:"true"`
-	repositories []interface{} `help:"Defines which git repositories to watch." values:"A list of zero or more local file paths pointing to valid git repositories."`
+	commitCount      int           `help:"The number of past commits to display." values:"A positive integer, 0..n." optional:"true"`
+	sections         []string      `help:"Sections to show" optional:"true" default:"["branch","files","commits"]"`
+	showModuleName   bool          `help:"Whether to show 'Git - ' before information in title" optional:"true" default:"true"`
+	branchInTitle    bool          `help:"Whether to show branch name in title instead of the widget body itself" optional:"true" default:"false"`
+	showFilesIfEmpty bool          `help:"Whether to show Changed Files section if no changed files" optional:"true" default:"true"`
+	lastFolderTitle  bool          `help:"Whether to show only last part of directory path instead of full path" optional:"true" default:"false"`
+	commitFormat     string        `help:"The string format for the commit message." optional:"true"`
+	dateFormat       string        `help:"The string format for the date/time in the commit message." optional:"true"`
+	repositories     []interface{} `help:"Defines which git repositories to watch." values:"A list of zero or more local file paths pointing to valid git repositories."`
 }
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
@@ -35,15 +35,15 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	settings := Settings{
 		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
-		commitCount:  ymlConfig.UInt("commitCount", 10),
-		sections: sections,
-		showModuleName: ymlConfig.UBool("showModuleName", true),
-		branchInTitle: ymlConfig.UBool("branchInTitle", false),
+		commitCount:      ymlConfig.UInt("commitCount", 10),
+		sections:         sections,
+		showModuleName:   ymlConfig.UBool("showModuleName", true),
+		branchInTitle:    ymlConfig.UBool("branchInTitle", false),
 		showFilesIfEmpty: ymlConfig.UBool("showFilesIfEmpty", true),
-		lastFolderTitle: ymlConfig.UBool("lastFolderTitle", false),
-		commitFormat: ymlConfig.UString("commitFormat", "[forestgreen]%h [white]%s [grey]%an on %cd[white]"),
-		dateFormat:   ymlConfig.UString("dateFormat", "%b %d, %Y"),
-		repositories: ymlConfig.UList("repositories"),
+		lastFolderTitle:  ymlConfig.UBool("lastFolderTitle", false),
+		commitFormat:     ymlConfig.UString("commitFormat", "[forestgreen]%h [white]%s [grey]%an on %cd[white]"),
+		dateFormat:       ymlConfig.UString("dateFormat", "%b %d, %Y"),
+		repositories:     ymlConfig.UList("repositories"),
 	}
 	if len(settings.sections) == 0 {
 		settings.sections = make([]string, 3)


### PR DESCRIPTION
Added the following config fields for `modules/git`:

```
sections         []interface{} `help:"Sections to show" optional:"true"`
showModuleName   bool          `help:"Whether to show 'Git - ' before information in title" optional:"true" default:"true"`
branchInTitle    bool          `help:"Whether to show branch name in title instead of the widget body itself" optional:"true" default:"false"`
showFilesIfEmpty bool          `help:"Whether to show Changed Files section if no changed files" optional:"true" default:"true"`
lastFolderTitle  bool          `help:"Whether to show only last part of directory path instead of full path" optional:"true" default:"false"`
```

![2021-09-06-093322_312x247_scrot](https://user-images.githubusercontent.com/33228844/132177872-6e24267f-c74b-4552-883f-1459790faf71.png)

