### PR TITLE
refactor: move from io/ioutil to io and os packages

### DIFF
--- a/cfg/config_files.go
+++ b/cfg/config_files.go
@@ -3,7 +3,6 @@ package cfg
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -147,7 +146,7 @@ func createWtfConfigFile() {
 	file, _ := os.Stat(filePath)
 
 	if file.Size() == 0 {
-		if ioutil.WriteFile(filePath, []byte(defaultConfigFile), 0600) != nil {
+		if os.WriteFile(filePath, []byte(defaultConfigFile), 0600) != nil {
 			displayDefaultConfigWriteError(err)
 			os.Exit(1)
 		}

--- a/cfg/copy.go
+++ b/cfg/copy.go
@@ -6,7 +6,6 @@ package cfg
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 )
@@ -56,12 +55,17 @@ func dcopy(src, dest string, info os.FileInfo) error {
 		return err
 	}
 
-	infos, err := ioutil.ReadDir(src)
+	entries, err := os.ReadDir(src)
 	if err != nil {
 		return err
 	}
 
-	for _, info := range infos {
+	for _, entry := range entries {
+		info, err := entry.Info()
+		if err != nil {
+			continue
+		}
+
 		if err := copy(
 			filepath.Join(src, info.Name()),
 			filepath.Join(dest, info.Name()),

--- a/modules/circleci/client.go
+++ b/modules/circleci/client.go
@@ -3,7 +3,7 @@ package circleci
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 
@@ -69,7 +69,7 @@ func (client *Client) circleRequest(path string) ([]byte, error) {
 		return nil, fmt.Errorf(resp.Status)
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/cryptoexchanges/blockfolio/widget.go
+++ b/modules/cryptoexchanges/blockfolio/widget.go
@@ -3,7 +3,7 @@ package blockfolio
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 
@@ -116,7 +116,7 @@ func MakeApiRequest(token string, method string) ([]byte, error) {
 		return nil, err
 	}
 	defer func() { _ = resp.Body.Close() }()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/football/widget.go
+++ b/modules/football/widget.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"strconv"
 	"strings"
 
@@ -100,7 +100,7 @@ func (widget *Widget) GetStandings(leagueId int) string {
 		return fmt.Sprintf("Error fetching standings: %s", err.Error())
 	}
 	defer func() { _ = resp.Body.Close() }()
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Sprintf("Error fetching standings: %s", err.Error())
 	}
@@ -146,7 +146,7 @@ func (widget *Widget) GetMatches(leagueId int) string {
 		return fmt.Sprintf("Error fetching matches: %s", err.Error())
 	}
 	defer func() { _ = resp.Body.Close() }()
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Sprintf("Error fetching matches: %s", err.Error())
 	}

--- a/modules/gcal/client.go
+++ b/modules/gcal/client.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -34,7 +33,7 @@ func (widget *Widget) Fetch() ([]*CalEvent, error) {
 
 	secretPath, _ := utils.ExpandHomeDir(widget.settings.secretFile)
 
-	b, err := ioutil.ReadFile(filepath.Clean(secretPath))
+	b, err := os.ReadFile(filepath.Clean(secretPath))
 	if err != nil {
 		return nil, err
 	}
@@ -128,7 +127,7 @@ func isAuthenticated(name string) bool {
 func (widget *Widget) authenticate() {
 	secretPath, _ := utils.ExpandHomeDir(filepath.Clean(widget.settings.secretFile))
 
-	b, err := ioutil.ReadFile(filepath.Clean(secretPath))
+	b, err := os.ReadFile(filepath.Clean(secretPath))
 	if err != nil {
 		log.Fatalf("Unable to read secret file. %v", widget.settings.secretFile)
 	}

--- a/modules/git/widget.go
+++ b/modules/git/widget.go
@@ -1,8 +1,8 @@
 package git
 
 import (
-	"io/ioutil"
 	"log"
+	"os"
 	"strings"
 
 	"github.com/gdamore/tcell"
@@ -174,7 +174,7 @@ func (widget *Widget) gitRepos(repoPaths []string) []*GitRepo {
 func (widget *Widget) findGitRepositories(repositories []*GitRepo, directory string) []*GitRepo {
 	directory = strings.TrimSuffix(directory, "/")
 
-	files, err := ioutil.ReadDir(directory)
+	files, err := os.ReadDir(directory)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/modules/googleanalytics/client.go
+++ b/modules/googleanalytics/client.go
@@ -3,9 +3,9 @@ package googleanalytics
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http"
+	"os"
 	"path/filepath"
 	"time"
 
@@ -48,7 +48,7 @@ func (widget *Widget) Fetch() []websiteReport {
 }
 
 func buildNetClient(secretPath string) *http.Client {
-	clientSecret, err := ioutil.ReadFile(filepath.Clean(secretPath))
+	clientSecret, err := os.ReadFile(filepath.Clean(secretPath))
 	if err != nil {
 		log.Fatalf("Unable to read secretPath. %v", err)
 	}

--- a/modules/gspreadsheets/client.go
+++ b/modules/gspreadsheets/client.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"net/url"
@@ -31,7 +30,7 @@ func (widget *Widget) Fetch() ([]*sheets.ValueRange, error) {
 
 	secretPath, _ := utils.ExpandHomeDir(widget.settings.secretFile)
 
-	b, err := ioutil.ReadFile(filepath.Clean(secretPath))
+	b, err := os.ReadFile(filepath.Clean(secretPath))
 	if err != nil {
 		log.Fatalf("Unable to read secretPath. %v", err)
 		return nil, err

--- a/modules/hackernews/client.go
+++ b/modules/hackernews/client.go
@@ -3,7 +3,7 @@ package hackernews
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -70,7 +70,7 @@ func apiRequest(path string) ([]byte, error) {
 		return nil, fmt.Errorf(resp.Status)
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/hibp/client.go
+++ b/modules/hibp/client.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 )
@@ -56,7 +56,7 @@ func (widget *Widget) fetchForAccount(account string, since string) (*Status, er
 		return nil, err
 	}
 
-	body, readErr := ioutil.ReadAll(response.Body)
+	body, readErr := io.ReadAll(response.Body)
 	if readErr != nil {
 		return nil, err
 	}

--- a/modules/jira/client.go
+++ b/modules/jira/client.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -88,7 +88,7 @@ func (widget *Widget) jiraRequest(path string) ([]byte, error) {
 		return nil, fmt.Errorf(resp.Status)
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/mercurial/hg_repo.go
+++ b/modules/mercurial/hg_repo.go
@@ -2,7 +2,7 @@ package mercurial
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"os/exec"
 	"path"
 	"strings"
@@ -43,7 +43,7 @@ func (repo *MercurialRepo) branch() string {
 }
 
 func (repo *MercurialRepo) bookmark() string {
-	bookmark, err := ioutil.ReadFile(path.Join(repo.Path, ".hg", "bookmarks.current"))
+	bookmark, err := os.ReadFile(path.Join(repo.Path, ".hg", "bookmarks.current"))
 	if err != nil {
 		return ""
 	}

--- a/modules/nbascore/widget.go
+++ b/modules/nbascore/widget.go
@@ -3,7 +3,7 @@ package nbascore
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"time"
@@ -63,7 +63,7 @@ func (widget *Widget) nbascore() (string, string, bool) {
 		return title, err.Error(), true
 	} // Get data from data.nba.net and check if successful
 
-	contents, err := ioutil.ReadAll(response.Body)
+	contents, err := io.ReadAll(response.Body)
 	if err != nil {
 		return title, err.Error(), true
 	}

--- a/modules/newrelic/client/http_helper.go
+++ b/modules/newrelic/client/http_helper.go
@@ -3,7 +3,7 @@ package newrelic
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -32,7 +32,7 @@ func (c *Client) doRequest(req *http.Request, out interface{}) error {
 		return err
 	}
 	defer func() { _ = resp.Body.Close() }()
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}

--- a/modules/pihole/client.go
+++ b/modules/pihole/client.go
@@ -3,7 +3,7 @@ package pihole
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	url2 "net/url"
 	"regexp"
@@ -71,7 +71,7 @@ func getStatus(c http.Client, apiURL string) (status Status, err error) {
 
 	var rBody []byte
 
-	if rBody, err = ioutil.ReadAll(resp.Body); err != nil {
+	if rBody, err = io.ReadAll(resp.Body); err != nil {
 		return status, fmt.Errorf(" failed to read status response")
 	}
 
@@ -155,7 +155,7 @@ func getTopItems(c http.Client, settings *Settings) (ti TopItems, err error) {
 
 	var rBody []byte
 
-	rBody, err = ioutil.ReadAll(resp.Body)
+	rBody, err = io.ReadAll(resp.Body)
 	if err = json.Unmarshal(rBody, &ti); err != nil {
 		return ti, fmt.Errorf(" failed to retrieve top items: check provided api URL and token\n %s",
 			parseError(err))
@@ -221,7 +221,7 @@ func getTopClients(c http.Client, settings *Settings) (tc TopClients, err error)
 
 	var rBody []byte
 
-	if rBody, err = ioutil.ReadAll(resp.Body); err != nil {
+	if rBody, err = io.ReadAll(resp.Body); err != nil {
 		return tc, fmt.Errorf(" failed to read top clients response\n %s", parseError(err))
 	}
 
@@ -280,7 +280,7 @@ func getQueryTypes(c http.Client, settings *Settings) (qt QueryTypes, err error)
 
 	var rBody []byte
 
-	if rBody, err = ioutil.ReadAll(resp.Body); err != nil {
+	if rBody, err = io.ReadAll(resp.Body); err != nil {
 		return qt, fmt.Errorf(" failed to read top clients response\n %s", parseError(err))
 	}
 
@@ -332,7 +332,7 @@ func checkServer(c http.Client, apiURL string) error {
 
 	var rBody []byte
 
-	if rBody, err = ioutil.ReadAll(resp.Body); err != nil {
+	if rBody, err = io.ReadAll(resp.Body); err != nil {
 		return fmt.Errorf(" Pi-hole server failed to respond\n %s", parseError(err))
 	}
 

--- a/modules/pocket/client.go
+++ b/modules/pocket/client.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 )
 
@@ -89,7 +89,7 @@ func (client *Client) request(req request, result interface{}) error {
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	responseBody, err := ioutil.ReadAll(resp.Body)
+	responseBody, err := io.ReadAll(resp.Body)
 
 	if err != nil {
 		return err

--- a/modules/pocket/widget.go
+++ b/modules/pocket/widget.go
@@ -2,7 +2,7 @@ package pocket
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/rivo/tview"
 	"github.com/wtfutil/wtf/cfg"
@@ -90,7 +90,7 @@ func writeMetaDataToDisk(metaData pocketMetaData) error {
 	}
 
 	filePath := fmt.Sprintf("%s/%s", wtfConfigDir, "pocket.data")
-	err = ioutil.WriteFile(filePath, fileData, 0644)
+	err = os.WriteFile(filePath, fileData, 0644)
 
 	return err
 }

--- a/modules/textfile/widget.go
+++ b/modules/textfile/widget.go
@@ -3,7 +3,7 @@ package textfile
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"time"
@@ -103,7 +103,7 @@ func (widget *Widget) formattedText() string {
 		formatter = formatters.Fallback
 	}
 
-	contents, _ := ioutil.ReadAll(file)
+	contents, _ := io.ReadAll(file)
 	iterator, _ := lexer.Tokenise(nil, string(contents))
 
 	var buf bytes.Buffer
@@ -118,7 +118,7 @@ func (widget *Widget) formattedText() string {
 func (widget *Widget) plainText() string {
 	filePath, _ := utils.ExpandHomeDir(filepath.Clean(widget.CurrentSource()))
 
-	text, err := ioutil.ReadFile(filepath.Clean(filePath))
+	text, err := os.ReadFile(filepath.Clean(filePath))
 	if err != nil {
 		return err.Error()
 	}

--- a/modules/todo/widget.go
+++ b/modules/todo/widget.go
@@ -2,7 +2,7 @@ package todo
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -261,7 +261,7 @@ func (widget *Widget) persist() {
 
 	fileData, _ := yaml.Marshal(&widget.list)
 
-	err := ioutil.WriteFile(filePath, fileData, 0644)
+	err := os.WriteFile(filePath, fileData, 0644)
 
 	if err != nil {
 		panic(err)

--- a/modules/twitterstats/client.go
+++ b/modules/twitterstats/client.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 
@@ -79,7 +79,7 @@ func (client *Client) GetStatsForUser(username string) TwitterStats {
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return stats
 	}

--- a/modules/uptimerobot/widget.go
+++ b/modules/uptimerobot/widget.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -160,7 +160,7 @@ func (widget *Widget) getMonitors() ([]Monitor, error) {
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	body, _ := ioutil.ReadAll(resp.Body)
+	body, _ := io.ReadAll(resp.Body)
 
 	// First pass to read the status
 	c := make(map[string]json.RawMessage)

--- a/modules/weatherservices/prettyweather/widget.go
+++ b/modules/weatherservices/prettyweather/widget.go
@@ -1,7 +1,7 @@
 package prettyweather
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -57,7 +57,7 @@ func (widget *Widget) prettyWeather() {
 	}
 	defer func() { _ = response.Body.Close() }()
 
-	contents, err := ioutil.ReadAll(response.Body)
+	contents, err := io.ReadAll(response.Body)
 	if err != nil {
 		widget.result = err.Error()
 		return

--- a/modules/zendesk/client.go
+++ b/modules/zendesk/client.go
@@ -3,7 +3,7 @@ package zendesk
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 )
 
@@ -38,7 +38,7 @@ func (widget *Widget) api(meth string) (*Resource, error) {
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -128,7 +127,7 @@ func OpenFile(path string) {
 
 // ReadFileBytes reads the contents of a file and returns those contents as a slice of bytes
 func ReadFileBytes(filePath string) ([]byte, error) {
-	fileData, err := ioutil.ReadFile(filepath.Clean(filePath))
+	fileData, err := os.ReadFile(filepath.Clean(filePath))
 	if err != nil {
 		return []byte{}, err
 	}


### PR DESCRIPTION
The `io/ioutil` package has been deprecated in Go 1.16 (See https://golang.org/doc/go1.16#ioutil). Since this project has been upgraded to Go 1.17 in #1115, this PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.