### PR TITLE
Cross test golang versions in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: go
 
 go:
   - "1.17.x"
+  - "1.18.x"
+  - "1.19.x"
 
 before_install:
   # Make sure travis builds work for forks


### PR DESCRIPTION
Prep for upgrade to at least 1.18



