### PR TITLE
Fix single word in a square bracket stripped error

### DIFF
--- a/modules/cmdrunner/widget.go
+++ b/modules/cmdrunner/widget.go
@@ -177,11 +177,11 @@ func (widget *Widget) content() (string, string, bool) {
 	result := widget.buffer.String()
 	widget.m.Unlock()
 
-	ansiTitle := tview.TranslateANSI(widget.CommonSettings().Title)
+	ansiTitle := tview.TranslateANSI(tview.Escape(widget.CommonSettings().Title))
 	if ansiTitle == defaultTitle {
-		ansiTitle = tview.TranslateANSI(widget.String())
+		ansiTitle = tview.TranslateANSI(tview.Escape(widget.String()))
 	}
-	ansiResult := tview.TranslateANSI(result)
+	ansiResult := tview.TranslateANSI(tview.Escape(result))
 
 	return ansiTitle, ansiResult, false
 }


### PR DESCRIPTION
Fix #1142 
the square bracket is used color / region tags in tview. This is because single word in a square bracket stripped.

Escape tag like string in cmdrunner title and result.