### PR TITLE
Upgrade to Go 1.17

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - "1.16.x"
+  - "1.17.x"
 
 before_install:
   # Make sure travis builds work for forks

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16-alpine as build
+FROM golang:1.17-alpine as build
 
 ARG version=master
 

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM golang:1.16 as build
+FROM golang:1.17 as build
 
 ARG version=master
 


### PR DESCRIPTION
Upgrade the build files to use Go 1.17.  

I did not update README.md as this is just to update the image and binary builds.  Everything should still be backward compatible.