### PR TITLE
Tags and filter system

### DIFF
--- a/checklist/checklist.go
+++ b/checklist/checklist.go
@@ -28,10 +28,11 @@ func NewChecklist(checkedIcon, uncheckedIcon string) Checklist {
 
 // Add creates a new checklist item and adds it to the list
 // The new one is at the start or end of the list, based on newPos
-func (list *Checklist) Add(checked bool, date *time.Time, text string, newPos ...string) {
+func (list *Checklist) Add(checked bool, date *time.Time, tags []string, text string, newPos ...string) {
 	item := NewChecklistItem(
 		checked,
 		date,
+		tags,
 		text,
 		list.checkedIcon,
 		list.uncheckedIcon,

--- a/checklist/checklist_item.go
+++ b/checklist/checklist_item.go
@@ -1,6 +1,7 @@
 package checklist
 
 import (
+	"fmt"
 	"time"
 )
 
@@ -10,15 +11,17 @@ type ChecklistItem struct {
 	Checked       bool
 	CheckedIcon   string
 	Date          *time.Time
+	Tags          []string
 	Text          string
 	UncheckedIcon string
 }
 
-func NewChecklistItem(checked bool, date *time.Time, text string, checkedIcon, uncheckedIcon string) *ChecklistItem {
+func NewChecklistItem(checked bool, date *time.Time, tags []string, text string, checkedIcon, uncheckedIcon string) *ChecklistItem {
 	item := &ChecklistItem{
 		Checked:       checked,
 		CheckedIcon:   checkedIcon,
 		Date:          date,
+		Tags:          tags,
 		Text:          text,
 		UncheckedIcon: uncheckedIcon,
 	}
@@ -35,6 +38,31 @@ func (item *ChecklistItem) CheckMark() string {
 	}
 
 	return item.UncheckedIcon
+}
+
+// EditText returns the content of the edit todo form, so includes formatted date and tags
+func (item *ChecklistItem) EditText() string {
+	datePrefix := ""
+	if item.Date != nil {
+		datePrefix = fmt.Sprintf("%d-%02d-%02d", item.Date.Year(), item.Date.Month(), item.Date.Day()) + " "
+	}
+
+	tagsPrefix := item.TagString()
+
+	return datePrefix + tagsPrefix + item.Text
+}
+
+func (item *ChecklistItem) TagString() string {
+	if len(item.Tags) == 0 {
+		return ""
+	}
+
+	s := ""
+	for _, tag := range item.Tags {
+		s += "#" + tag + " "
+	}
+
+	return s
 }
 
 // Toggle changes the checked state of the ChecklistItem

--- a/checklist/checklist_item_test.go
+++ b/checklist/checklist_item_test.go
@@ -10,6 +10,7 @@ func testChecklistItem() *ChecklistItem {
 	item := NewChecklistItem(
 		false,
 		nil,
+		make([]string, 0),
 		"test",
 		"",
 		"",

--- a/checklist/checklist_test.go
+++ b/checklist/checklist_test.go
@@ -18,7 +18,7 @@ func Test_NewCheckist(t *testing.T) {
 
 func Test_Add(t *testing.T) {
 	cl := NewChecklist("o", "-")
-	cl.Add(true, nil, "test item")
+	cl.Add(true, nil, make([]string, 0), "test item")
 
 	assert.Equal(t, 1, len(cl.Items))
 }
@@ -41,7 +41,7 @@ func Test_CheckedItems(t *testing.T) {
 			expectedLen: 1,
 			checkedLen:  0,
 			before: func(cl *Checklist) {
-				cl.Add(false, nil, "unchecked item")
+				cl.Add(false, nil, make([]string, 0), "unchecked item")
 			},
 		},
 		{
@@ -49,8 +49,8 @@ func Test_CheckedItems(t *testing.T) {
 			expectedLen: 2,
 			checkedLen:  1,
 			before: func(cl *Checklist) {
-				cl.Add(false, nil, "unchecked item")
-				cl.Add(true, nil, "checked item")
+				cl.Add(false, nil, make([]string, 0), "unchecked item")
+				cl.Add(true, nil, make([]string, 0), "checked item")
 			},
 		},
 		{
@@ -58,9 +58,9 @@ func Test_CheckedItems(t *testing.T) {
 			expectedLen: 3,
 			checkedLen:  2,
 			before: func(cl *Checklist) {
-				cl.Add(false, nil, "unchecked item")
-				cl.Add(true, nil, "checked item 11")
-				cl.Add(true, nil, "checked item 2")
+				cl.Add(false, nil, make([]string, 0), "unchecked item")
+				cl.Add(true, nil, make([]string, 0), "checked item 11")
+				cl.Add(true, nil, make([]string, 0), "checked item 2")
 			},
 		},
 	}
@@ -98,7 +98,7 @@ func Test_Delete(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			cl := NewChecklist("o", "-")
 
-			cl.Add(true, nil, "test item")
+			cl.Add(true, nil, make([]string, 0), "test item")
 			cl.Delete(tt.idx)
 
 			assert.Equal(t, tt.expectedLen, len(cl.Items))
@@ -132,8 +132,8 @@ func Test_IsSelectable(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cl := NewChecklist("o", "-")
-			cl.Add(true, nil, "test item 1")
-			cl.Add(false, nil, "test item 2")
+			cl.Add(true, nil, make([]string, 0), "test item 1")
+			cl.Add(false, nil, make([]string, 0), "test item 2")
 
 			cl.selected = tt.selected
 
@@ -168,8 +168,8 @@ func Test_IsUnselectable(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cl := NewChecklist("o", "-")
-			cl.Add(true, nil, "test item 1")
-			cl.Add(false, nil, "test item 2")
+			cl.Add(true, nil, make([]string, 0), "test item 1")
+			cl.Add(false, nil, make([]string, 0), "test item 2")
 
 			cl.selected = tt.selected
 
@@ -193,16 +193,16 @@ func Test_LongestLine(t *testing.T) {
 			name:        "with different-length items",
 			expectedLen: 12,
 			before: func(cl *Checklist) {
-				cl.Add(true, nil, "test item 1")
-				cl.Add(false, nil, "test item 22")
+				cl.Add(true, nil, make([]string, 0), "test item 1")
+				cl.Add(false, nil, make([]string, 0), "test item 22")
 			},
 		},
 		{
 			name:        "with same-length items",
 			expectedLen: 11,
 			before: func(cl *Checklist) {
-				cl.Add(true, nil, "test item 1")
-				cl.Add(false, nil, "test item 2")
+				cl.Add(true, nil, make([]string, 0), "test item 1")
+				cl.Add(false, nil, make([]string, 0), "test item 2")
 			},
 		},
 	}
@@ -219,8 +219,8 @@ func Test_LongestLine(t *testing.T) {
 
 func Test_IndexByItem(t *testing.T) {
 	cl := NewChecklist("o", "-")
-	cl.Add(false, nil, "unchecked item")
-	cl.Add(true, nil, "checked item")
+	cl.Add(false, nil, make([]string, 0), "unchecked item")
+	cl.Add(true, nil, make([]string, 0), "checked item")
 
 	tests := []struct {
 		name        string
@@ -242,7 +242,7 @@ func Test_IndexByItem(t *testing.T) {
 		},
 		{
 			name:        "with valid item",
-			item:        NewChecklistItem(false, nil, "invalid", "x", " "),
+			item:        NewChecklistItem(false, nil, make([]string, 0), "invalid", "x", " "),
 			expectedIdx: 0,
 			expectedOk:  false,
 		},
@@ -277,7 +277,7 @@ func Test_UncheckedItems(t *testing.T) {
 			expectedLen: 1,
 			checkedLen:  0,
 			before: func(cl *Checklist) {
-				cl.Add(true, nil, "unchecked item")
+				cl.Add(true, nil, make([]string, 0), "unchecked item")
 			},
 		},
 		{
@@ -285,8 +285,8 @@ func Test_UncheckedItems(t *testing.T) {
 			expectedLen: 2,
 			checkedLen:  1,
 			before: func(cl *Checklist) {
-				cl.Add(false, nil, "unchecked item")
-				cl.Add(true, nil, "checked item")
+				cl.Add(false, nil, make([]string, 0), "unchecked item")
+				cl.Add(true, nil, make([]string, 0), "checked item")
 			},
 		},
 		{
@@ -294,9 +294,9 @@ func Test_UncheckedItems(t *testing.T) {
 			expectedLen: 3,
 			checkedLen:  2,
 			before: func(cl *Checklist) {
-				cl.Add(false, nil, "unchecked item")
-				cl.Add(true, nil, "checked item 11")
-				cl.Add(false, nil, "checked item 2")
+				cl.Add(false, nil, make([]string, 0), "unchecked item")
+				cl.Add(true, nil, make([]string, 0), "checked item 11")
+				cl.Add(false, nil, make([]string, 0), "checked item 2")
 			},
 		},
 	}
@@ -314,7 +314,7 @@ func Test_UncheckedItems(t *testing.T) {
 
 func Test_Unselect(t *testing.T) {
 	cl := NewChecklist("o", "-")
-	cl.Add(false, nil, "unchecked item")
+	cl.Add(false, nil, make([]string, 0), "unchecked item")
 
 	cl.selected = 0
 	assert.Equal(t, 0, cl.selected)
@@ -340,16 +340,16 @@ func Test_Len(t *testing.T) {
 			name:        "with one item",
 			expectedLen: 1,
 			before: func(cl *Checklist) {
-				cl.Add(false, nil, "unchecked item")
+				cl.Add(false, nil, make([]string, 0), "unchecked item")
 			},
 		},
 		{
 			name:        "with multiple items",
 			expectedLen: 3,
 			before: func(cl *Checklist) {
-				cl.Add(false, nil, "unchecked item")
-				cl.Add(true, nil, "checked item 1")
-				cl.Add(false, nil, "checked item 2")
+				cl.Add(false, nil, make([]string, 0), "unchecked item")
+				cl.Add(true, nil, make([]string, 0), "checked item 1")
+				cl.Add(false, nil, make([]string, 0), "checked item 2")
 			},
 		},
 	}
@@ -394,8 +394,8 @@ func Test_Less(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cl := NewChecklist("o", "-")
-			cl.Add(false, nil, tt.first)
-			cl.Add(false, nil, tt.second)
+			cl.Add(false, nil, make([]string, 0), tt.first)
+			cl.Add(false, nil, make([]string, 0), tt.second)
 
 			assert.Equal(t, tt.expected, cl.Less(0, 1))
 		})
@@ -424,8 +424,8 @@ func Test_Swap(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cl := NewChecklist("o", "-")
-			cl.Add(false, nil, tt.first)
-			cl.Add(false, nil, tt.second)
+			cl.Add(false, nil, make([]string, 0), tt.first)
+			cl.Add(false, nil, make([]string, 0), tt.second)
 
 			cl.Swap(0, 1)
 

--- a/modules/todo/display.go
+++ b/modules/todo/display.go
@@ -77,7 +77,8 @@ func (widget *Widget) sortListByChecked(firstGroup []*checklist.ChecklistItem, s
 }
 
 func (widget *Widget) shouldShowItem(item *checklist.ChecklistItem) bool {
-	match, _ := regexp.MatchString("(?i).*"+widget.showFilter+".*", item.Text)
+	pattern := "(?i).*" + widget.showFilter + ".*"
+	match, _ := regexp.MatchString(pattern, item.Text)
 	if widget.showFilter != "" && !match {
 		return false
 	}
@@ -151,25 +152,6 @@ func (widget *Widget) formattedItemLine(idx int, currItem *checklist.ChecklistIt
 	}
 
 	return utils.HighlightableHelper(widget.View, row, idx, len(currItem.Text))
-}
-
-func getTodoDate(text string, defaultVal ...time.Time) *time.Time {
-	if len(text) < 12 {
-		if len(defaultVal) > 0 {
-			return &defaultVal[0]
-		} else {
-			return nil
-		}
-	}
-	date, err := time.Parse("2006-01-02", text[1:11])
-	if err != nil {
-		if len(defaultVal) > 0 {
-			return &defaultVal[0]
-		} else {
-			return nil
-		}
-	}
-	return &date
 }
 
 func (widget *Widget) getDateString(date *time.Time) string {

--- a/modules/todo/display.go
+++ b/modules/todo/display.go
@@ -2,7 +2,6 @@ package todo
 
 import (
 	"fmt"
-	"regexp"
 	"strings"
 	"time"
 
@@ -77,9 +76,7 @@ func (widget *Widget) sortListByChecked(firstGroup []*checklist.ChecklistItem, s
 }
 
 func (widget *Widget) shouldShowItem(item *checklist.ChecklistItem) bool {
-	pattern := "(?i).*" + widget.showFilter + ".*"
-	match, _ := regexp.MatchString(pattern, item.Text)
-	if widget.showFilter != "" && !match {
+	if widget.showFilter != "" && !strings.Contains(strings.ToLower(item.Text), widget.showFilter) {
 		return false
 	}
 

--- a/modules/todo/display.go
+++ b/modules/todo/display.go
@@ -2,6 +2,7 @@ package todo
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 
@@ -28,6 +29,9 @@ func (widget *Widget) content() (string, string, bool) {
 	title := widget.CommonSettings().Title
 	if widget.showTagPrefix != "" {
 		title += " #" + widget.showTagPrefix
+	}
+	if widget.showFilter != "" {
+		title += fmt.Sprintf(" /%s", widget.showFilter)
 	}
 	if widget.settings.hiddenNumInTitle {
 		title += fmt.Sprintf(" (%d hidden)", hidden)
@@ -73,6 +77,11 @@ func (widget *Widget) sortListByChecked(firstGroup []*checklist.ChecklistItem, s
 }
 
 func (widget *Widget) shouldShowItem(item *checklist.ChecklistItem) bool {
+	match, _ := regexp.MatchString("(?i).*"+widget.showFilter+".*", item.Text)
+	if widget.showFilter != "" && !match {
+		return false
+	}
+
 	if !widget.settings.parseTags {
 		return true
 	}

--- a/modules/todo/display.go
+++ b/modules/todo/display.go
@@ -51,7 +51,7 @@ func (widget *Widget) sortListByChecked(firstGroup []*checklist.ChecklistItem, s
 	selectedItem := widget.SelectedItem()
 	for idx, item := range firstGroup {
 		if widget.shouldShowItem(item) {
-			str += widget.formattedItemLine(idx, item, selectedItem, widget.list.LongestLine())
+			str += widget.formattedItemLine(idx-hidden, item, selectedItem, widget.list.LongestLine())
 		} else {
 			hidden = hidden + 1
 		}
@@ -61,7 +61,7 @@ func (widget *Widget) sortListByChecked(firstGroup []*checklist.ChecklistItem, s
 
 	for idx, item := range secondGroup {
 		if widget.shouldShowItem(item) {
-			str += widget.formattedItemLine(idx+offset, item, selectedItem, widget.list.LongestLine())
+			str += widget.formattedItemLine(idx+offset-hidden, item, selectedItem, widget.list.LongestLine())
 		} else {
 			hidden = hidden + 1
 		}

--- a/modules/todo/keyboard.go
+++ b/modules/todo/keyboard.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/gdamore/tcell"
-	"github.com/rivo/tview"
 	"github.com/wtfutil/wtf/cfg"
 	"github.com/wtfutil/wtf/utils"
 )
@@ -19,6 +18,7 @@ func (widget *Widget) initializeKeyboardControls() {
 	widget.SetKeyboardChar("n", widget.newItem, "Create new item")
 	widget.SetKeyboardChar("o", widget.openFile, "Open file")
 	widget.SetKeyboardChar("#", widget.setTag, "Set tag(s) to show")
+	widget.SetKeyboardChar("/", widget.setFilter, "Filter shown items")
 
 	widget.SetKeyboardKey(tcell.KeyDown, widget.NextTodo, "Select next item")
 	widget.SetKeyboardKey(tcell.KeyUp, widget.PrevTodo, "Select previous item")
@@ -118,21 +118,14 @@ func (widget *Widget) setTag() {
 		return
 	}
 
-	form := widget.modalForm("Tag prefix:", "")
+	widget.processFormInput("Tag prefix:", "", func(filter string) {
+		widget.showTagPrefix = filter
+	})
+}
 
-	saveFctn := func() {
-		widget.showTagPrefix = form.GetFormItem(0).(*tview.InputField).GetText()
-
-		widget.pages.RemovePage("modal")
-		widget.tviewApp.SetFocus(widget.View)
-		widget.display()
-	}
-
-	widget.addButtons(form, saveFctn)
-	widget.modalFocus(form)
-
-	widget.tviewApp.QueueUpdate(func() {
-		widget.tviewApp.Draw()
+func (widget *Widget) setFilter() {
+	widget.processFormInput("Filter:", "", func(filter string) {
+		widget.showFilter = filter
 	})
 }
 
@@ -193,6 +186,10 @@ func (widget *Widget) toggleChecked() {
 }
 
 func (widget *Widget) unselect() {
-	widget.Selected = -1
+	if widget.showFilter != "" {
+		widget.showFilter = ""
+	} else {
+		widget.Selected = -1
+	}
 	widget.display()
 }

--- a/modules/todo/keyboard.go
+++ b/modules/todo/keyboard.go
@@ -2,6 +2,7 @@ package todo
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/gdamore/tcell"
 	"github.com/wtfutil/wtf/cfg"
@@ -125,7 +126,7 @@ func (widget *Widget) setTag() {
 
 func (widget *Widget) setFilter() {
 	widget.processFormInput("Filter:", "", func(filter string) {
-		widget.showFilter = filter
+		widget.showFilter = strings.ToLower(filter)
 	})
 }
 

--- a/modules/todo/keyboard.go
+++ b/modules/todo/keyboard.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/gdamore/tcell"
+	"github.com/rivo/tview"
 	"github.com/wtfutil/wtf/cfg"
 	"github.com/wtfutil/wtf/utils"
 )
@@ -12,14 +13,15 @@ func (widget *Widget) initializeKeyboardControls() {
 	widget.InitializeHelpTextKeyboardControl(widget.ShowHelp)
 	widget.InitializeRefreshKeyboardControl(widget.Refresh)
 
-	widget.SetKeyboardChar("j", widget.Next, "Select next item")
-	widget.SetKeyboardChar("k", widget.Prev, "Select previous item")
+	widget.SetKeyboardChar("j", widget.NextTodo, "Select next item")
+	widget.SetKeyboardChar("k", widget.PrevTodo, "Select previous item")
 	widget.SetKeyboardChar(" ", widget.toggleChecked, "Toggle checkmark")
 	widget.SetKeyboardChar("n", widget.newItem, "Create new item")
 	widget.SetKeyboardChar("o", widget.openFile, "Open file")
+	widget.SetKeyboardChar("#", widget.setTag, "Set tag(s) to show")
 
-	widget.SetKeyboardKey(tcell.KeyDown, widget.Next, "Select next item")
-	widget.SetKeyboardKey(tcell.KeyUp, widget.Prev, "Select previous item")
+	widget.SetKeyboardKey(tcell.KeyDown, widget.NextTodo, "Select next item")
+	widget.SetKeyboardKey(tcell.KeyUp, widget.PrevTodo, "Select previous item")
 	widget.SetKeyboardKey(tcell.KeyEsc, widget.unselect, "Clear selection")
 	widget.SetKeyboardKey(tcell.KeyCtrlD, widget.deleteSelected, "Delete item")
 	widget.SetKeyboardKey(tcell.KeyCtrlJ, widget.demoteSelected, "Demote item")
@@ -28,6 +30,28 @@ func (widget *Widget) initializeKeyboardControls() {
 	widget.SetKeyboardKey(tcell.KeyCtrlF, widget.makeSelectedFirst, "Make item first")
 	widget.SetKeyboardKey(tcell.KeyEnter, widget.updateSelected, "Edit item")
 
+}
+
+func (widget *Widget) NextTodo() {
+	newIndex := widget.Selected + 1
+	for newIndex < len(widget.list.Items) && !widget.shouldShowItem(widget.list.Items[newIndex]) {
+		newIndex = newIndex + 1
+	}
+	if newIndex < len(widget.list.Items) {
+		widget.Selected = newIndex
+	}
+	widget.display()
+}
+
+func (widget *Widget) PrevTodo() {
+	newIndex := widget.Selected - 1
+	for newIndex >= 0 && !widget.shouldShowItem(widget.list.Items[newIndex]) {
+		newIndex = newIndex - 1
+	}
+	if newIndex >= 0 {
+		widget.Selected = newIndex
+	}
+	widget.display()
 }
 
 func (widget *Widget) deleteSelected() {
@@ -87,6 +111,29 @@ func (widget *Widget) makeSelectedLast() {
 func (widget *Widget) openFile() {
 	confDir, _ := cfg.WtfConfigDir()
 	utils.OpenFile(fmt.Sprintf("%s/%s", confDir, widget.filePath))
+}
+
+func (widget *Widget) setTag() {
+	if !widget.settings.parseTags {
+		return
+	}
+
+	form := widget.modalForm("Tag prefix:", "")
+
+	saveFctn := func() {
+		widget.showTagPrefix = form.GetFormItem(0).(*tview.InputField).GetText()
+
+		widget.pages.RemovePage("modal")
+		widget.tviewApp.SetFocus(widget.View)
+		widget.display()
+	}
+
+	widget.addButtons(form, saveFctn)
+	widget.modalFocus(form)
+
+	widget.tviewApp.QueueUpdate(func() {
+		widget.tviewApp.Draw()
+	})
 }
 
 func (widget *Widget) promoteSelected() {

--- a/modules/todo/keyboard.go
+++ b/modules/todo/keyboard.go
@@ -19,7 +19,7 @@ func (widget *Widget) initializeKeyboardControls() {
 	widget.SetKeyboardChar("n", widget.newItem, "Create new item")
 	widget.SetKeyboardChar("o", widget.openFile, "Open file")
 	widget.SetKeyboardChar("#", widget.setTag, "Set tag(s) to show")
-	widget.SetKeyboardChar("/", widget.setFilter, "Filter shown items")
+	widget.SetKeyboardChar("f", widget.setFilter, "Filter shown items")
 
 	widget.SetKeyboardKey(tcell.KeyDown, widget.NextTodo, "Select next item")
 	widget.SetKeyboardKey(tcell.KeyUp, widget.PrevTodo, "Select previous item")

--- a/modules/todo/settings.go
+++ b/modules/todo/settings.go
@@ -25,6 +25,11 @@ type Settings struct {
 	undatedAsDays     int
 	hideYearIfCurrent bool
 	dateFormat        string
+	parseTags         bool
+	tagColor          string
+	tagsAtEnd         bool
+	hideTags          []interface{}
+	hiddenNumInTitle  bool
 }
 
 // NewSettingsFromYAML creates a new settings instance from a YAML config block
@@ -45,6 +50,11 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 		undatedAsDays:     ymlConfig.UInt("dates.undatedAsDays", 7),
 		hideYearIfCurrent: ymlConfig.UBool("dates.hideYearIfCurrent", true),
 		dateFormat:        ymlConfig.UString("dates.format", "yyyy-mm-dd"),
+		parseTags:         ymlConfig.UBool("tags.enabled", true),
+		tagColor:          ymlConfig.UString("colors.tags", "khaki"),
+		tagsAtEnd:         ymlConfig.UString("tags.pos", "end") == "end",
+		hideTags:          ymlConfig.UList("tags.hide"),
+		hiddenNumInTitle:  ymlConfig.UBool("tags.hiddenInTitle", true),
 	}
 
 	switch settings.newPos {

--- a/modules/todo/widget.go
+++ b/modules/todo/widget.go
@@ -254,11 +254,6 @@ func (widget *Widget) getTextAndDate(text string) (string, *time.Time) {
 	return text, nil
 }
 
-// helper for setting dated todo text in a stable format
-func (widget *Widget) _textWithDate(date time.Time, text string) string {
-	return fmt.Sprintf("[%d-%02d-%02d]", date.Year(), date.Month(), date.Day()) + text
-}
-
 // persist writes the todo list to Yaml file
 func (widget *Widget) persist() {
 	confDir, _ := cfg.WtfConfigDir()

--- a/modules/todo/widget.go
+++ b/modules/todo/widget.go
@@ -161,7 +161,7 @@ func (widget *Widget) getTextComponents(text string) (string, *time.Time, []stri
 
 func getTodoTags(text string, date *time.Time) (string, []string) {
 	tags := make([]string, 0)
-	r, _ := regexp.Compile("(?i)(^|\\s)#[a-z0-9]+")
+	r, _ := regexp.Compile(`(?i)(^|\s)#[a-z0-9]+`)
 	matches := r.FindAllString(text, -1)
 
 	for _, tag := range matches {

--- a/view/keyboard_widget.go
+++ b/view/keyboard_widget.go
@@ -9,7 +9,7 @@ import (
 	"github.com/wtfutil/wtf/utils"
 )
 
-const helpKeyChar = "?"
+const helpKeyChar = "/"
 const refreshKeyChar = "r"
 
 type helpItem struct {

--- a/view/keyboard_widget.go
+++ b/view/keyboard_widget.go
@@ -9,7 +9,7 @@ import (
 	"github.com/wtfutil/wtf/utils"
 )
 
-const helpKeyChar = "/"
+const helpKeyChar = "?"
 const refreshKeyChar = "r"
 
 type helpItem struct {


### PR DESCRIPTION
![2021-09-12-180517_701x347_scrot](https://user-images.githubusercontent.com/33228844/132994719-cd299bf3-6659-4e97-9814-e79faacba46c.png)

- add tags to todos simply by typing `#tag` anywhere inside the text prompt when adding/editing an item
- filter items by tag by pressing `#` and entering a full tag or tag prefix to filter items by (for example you can enter `2` and only be shown todos tagged `#2read`, `2check`, etc). no need to enter the leading `#`
- filter items by substring by pressing `f` and entering text. items are shown only if they have this substring somewhere inside of them (case-insensitive)
- when you are filtering and press escape, the filter is wiped so you can see everything once again

you can modify the tag system a bit inside the yaml config:
- `tags.enabled` bool to enable/disable the whole system (default `true`)
- `tags.pos` is `start` or `end`, determines whether to display tags before or after todo text (default `end`)
- `tags.hide` list of tags to hide by default (so you have to use `#` to see them)
- `tags.hiddenInTitle` bool for whether to display number of items currently hidden by the tag + filter systems (default `true`)
- `colors.tags` to change the color of the tags when displayed (default `khaki`)

some examples of valid new/edit inputs that add tags correctly:

- `tomorrow laundry #chore` (if you want to add a date to the todo, it must come first!) -> text: `laundry`, tags: `[chore]`
- `#chore laundry` -> text: `laundry`, tags: `[chore]`
- `#this also #works` -> text: `also`, tags: `[this, works]`