### PR TITLE
Updated Install Paths in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ install:
 	@echo "Installing ${APP} with ${GOVERS}..."
 	@go clean
 	@go install -ldflags="-s -w -X main.version=$(shell git describe --always --abbrev=6) -X main.date=$(shell date +%FT%T%z)"
-	@mv ~/go/bin/wtf ~/go/bin/${APP}
+	@mv $(GOBIN)/wtf $(GOBIN)/${APP}
 	$(eval INSTALLPATH = $(shell which ${APP}))
 	@echo "${APP} installed into ${INSTALLPATH}"
 
@@ -169,4 +169,4 @@ test: build
 
 ## uninstall: uninstals a locally-installed version
 uninstall:
-	@rm ~/go/bin/${APP}
+	@rm $(GOBIN)/${APP}


### PR DESCRIPTION

### Makefile install paths updated

Switched static install paths from `~/go/bin` to `$(GOBIN)` so it works everywhere.

