### PR TITLE
WTF-1221 Remove explicit calls to *Draw() functions from within the m…

### DIFF
--- a/app/wtf_app.go
+++ b/app/wtf_app.go
@@ -107,6 +107,7 @@ func (wtfApp *WtfApp) stopAllWidgets() {
 
 func (wtfApp *WtfApp) keyboardIntercept(event *tcell.EventKey) *tcell.EventKey {
 	// These keys are global keys used by the app. Widgets should not implement these keys
+
 	switch event.Key() {
 	case tcell.KeyCtrlC:
 		wtfApp.Stop()

--- a/modules/bargraph/widget.go
+++ b/modules/bargraph/widget.go
@@ -68,15 +68,5 @@ func (widget *Widget) Refresh() {
 	}
 
 	widget.View.Clear()
-
-	widget.tviewApp.QueueUpdateDraw(func() {
-		display(widget)
-	})
-
-}
-
-/* -------------------- Unexported Functions -------------------- */
-
-func display(widget *Widget) {
 	MakeGraph(widget)
 }

--- a/modules/git/widget.go
+++ b/modules/git/widget.go
@@ -102,11 +102,9 @@ func (widget *Widget) addCancelButton(form *tview.Form) {
 }
 
 func (widget *Widget) modalFocus(form *tview.Form) {
-	widget.tviewApp.QueueUpdateDraw(func() {
-		frame := widget.modalFrame(form)
-		widget.pages.AddPage("modal", frame, false, true)
-		widget.tviewApp.SetFocus(frame)
-	})
+	frame := widget.modalFrame(form)
+	widget.pages.AddPage("modal", frame, false, true)
+	widget.tviewApp.SetFocus(frame)
 }
 
 func (widget *Widget) modalForm(lbl, text string) *tview.Form {

--- a/modules/mercurial/widget.go
+++ b/modules/mercurial/widget.go
@@ -100,11 +100,9 @@ func (widget *Widget) addCancelButton(form *tview.Form) {
 }
 
 func (widget *Widget) modalFocus(form *tview.Form) {
-	widget.tviewApp.QueueUpdateDraw(func() {
-		frame := widget.modalFrame(form)
-		widget.pages.AddPage("modal", frame, false, true)
-		widget.tviewApp.SetFocus(frame)
-	})
+	frame := widget.modalFrame(form)
+	widget.pages.AddPage("modal", frame, false, true)
+	widget.tviewApp.SetFocus(frame)
 }
 
 func (widget *Widget) modalForm(lbl, text string) *tview.Form {

--- a/modules/resourceusage/widget.go
+++ b/modules/resourceusage/widget.go
@@ -130,17 +130,11 @@ func (widget *Widget) Refresh() {
 		return
 	}
 
-	widget.tviewApp.QueueUpdateDraw(func() {
-		widget.View.Clear()
-		display(widget)
-	})
+	widget.View.Clear()
+	MakeGraph(widget)
 }
 
 /* -------------------- Unexported Functions -------------------- */
-
-func display(widget *Widget) {
-	MakeGraph(widget)
-}
 
 func getDataFromSystem(widget *Widget) (cpuStats []float64, memInfo mem.VirtualMemoryStat) {
 	if widget.settings.showCPU {

--- a/modules/todo/widget.go
+++ b/modules/todo/widget.go
@@ -308,10 +308,6 @@ func (widget *Widget) processFormInput(prompt string, initValue string, onSave f
 
 	widget.addButtons(form, saveFctn)
 	widget.modalFocus(form)
-
-	widget.tviewApp.QueueUpdate(func() {
-		widget.tviewApp.Draw()
-	})
 }
 
 // updateSelectedItem update the text of the selected item.
@@ -377,11 +373,9 @@ func (widget *Widget) addSaveButton(form *tview.Form, fctn func()) {
 }
 
 func (widget *Widget) modalFocus(form *tview.Form) {
-	widget.tviewApp.QueueUpdateDraw(func() {
-		frame := widget.modalFrame(form)
-		widget.pages.AddPage("modal", frame, false, true)
-		widget.tviewApp.SetFocus(frame)
-	})
+	frame := widget.modalFrame(form)
+	widget.pages.AddPage("modal", frame, false, true)
+	widget.tviewApp.SetFocus(frame)
 }
 
 func (widget *Widget) modalForm(lbl, text string) *tview.Form {

--- a/view/scrollable_widget.go
+++ b/view/scrollable_widget.go
@@ -84,8 +84,6 @@ func (widget *ScrollableWidget) Unselect() {
 func (widget *ScrollableWidget) Redraw(data func() (string, string, bool)) {
 	widget.TextWidget.Redraw(data)
 
-	widget.tviewApp.QueueUpdateDraw(func() {
-		widget.View.Highlight(strconv.Itoa(widget.Selected))
-		widget.View.ScrollToHighlight()
-	})
+	widget.View.Highlight(strconv.Itoa(widget.Selected))
+	widget.View.ScrollToHighlight()
 }

--- a/view/text_widget.go
+++ b/view/text_widget.go
@@ -45,14 +45,12 @@ func (widget *TextWidget) TextView() *tview.TextView {
 
 // Redraw forces a refresh of the onscreen text content of this widget
 func (widget *TextWidget) Redraw(data func() (string, string, bool)) {
-	widget.tviewApp.QueueUpdateDraw(func() {
-		title, content, wrap := data()
+	title, content, wrap := data()
 
-		widget.View.Clear()
-		widget.View.SetWrap(wrap)
-		widget.View.SetTitle(widget.ContextualTitle(title))
-		widget.View.SetText(strings.TrimRight(content, "\n"))
-	})
+	widget.View.Clear()
+	widget.View.SetWrap(wrap)
+	widget.View.SetTitle(widget.ContextualTitle(title))
+	widget.View.SetText(strings.TrimRight(content, "\n"))
 }
 
 /* -------------------- Unexported Functions -------------------- */


### PR DESCRIPTION
…odule go routines.

With the tview update, direct calls to any of tview's `Draw()` functions would hang the app. This is because they're being called from within the modules, and the modules are run within go routines (the tview docs are pretty clear that this is a Bad Idea™). 

This change keeps the app from hanging, however it introduces a rendering problem: modal dialogs do not display the dialog part until after the user presses a key (key events redraw the entire screen).

Relates to https://github.com/wtfutil/wtf/issues/1221

Signed-off-by: Chris Cummer <chriscummer@me.com>