### PR TITLE
feat(steam): adding steam status module

### DIFF
--- a/app/widget_maker.go
+++ b/app/widget_maker.go
@@ -61,6 +61,7 @@ import (
 	"github.com/wtfutil/wtf/modules/spotify"
 	"github.com/wtfutil/wtf/modules/spotifyweb"
 	"github.com/wtfutil/wtf/modules/status"
+	"github.com/wtfutil/wtf/modules/steam"
 	"github.com/wtfutil/wtf/modules/stocks/finnhub"
 	"github.com/wtfutil/wtf/modules/stocks/yfinance"
 	"github.com/wtfutil/wtf/modules/subreddit"
@@ -286,6 +287,9 @@ func MakeWidget(
 	case "status":
 		settings := status.NewSettingsFromYAML(moduleName, moduleConfig, config)
 		widget = status.NewWidget(tviewApp, settings)
+	case "steam":
+		settings := steam.NewSettingsFromYAML(moduleName, moduleConfig, config)
+		widget = steam.NewWidget(tviewApp, pages, settings)
 	case "subreddit":
 		settings := subreddit.NewSettingsFromYAML(moduleName, moduleConfig, config)
 		widget = subreddit.NewWidget(tviewApp, pages, settings)

--- a/modules/steam/client.go
+++ b/modules/steam/client.go
@@ -1,0 +1,72 @@
+package steam
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+)
+
+type Steam struct {
+	client  *http.Client
+	baseUrl string
+}
+
+type ClientOpts struct {
+	key     string
+	baseUrl string
+}
+
+func NewClient(opts *ClientOpts) *Steam {
+	baseUrl := opts.baseUrl
+
+	if opts.baseUrl == "" {
+		baseUrl = "http://api.steampowered.com/ISteamUser/GetPlayerSummaries/v0002/?key="
+	}
+
+	baseUrl += opts.key + "&steamids="
+
+	return &Steam{
+		client:  &http.Client{},
+		baseUrl: baseUrl,
+	}
+}
+
+type Player struct {
+	Personaname   string `json:"personaname"`
+	ProfileUrl    string `json:"profileurl"`
+	Personastate  int    `json:"personastate"`
+	Gameextrainfo string `json:"gameextrainfo"`
+}
+
+type SteamResponse struct {
+	Response struct {
+		Players []Player `json:"players"`
+	} `json:"response"`
+}
+
+func (s *Steam) Status(steamID string) (*Player, error) {
+	resp, err := s.fetch(steamID)
+	if err != nil {
+		return nil, err
+	}
+
+	var response SteamResponse
+
+	if err := json.Unmarshal(resp, &response); err != nil {
+		return nil, err
+	}
+
+	return &response.Response.Players[0], nil
+}
+
+func (s *Steam) fetch(id string) ([]byte, error) {
+	resp, err := http.Get(s.baseUrl + id)
+
+	if err != nil || resp.StatusCode != 200 {
+		return nil, fmt.Errorf("error fetching %s steam status: %v, status: %d", id, err, resp.StatusCode)
+	}
+
+	defer resp.Body.Close()
+	return ioutil.ReadAll(resp.Body)
+}

--- a/modules/steam/keyboard.go
+++ b/modules/steam/keyboard.go
@@ -1,0 +1,15 @@
+package steam
+
+import "github.com/gdamore/tcell/v2"
+
+func (widget *Widget) initializeKeyboardControls() {
+	widget.InitializeHelpTextKeyboardControl(widget.ShowHelp)
+	widget.InitializeRefreshKeyboardControl(widget.Refresh)
+
+	widget.SetKeyboardChar("j", widget.Next, "Select next item")
+	widget.SetKeyboardChar("k", widget.Prev, "Select previous item")
+
+	widget.SetKeyboardKey(tcell.KeyDown, widget.Next, "Select next item")
+	widget.SetKeyboardKey(tcell.KeyUp, widget.Prev, "Select previous item")
+	widget.SetKeyboardKey(tcell.KeyEsc, widget.Unselect, "Clear selection")
+}

--- a/modules/steam/settings.go
+++ b/modules/steam/settings.go
@@ -1,0 +1,33 @@
+package steam
+
+import (
+	"os"
+
+	"github.com/olebedev/config"
+	"github.com/wtfutil/wtf/cfg"
+	"github.com/wtfutil/wtf/utils"
+)
+
+const (
+	defaultFocusable = true
+)
+
+type Settings struct {
+	*cfg.Common
+
+	numberOfResults int      `help:"Number of rows to show. Default is 10." optional:"true"`
+	key             string   `help:"Steam API key (default is env var STEAM_API_KEY)"`
+	userIds         []string `help:"Steam user ids" optional:"true"`
+}
+
+func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
+	steam := ymlConfig.UString("steam")
+	settings := Settings{
+		Common: cfg.NewCommonSettingsFromModule(name, steam, defaultFocusable, ymlConfig, globalConfig),
+
+		numberOfResults: ymlConfig.UInt("numberOfResults", 10),
+		key:             ymlConfig.UString("key", os.Getenv("STEAM_API_KEY")),
+		userIds:         utils.ToStrs(ymlConfig.UList("userIds", make([]interface{}, 0))),
+	}
+	return &settings
+}

