### PR TITLE
fix make lint and make gosec error (#1127)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,8 @@ export GOPROXY = https://proxy.golang.org,direct
 # Determines the path to this Makefile
 THIS_FILE := $(lastword $(MAKEFILE_LIST))
 
+GOBIN := $(GOPATH)/bin
+
 APP=wtfutil
 
 define HEADER
@@ -77,8 +79,11 @@ docker-install:
 	docker rm wtf_build
 
 ## gosec: runs the gosec static security scanner against the source code
-gosec:
+gosec: $(GOBIN)/gosec
 	gosec -tests ./...
+
+$(GOBIN)/gosec:
+	cd && go install github.com/securego/gosec/v2/cmd/gosec@latest
 
 ## help: prints this help message
 help:
@@ -101,9 +106,12 @@ install:
 	@echo "${APP} installed into ${INSTALLPATH}"
 
 ## lint: runs a number of code quality checks against the source code
-lint:
+lint: $(GOBIN)/golangci-lint
 	golangci-lint cache clean
 	golangci-lint run
+
+$(GOBIN)/golangci-lint:
+	cd && go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
 
 # lint:
 # 	@echo "\033[35mhttps://github.com/kisielk/errcheck\033[0m"


### PR DESCRIPTION
fix #1127

Install golangci-lint / gosec, if it is not installed.
If we only support over go 1.16, we should use go install instead of go
get.

Use binary installation for golangci-lint because they recommends.
https://golangci-lint.run/usage/install/#local-installation