### PR TITLE
Tag Stories in FeedReader

### DIFF
--- a/modules/feedreader/widget.go
+++ b/modules/feedreader/widget.go
@@ -24,8 +24,9 @@ const (
 
 // FeedItem represents an item returned from an RSS or Atom feed
 type FeedItem struct {
-	item   *gofeed.Item
-	viewed bool
+	item		*gofeed.Item
+	sourceTitle	string
+	viewed		bool
 }
 
 // Widget is the container for RSS and Atom data
@@ -59,6 +60,9 @@ func getShowText(feedItem *FeedItem, showType ShowType) string {
 
 	space := regexp.MustCompile(`\s+`)
 	title := space.ReplaceAllString(feedItem.item.Title, " ")
+	if (feedItem.sourceTitle != "") {
+		title = "[" + feedItem.sourceTitle + "] " + space.ReplaceAllString(feedItem.item.Title, " ")
+	}
 
 	// Convert any escaped characters to their character representation
 	title = html.UnescapeString(title)
@@ -148,9 +152,6 @@ func (widget *Widget) fetchForFeed(feedURL string) ([]*FeedItem, error) {
 	} else {
 		feed, err = widget.parser.ParseURL(feedURL)
 	}
-	if err != nil {
-		return nil, err
-	}
 
 	if err != nil {
 		return nil, err
@@ -166,8 +167,9 @@ func (widget *Widget) fetchForFeed(feedURL string) ([]*FeedItem, error) {
 		}
 
 		feedItem := &FeedItem{
-			item:   gofeedItem,
-			viewed: false,
+			item:			gofeedItem,
+			sourceTitle:	feed.Title,
+			viewed:			false,
 		}
 
 		feedItems = append(feedItems, feedItem)

--- a/modules/feedreader/widget.go
+++ b/modules/feedreader/widget.go
@@ -24,9 +24,9 @@ const (
 
 // FeedItem represents an item returned from an RSS or Atom feed
 type FeedItem struct {
-	item		*gofeed.Item
-	sourceTitle	string
-	viewed		bool
+	item        *gofeed.Item
+	sourceTitle string
+	viewed      bool
 }
 
 // Widget is the container for RSS and Atom data
@@ -60,7 +60,7 @@ func getShowText(feedItem *FeedItem, showType ShowType) string {
 
 	space := regexp.MustCompile(`\s+`)
 	title := space.ReplaceAllString(feedItem.item.Title, " ")
-	if (feedItem.sourceTitle != "") {
+	if feedItem.sourceTitle != "" {
 		title = "[" + feedItem.sourceTitle + "] " + space.ReplaceAllString(feedItem.item.Title, " ")
 	}
 
@@ -167,9 +167,9 @@ func (widget *Widget) fetchForFeed(feedURL string) ([]*FeedItem, error) {
 		}
 
 		feedItem := &FeedItem{
-			item:			gofeedItem,
-			sourceTitle:	feed.Title,
-			viewed:			false,
+			item:        gofeedItem,
+			sourceTitle: feed.Title,
+			viewed:      false,
 		}
 
 		feedItems = append(feedItems, feedItem)

--- a/modules/feedreader/widget_test.go
+++ b/modules/feedreader/widget_test.go
@@ -45,6 +45,15 @@ func Test_getShowText(t *testing.T) {
 			expected: "<Cats and Dogs>",
 		},
 		{
+			name: "with source-title",
+			feedItem: &FeedItem{
+				sourceTitle: "WTF",
+				item: &gofeed.Item{Title: "<Cats and Dogs>"},
+			},
+			showType: SHOW_TITLE,
+			expected: "[WTF] <Cats and Dogs>",
+		},
+		{
 			name: "with link",
 			feedItem: &FeedItem{
 				item: &gofeed.Item{Title: "Cats and Dogs", Link: "https://cats.com/dog.xml"},

--- a/modules/feedreader/widget_test.go
+++ b/modules/feedreader/widget_test.go
@@ -48,7 +48,7 @@ func Test_getShowText(t *testing.T) {
 			name: "with source-title",
 			feedItem: &FeedItem{
 				sourceTitle: "WTF",
-				item: &gofeed.Item{Title: "<Cats and Dogs>"},
+				item:        &gofeed.Item{Title: "<Cats and Dogs>"},
 			},
 			showType: SHOW_TITLE,
 			expected: "[WTF] <Cats and Dogs>",


### PR DESCRIPTION
With the FeedReader, it's possible to have multiple feeds. With multiple feeds, all stories are jumbled up in the same list. One cannot know the source of a story at first glance. The way this possible is the to use the `t` keyboard shortcut which cycles the showType through title, link, and content. It is better UX to have some tag showing the origin of a story.

This change introduces a tag on the story title. This tag is the same as the Feed.Title. This change is backward compatible. If a feed does not come with a title, this change yields itself to the previous implementation.

To test this, run tool with `make run`. Feeds which have titles in their schemas should show up with their titles in square brackets. Examples of such feeds I have in my config are Hacker News, Ruby Weekly, and avdi.codes

Fixes wtfutil/wtf#1138
