### PR TITLE
add config options for digital clock

### DIFF
--- a/modules/digitalclock/clocks.go
+++ b/modules/digitalclock/clocks.go
@@ -52,8 +52,11 @@ func getColon() string {
 	return " "
 }
 
-func getDate() string {
-	return fmt.Sprintf("Date: %s", time.Now().Format("Monday January 02 2006"))
+func getDate(dateFormat string, withDatePrefix bool) string {
+	if withDatePrefix {
+		return fmt.Sprintf("Date: %s", time.Now().Format(dateFormat))
+	}
+	return time.Now().Format(dateFormat)
 }
 
 func getUTC() string {

--- a/modules/digitalclock/display.go
+++ b/modules/digitalclock/display.go
@@ -17,7 +17,7 @@ func renderWidget(widgetSettings Settings) string {
 	}
 
 	if widgetSettings.withDate {
-		outputStrings = append(outputStrings, getDate(), getUTC(), getEpoch())
+		outputStrings = append(outputStrings, getDate(widgetSettings.dateFormat, widgetSettings.withDatePrefix), getUTC(), getEpoch())
 	}
 
 	return mergeLines(outputStrings)

--- a/modules/digitalclock/settings.go
+++ b/modules/digitalclock/settings.go
@@ -14,10 +14,12 @@ const (
 type Settings struct {
 	*cfg.Common
 
-	color      string `help:"The color of the clock."`
-	font       string `help:"The font of the clock." values:"bigfont or digitalfont"`
-	hourFormat string `help:"The format of the clock." values:"12 or 24"`
-	withDate   bool   `help:"Whether or not to display date information"`
+	color          string `help:"The color of the clock."`
+	font           string `help:"The font of the clock." values:"bigfont or digitalfont"`
+	hourFormat     string `help:"The format of the clock." values:"12 or 24"`
+	dateFormat     string `help:"The format of the date."`
+	withDate       bool   `help:"Whether or not to display date information"`
+	withDatePrefix bool   `help:"Whether or not to display Date: prefix"`
 }
 
 // NewSettingsFromYAML creates a new settings instance from a YAML config block
@@ -25,10 +27,12 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	settings := Settings{
 		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
-		color:      ymlConfig.UString("color"),
-		font:       ymlConfig.UString("font"),
-		hourFormat: ymlConfig.UString("hourFormat", "24"),
-		withDate:   ymlConfig.UBool("withDate", true),
+		color:          ymlConfig.UString("color"),
+		font:           ymlConfig.UString("font"),
+		hourFormat:     ymlConfig.UString("hourFormat", "24"),
+		dateFormat:     ymlConfig.UString("dateFormat", "Monday January 02 2006"),
+		withDate:       ymlConfig.UBool("withDate", true),
+		withDatePrefix: ymlConfig.UBool("withDatePrefix", true),
 	}
 
 	return &settings


### PR DESCRIPTION
# What
Add two new config options for smaller displays
```
withDate       bool   `help:"Whether or not to display date information"`
withDatePrefix bool   `help:"Whether or not to display Date: prefix"`
```

Defaults to existing date format.

# Docs
Coming