### PR TITLE
Fix all linter errors

### DIFF
--- a/cfg/position_validation.go
+++ b/cfg/position_validation.go
@@ -8,29 +8,28 @@ import (
 
 // Common examples of invalid position configuration are:
 //
-//    position:
-//      top: -3
-//      left: 2
-//      width: 0
-//      height: 1
+//	position:
+//	  top: -3
+//	  left: 2
+//	  width: 0
+//	  height: 1
 //
-//    position:
-//      top: 3
-//      width: 2
-//      height: 1
+//	position:
+//	  top: 3
+//	  width: 2
+//	  height: 1
 //
-//    position:
-//      top: 3
-//      # left: 2
-//      width: 2
-//      height: 1
+//	position:
+//	  top: 3
+//	  # left: 2
+//	  width: 2
+//	  height: 1
 //
-//    position:
-//    top: 3
-//    left: 2
-//    width: 2
-//    height: 1
-//
+//	position:
+//	top: 3
+//	left: 2
+//	width: 2
+//	height: 1
 type positionValidation struct {
 	err    error
 	name   string

--- a/cfg/secrets.go
+++ b/cfg/secrets.go
@@ -23,7 +23,7 @@ type SecretLoadParams struct {
 //
 // The credential helpers impose this structure:
 //
-//   SERVICE is mapped to a SECRET and USERNAME
+//	SERVICE is mapped to a SECRET and USERNAME
 //
 // Only SECRET is secret, SERVICE and USERNAME are not, so this
 // API doesn't expose USERNAME.
@@ -33,46 +33,46 @@ type SecretLoadParams struct {
 // API server, its easier to just use the module name as the
 // SERVICE:
 //
-//     cfg.ModuleSecret(name, globalConfig, &settings.apiKey).Load()
+//	   cfg.ModuleSecret(name, globalConfig, &settings.apiKey).Load()
 //
-//  The user will use the module name as the service, and the API key as
-//  the secret, for example:
+//	The user will use the module name as the service, and the API key as
+//	the secret, for example:
 //
-//     % wtfutil save-secret circleci
-//     Secret: ...
+//	   % wtfutil save-secret circleci
+//	   Secret: ...
 //
 // If a module (such as pihole, jenkins, or github) might have multiple
 // instantiations each using a different API service (with its own unique
 // API key), then the module should use the API URL to lookup the secret.
 // For example, for github:
 //
-//     cfg.ModuleSecret(name, globalConfig, &settings.apiKey).
-//         Service(settings.baseURL).
-//         Load()
+//	cfg.ModuleSecret(name, globalConfig, &settings.apiKey).
+//	    Service(settings.baseURL).
+//	    Load()
 //
 // The user will use the API URL as the service, and the API key as the
 // secret, for example, with github configured as:
 //
-//     -- config.yml
-//     mods:
-//       github:
-//         baseURL: "https://github.mycompany.com/api/v3"
-//         ...
+//	   -- config.yml
+//	   mods:
+//	     github:
+//	       baseURL: "https://github.mycompany.com/api/v3"
+//	       ...
 //
-//  the secret must be saved as:
+//	the secret must be saved as:
 //
-//     % wtfutil save-secret https://github.mycompany.com/api/v3
-//     Secret: ...
+//	   % wtfutil save-secret https://github.mycompany.com/api/v3
+//	   Secret: ...
 //
-//  If baseURL is not set in the configuration it will be the modules
-//  default, and the SERVICE will default to the module name, "github",
-//  and the user must save the secret as:
+//	If baseURL is not set in the configuration it will be the modules
+//	default, and the SERVICE will default to the module name, "github",
+//	and the user must save the secret as:
 //
-//     % wtfutil save-secret github
-//     Secret: ...
+//	   % wtfutil save-secret github
+//	   Secret: ...
 //
-//  Ideally, the individual module documentation would describe the
-//  SERVICE name to use to save the secret.
+//	Ideally, the individual module documentation would describe the
+//	SERVICE name to use to save the secret.
 func ModuleSecret(name string, globalConfig *config.Config, secret *string) *SecretLoadParams {
 	return &SecretLoadParams{
 		name:         name,

--- a/modules/cryptoexchanges/blockfolio/widget.go
+++ b/modules/cryptoexchanges/blockfolio/widget.go
@@ -88,7 +88,7 @@ func (widget *Widget) content() (string, string, bool) {
 	return title, res, true
 }
 
-//always the same
+// always the same
 const magic = "edtopjhgn2345piuty89whqejfiobh89-2q453"
 
 type Position struct {

--- a/modules/ipaddresses/ipapi/widget.go
+++ b/modules/ipaddresses/ipapi/widget.go
@@ -85,7 +85,7 @@ func (widget *Widget) Refresh() {
 	widget.Redraw(func() (string, string, bool) { return widget.CommonSettings().Title, widget.result, false })
 }
 
-//this method reads the config and calls ipinfo for ip information
+// this method reads the config and calls ipinfo for ip information
 func (widget *Widget) ipinfo() {
 	client := &http.Client{}
 	req, err := http.NewRequest("GET", "http://ip-api.com/json?fields=66846719", nil)

--- a/modules/ipaddresses/ipinfo/widget.go
+++ b/modules/ipaddresses/ipinfo/widget.go
@@ -48,7 +48,7 @@ func (widget *Widget) Refresh() {
 	widget.Redraw(func() (string, string, bool) { return widget.CommonSettings().Title, widget.result, false })
 }
 
-//this method reads the config and calls ipinfo for ip information
+// this method reads the config and calls ipinfo for ip information
 func (widget *Widget) ipinfo() {
 	client := &http.Client{}
 	var url string

--- a/modules/krisinformation/client.go
+++ b/modules/krisinformation/client.go
@@ -61,7 +61,7 @@ type Item struct {
 	Updated     time.Time
 }
 
-//NewClient returns a new Client
+// NewClient returns a new Client
 func NewClient(latitude, longitude float64, radius int, county string, country bool) *Client {
 	return &Client{
 		latitude:  latitude,
@@ -168,9 +168,10 @@ func hsin(theta float64) float64 {
 }
 
 // Distance function returns the distance (in meters) between two points of
-//     a given longitude and latitude relatively accurately (using a spherical
-//     approximation of the Earth) through the Haversin Distance Formula for
-//     great arc distance on a sphere with accuracy for small distances
+//
+//	a given longitude and latitude relatively accurately (using a spherical
+//	approximation of the Earth) through the Haversin Distance Formula for
+//	great arc distance on a sphere with accuracy for small distances
 //
 // point coordinates are supplied in degrees and converted into rad. in the func
 //

--- a/modules/pocket/client.go
+++ b/modules/pocket/client.go
@@ -184,12 +184,15 @@ func (client *Client) GetAccessToken(requestToken string) (accessToken string, e
 
 }
 
-/*LinkState  represents link states to be retrieved
+/*
+LinkState  represents link states to be retrieved
 According to the api https://getpocket.com/developer/docs/v3/retrieve
 there are 3 states:
+
 	1-archive
 	2-unread
 	3-all
+
 however archive does not really well work and returns links that are in the
 unread list
 buy inspecting getpocket I found out that there is an undocumanted read state

--- a/modules/pocket/widget.go
+++ b/modules/pocket/widget.go
@@ -115,13 +115,14 @@ func readMetaDataFromDisk() (pocketMetaData, error) {
 }
 
 /*
-	Authorization workflow is documented at https://getpocket.com/developer/docs/authentication
-	broken to 4 steps :
-		1- Obtain a platform consumer key from http://getpocket.com/developer/apps/new.
-		2- Obtain a request token
-		3- Redirect user to Pocket to continue authorization
-		4- Receive the callback from Pocket, this wont be used
-		5- Convert a request token into a Pocket access token
+Authorization workflow is documented at https://getpocket.com/developer/docs/authentication
+broken to 4 steps :
+
+	1- Obtain a platform consumer key from http://getpocket.com/developer/apps/new.
+	2- Obtain a request token
+	3- Redirect user to Pocket to continue authorization
+	4- Receive the callback from Pocket, this wont be used
+	5- Convert a request token into a Pocket access token
 */
 func (widget *Widget) authorizeWorkFlow() (string, string, bool) {
 	title := widget.CommonSettings().Title

--- a/modules/power/battery_freebsd.go
+++ b/modules/power/battery_freebsd.go
@@ -40,9 +40,10 @@ func (battery *Battery) String() string {
 /* -------------------- Unexported Functions -------------------- */
 
 // returns 3 numbers
-//   1/0   = AC/battery
-//   c     = battery charge percentage
-//   -1/s  = charging / seconds to empty
+//
+//	1/0   = AC/battery
+//	c     = battery charge percentage
+//	-1/s  = charging / seconds to empty
 func (battery *Battery) execute() string {
 	cmd := exec.Command("apm", "-alt")
 	return utils.ExecuteCommand(cmd)

--- a/modules/power/managed_devices.go
+++ b/modules/power/managed_devices.go
@@ -107,7 +107,7 @@ func (manDev *ManagedDevice) Add(chunk string) {
 	}
 }
 
-//Dump writes out all the device attributes as a single string
+// Dump writes out all the device attributes as a single string
 func (manDev *ManagedDevice) Dump() string {
 	out := ""
 

--- a/modules/security/wifi.go
+++ b/modules/security/wifi.go
@@ -83,7 +83,7 @@ func matchStr(data [][]string) string {
 	return data[1][1]
 }
 
-//Windows
+// Windows
 func wifiEncryptionWindows() string {
 	return parseWlanNetsh("Authentication")
 }

--- a/modules/steam/client.go
+++ b/modules/steam/client.go
@@ -3,7 +3,7 @@ package steam
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 )
 
@@ -68,5 +68,5 @@ func (s *Steam) fetch(id string) ([]byte, error) {
 	}
 
 	defer resp.Body.Close()
-	return ioutil.ReadAll(resp.Body)
+	return io.ReadAll(resp.Body)
 }

--- a/modules/weatherservices/prettyweather/widget.go
+++ b/modules/weatherservices/prettyweather/widget.go
@@ -33,7 +33,7 @@ func (widget *Widget) Refresh() {
 	widget.Redraw(func() (string, string, bool) { return widget.CommonSettings().Title, widget.result, false })
 }
 
-//this method reads the config and calls wttr.in for pretty weather
+// this method reads the config and calls wttr.in for pretty weather
 func (widget *Widget) prettyWeather() {
 	client := &http.Client{}
 

--- a/utils/email_addresses.go
+++ b/utils/email_addresses.go
@@ -11,9 +11,8 @@ import (
 //
 // Example:
 //
-//    NameFromEmail("test_user@example.com")
-//    > "Test_user"
-//
+//	NameFromEmail("test_user@example.com")
+//	> "Test_user"
 func NameFromEmail(email string) string {
 	parts := strings.Split(email, "@")
 	name := strings.ReplaceAll(parts[0], ".", " ")
@@ -27,9 +26,8 @@ func NameFromEmail(email string) string {
 //
 // Example:
 //
-//    NamesFromEmail("test_user@example.com", "other_user@example.com")
-//    > []string{"Test_user", "Other_user"}
-//
+//	NamesFromEmail("test_user@example.com", "other_user@example.com")
+//	> []string{"Test_user", "Other_user"}
 func NamesFromEmails(emails []string) []string {
 	names := make([]string, len(emails))
 

--- a/utils/text.go
+++ b/utils/text.go
@@ -15,9 +15,8 @@ import (
 //
 // Example:
 //
-//    x := CenterText("cat", 11)
-//    > "    cat    "
-//
+//	x := CenterText("cat", 11)
+//	> "    cat    "
 func CenterText(str string, width int) string {
 	if width < 0 {
 		width = 0
@@ -30,11 +29,9 @@ func CenterText(str string, width int) string {
 //
 // Example:
 //
-//    a := "{ cat } { dog }"
-//    b := FindBetween(a, "{", "}")
-//    > [" cat ", " dog "]
-//
-//
+//	a := "{ cat } { dog }"
+//	b := FindBetween(a, "{", "}")
+//	> [" cat ", " dog "]
 func FindBetween(input string, left string, right string) []string {
 	out := []string{}
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -34,12 +34,11 @@ const (
 //
 // Example:
 //
-//    x := DoesNotInclude([]string{"cat", "dog", "rat"}, "dog")
-//    > false
+//	x := DoesNotInclude([]string{"cat", "dog", "rat"}, "dog")
+//	> false
 //
-//    x := DoesNotInclude([]string{"cat", "dog", "rat"}, "pig")
-//    > true
-//
+//	x := DoesNotInclude([]string{"cat", "dog", "rat"}, "pig")
+//	> true
 func DoesNotInclude(strs []string, val string) bool {
 	return !Includes(strs, val)
 }
@@ -72,12 +71,11 @@ func FindMatch(pattern string, data string) [][]string {
 //
 // Example:
 //
-//    x := Includes([]string{"cat", "dog", "rat"}, "dog")
-//    > true
+//	x := Includes([]string{"cat", "dog", "rat"}, "dog")
+//	> true
 //
-//    x := Includes([]string{"cat", "dog", "rat"}, "pig")
-//    > false
-//
+//	x := Includes([]string{"cat", "dog", "rat"}, "pig")
+//	> false
 func Includes(strs []string, val string) bool {
 	for _, str := range strs {
 		if val == str {
@@ -189,9 +187,8 @@ func CalculateDimensions(moduleConfig, globalConfig *config.Config) (int, int, e
 //
 // Examples:
 //
-//   MaxInt(3, 2) => 3
-//   MaxInt(2, 3) => 3
-//
+//	MaxInt(3, 2) => 3
+//	MaxInt(2, 3) => 3
 func MaxInt(x, y int) int {
 	if x > y {
 		return x
@@ -203,10 +200,9 @@ func MaxInt(x, y int) int {
 //
 // Examples:
 //
-//   clamp(6, 3, 8) => 6
-//   clamp(1, 3, 8) => 3
-//   clamp(9, 3, 8) => 8
-//
+//	clamp(6, 3, 8) => 6
+//	clamp(1, 3, 8) => 3
+//	clamp(9, 3, 8) => 8
 func Clamp(x, a, b int) int {
 	if a > x {
 		return a

--- a/view/bargraph.go
+++ b/view/bargraph.go
@@ -10,7 +10,7 @@ import (
 	"github.com/wtfutil/wtf/wtf"
 )
 
-//BarGraph defines the data required to make a bar graph
+// BarGraph defines the data required to make a bar graph
 type BarGraph struct {
 	maxStars int
 	starChar string
@@ -52,7 +52,7 @@ func (widget *BarGraph) BuildBars(data []Bar) {
 	widget.View.SetText(BuildStars(data, widget.maxStars, widget.starChar))
 }
 
-//BuildStars build the string to display
+// BuildStars build the string to display
 func BuildStars(data []Bar, maxStars int, starChar string) string {
 	var buffer bytes.Buffer
 

--- a/view/keyboard_widget.go
+++ b/view/keyboard_widget.go
@@ -95,8 +95,7 @@ func (widget *KeyboardWidget) InitializeRefreshKeyboardControl(refreshFunc func(
 // InputCapture is the function passed to tview's SetInputCapture() function
 // This is done during the main widget's creation process using the following code:
 //
-//    widget.View.SetInputCapture(widget.InputCapture)
-//
+//	widget.View.SetInputCapture(widget.InputCapture)
 func (widget *KeyboardWidget) InputCapture(event *tcell.EventKey) *tcell.EventKey {
 	if event == nil {
 		return nil
@@ -131,8 +130,7 @@ func (widget *KeyboardWidget) LaunchDocumentation() {
 // SetKeyboardChar sets a character/function combination that responds to key presses
 // Example:
 //
-//    widget.SetKeyboardChar("d", widget.deleteSelectedItem)
-//
+//	widget.SetKeyboardChar("d", widget.deleteSelectedItem)
 func (widget *KeyboardWidget) SetKeyboardChar(char string, fn func(), helpText string) {
 	if char == "" {
 		return
@@ -150,8 +148,7 @@ func (widget *KeyboardWidget) SetKeyboardChar(char string, fn func(), helpText s
 // SetKeyboardKey sets a tcell.Key/function combination that responds to key presses
 // Example:
 //
-//    widget.SetKeyboardKey(tcell.KeyCtrlD, widget.deleteSelectedItem)
-//
+//	widget.SetKeyboardKey(tcell.KeyCtrlD, widget.deleteSelectedItem)
 func (widget *KeyboardWidget) SetKeyboardKey(key tcell.Key, fn func(), helpText string) {
 	widget.keyMap[key] = fn
 	widget.keyHelp = append(widget.keyHelp, helpItem{tcell.KeyNames[key], helpText})

--- a/view/multisource_widget.go
+++ b/view/multisource_widget.go
@@ -72,12 +72,11 @@ func (widget *MultiSourceWidget) PrevSource() {
 //
 // Example:
 //
-//   widget := Widget{
-//     MultiSourceWidget: wtf.NewMultiSourceWidget(settings.common, "person", "people")
-//   }
+//	widget := Widget{
+//	  MultiSourceWidget: wtf.NewMultiSourceWidget(settings.common, "person", "people")
+//	}
 //
-//   widget.SetDisplayFunction(widget.display)
-//
+//	widget.SetDisplayFunction(widget.display)
 func (widget *MultiSourceWidget) SetDisplayFunction(displayFunc func()) {
 	widget.DisplayFunction = displayFunc
 }


### PR DESCRIPTION
Fix the various linter errors that golangci-lint is triggering on every build.
Note that these aren't triggered by golang 1.18, but are in golang 1.19 (but also seem to pass for 1.17 and 1.18)

Most are really whitespacing of comments.
One is replacing ioutil with io for a single method, which actually aligns with similar client code.