### PR TITLE
Remove 'blank' arg from default configs

### DIFF
--- a/_sample_configs/sample_config.yml
+++ b/_sample_configs/sample_config.yml
@@ -6,7 +6,7 @@ wtf:
       focused: orange
       normal: gray
     checked: yellow
-    highlight: 
+    highlight:
       fore: black
       back: gray
     rows:
@@ -158,7 +158,7 @@ wtf:
       refreshInterval: 1
     uptime:
       type: cmdrunner
-      args: [""]
+      args: []
       cmd: "uptime"
       enabled: true
       position:

--- a/_sample_configs/small_config.yml
+++ b/_sample_configs/small_config.yml
@@ -6,7 +6,7 @@ wtf:
   mods:
     uptime:
       type: cmdrunner
-      args: [""]
+      args: []
       cmd: "uptime"
       enabled: true
       position:


### PR DESCRIPTION
From #1197, this seems to break on linux
Thought is that on linux this is translating into some weird extra arg
Since we can have a blank args list, I think this makes sense to keep it blank