--- a/modules/steam/widget.go
+++ b/modules/steam/widget.go
@@ -1,0 +1,127 @@
+package steam
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/rivo/tview"
+	"github.com/wtfutil/wtf/utils"
+	"github.com/wtfutil/wtf/view"
+	"golang.org/x/sync/errgroup"
+)
+
+type Widget struct {
+	view.ScrollableWidget
+
+	settings *Settings
+	err      error
+	steam    *Steam
+	players  []*Player
+}
+
+func NewWidget(tviewApp *tview.Application, pages *tview.Pages, settings *Settings) *Widget {
+	widget := &Widget{
+		ScrollableWidget: view.NewScrollableWidget(tviewApp, pages, settings.Common),
+		settings:         settings,
+		steam:            NewClient(&ClientOpts{key: settings.key}),
+	}
+
+	widget.SetRenderFunction(widget.Render)
+	widget.initializeKeyboardControls()
+
+	return widget
+}
+
+func (widget *Widget) Refresh() {
+	errg, _ := errgroup.WithContext(context.Background())
+	players := make([]*Player, len(widget.settings.userIds))
+
+	for i, id := range widget.settings.userIds {
+		func(idx int, id string) {
+			errg.Go(func() error {
+				status, err := widget.steam.Status(id)
+				if err != nil {
+					return err
+				}
+				players[idx] = status
+				return nil
+			})
+		}(i, id)
+	}
+
+	if err := errg.Wait(); err != nil {
+		widget.err = err
+		widget.players = nil
+		widget.SetItemCount(0)
+	} else {
+		widget.err = nil
+		if len(players) <= widget.settings.numberOfResults {
+			widget.players = players
+		} else {
+			widget.players = players[:widget.settings.numberOfResults]
+		}
+		widget.SetItemCount(len(widget.players))
+	}
+
+	widget.Render()
+}
+
+func (widget *Widget) Render() {
+	widget.Redraw(widget.content)
+}
+
+func friendlyStatus(personastate int) string {
+	switch personastate {
+	case 0:
+		return "Offline"
+	case 1:
+		return "Online"
+	case 2:
+		return "Busy"
+	case 3:
+		return "Away"
+	case 4:
+		return "Snooze"
+	case 5:
+		return "Looking to Trade"
+	case 6:
+		return "Looking to Play"
+	}
+	return ""
+}
+
+func (widget *Widget) content() (string, string, bool) {
+	var title = "Steam Statuses"
+
+	if widget.CommonSettings().Title != "" {
+		title = widget.CommonSettings().Title
+	}
+
+	if widget.err != nil {
+		return title, widget.err.Error(), true
+	}
+
+	if len(widget.players) == 0 {
+		return title, "No data", false
+	}
+
+	var str string
+
+	for idx, player := range widget.players {
+		status := friendlyStatus(player.Personastate)
+
+		row := fmt.Sprintf(
+			"[white]%s: [yellow]%s",
+			player.Personaname,
+			status,
+		)
+
+		if len(player.Gameextrainfo) > 0 {
+			row += " [red](" + player.Gameextrainfo + ")"
+		}
+
+		str += utils.HighlightableHelper(widget.View, row, idx, len(player.Personaname))
+	}
+
+	return title, str, false
+}


### PR DESCRIPTION
Adding a module that displays a list of [Steam](https://steamcommunity.com/dev) usernames and their corresponding status. I modeled this after the `twitch` module.

Steam API key is required and is provided via env var.