### PR TITLE
[kubernetes] use k8s client per widget

### DIFF
--- a/modules/kubernetes/client.go
+++ b/modules/kubernetes/client.go
@@ -1,17 +1,11 @@
 package kubernetes
 
 import (
-	"sync"
-
 	"k8s.io/client-go/kubernetes"
 	// Includes authentication modules for various Kubernetes providers
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/tools/clientcmd"
 )
-
-var kubeClient *clientInstance
-var kubeError error
-var clientOnce sync.Once
 
 type clientInstance struct {
 	Client kubernetes.Interface
@@ -19,18 +13,14 @@ type clientInstance struct {
 
 // getInstance returns a Kubernetes interface for a clientset
 func (widget *Widget) getInstance() (*clientInstance, error) {
-	clientOnce.Do(func() {
-		if kubeClient == nil {
-			client, err := widget.getKubeClient()
-			if err != nil {
-				kubeError = err
-			}
-			kubeClient = &clientInstance{
-				Client: client,
-			}
-		}
+	var err error
+
+	widget.clientOnce.Do(func() {
+		widget.client = &clientInstance{}
+		widget.client.Client, err = widget.getKubeClient()
 	})
-	return kubeClient, kubeError
+
+	return widget.client, err
 }
 
 // getKubeClient returns a kubernetes clientset for the kubeconfig provided

--- a/modules/kubernetes/widget.go
+++ b/modules/kubernetes/widget.go
@@ -2,6 +2,7 @@ package kubernetes
 
 import (
 	"fmt"
+	"sync"
 
 	"github.com/rivo/tview"
 	"github.com/wtfutil/wtf/utils"
@@ -13,6 +14,9 @@ import (
 // Widget contains all the config for the widget
 type Widget struct {
 	view.TextWidget
+
+	client     *clientInstance
+	clientOnce sync.Once
 
 	objects    []string
 	title      string


### PR DESCRIPTION
Fixes #1081

This changeset introduces k8s client per widget, instead of using one global client.