### PR TITLE
Support horizontal scroll in Git module (#1049)

### DIFF
--- a/modules/git/keyboard.go
+++ b/modules/git/keyboard.go
@@ -1,7 +1,5 @@
 package git
 
-import "github.com/gdamore/tcell"
-
 func (widget *Widget) initializeKeyboardControls() {
 	widget.InitializeHelpTextKeyboardControl(widget.ShowHelp)
 	widget.InitializeRefreshKeyboardControl(widget.Refresh)
@@ -10,7 +8,4 @@ func (widget *Widget) initializeKeyboardControls() {
 	widget.SetKeyboardChar("h", widget.PrevSource, "Select previous source")
 	widget.SetKeyboardChar("p", widget.Pull, "Pull repo")
 	widget.SetKeyboardChar("c", widget.Checkout, "Checkout branch")
-
-	widget.SetKeyboardKey(tcell.KeyLeft, widget.PrevSource, "Select previous source")
-	widget.SetKeyboardKey(tcell.KeyRight, widget.NextSource, "Select next source")
 }

--- a/modules/git/widget.go
+++ b/modules/git/widget.go
@@ -19,7 +19,7 @@ const (
 
 type Widget struct {
 	view.MultiSourceWidget
-	view.TextWidget
+	view.ScrollableWidget
 
 	GitRepos []*GitRepo
 
@@ -31,7 +31,7 @@ type Widget struct {
 func NewWidget(tviewApp *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
 	widget := Widget{
 		MultiSourceWidget: view.NewMultiSourceWidget(settings.Common, "repository", "repositories"),
-		TextWidget:        view.NewTextWidget(tviewApp, pages, settings.Common),
+		ScrollableWidget:  view.NewScrollableWidget(tviewApp, pages, settings.Common),
 
 		tviewApp: tviewApp,
 		pages:    pages,


### PR DESCRIPTION
This PR is just my suggestion for #1049.

In order to support horizontal scrolling, we need to think of key bindings.

Originally, left/right key are assigned to move the projects.
h/l keys are also assigned to this function.

I suggest changing left/right key for horizontal scrolling and h/l keys for moving the project.
I thought to use shift as a modifier key, but other module doesn't use this kind of complicated key bindings.