### PR TITLE
Use the tview.Escape method to preserve square brackets

### DIFF
--- a/modules/textfile/widget.go
+++ b/modules/textfile/widget.go
@@ -104,7 +104,9 @@ func (widget *Widget) formattedText() string {
 	}
 
 	contents, _ := io.ReadAll(file)
-	iterator, _ := lexer.Tokenise(nil, string(contents))
+	str := string(contents)
+	str = tview.Escape(str)
+	iterator, _ := lexer.Tokenise(nil, str)
 
 	var buf bytes.Buffer
 	err = formatter.Format(&buf, style, iterator)
@@ -122,7 +124,7 @@ func (widget *Widget) plainText() string {
 	if err != nil {
 		return err.Error()
 	}
-	return string(text)
+	return tview.Escape(string(text))
 }
 
 func (widget *Widget) watchForFileChanges() {


### PR DESCRIPTION
Addresses #1263