### PR TITLE
fix empty list issue with pocket client

### DIFF
--- a/modules/pocket/keyboard.go
+++ b/modules/pocket/keyboard.go
@@ -8,6 +8,10 @@ func (widget *Widget) initializeKeyboardControls() {
 
 	widget.SetKeyboardChar("a", widget.toggleLink, "Toggle Link")
 	widget.SetKeyboardChar("t", widget.toggleView, "Toggle view (links ,archived links)")
+	widget.SetKeyboardChar("j", widget.Next, "Select Next Link")
+	widget.SetKeyboardChar("k", widget.Prev, "Select Previous Link")
+	widget.SetKeyboardChar("o", widget.openLink, "Open Link in the browser")
+
 	widget.SetKeyboardKey(tcell.KeyDown, widget.Next, "Select Next Link")
 	widget.SetKeyboardKey(tcell.KeyUp, widget.Prev, "Select Previous Link")
 	widget.SetKeyboardKey(tcell.KeyEnter, widget.openLink, "Open Link in the browser")


### PR DESCRIPTION
The default marshaling behavior of `json.Marshal` returns a string
`null` for a `nil` interface. This makes the DefaultHTTPClient provide
the string `null` as the body where none was expected.
Without this, the cloudflare server returns a 403 Bad Request, causing
the widget to show an empty pane.

Additionally set a custom user-agent to identify wtfutil. in-line with
the reddit submodule.

