### PR TITLE
Add instructions for go install to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,12 @@ and you should be good to go.
 
 ### Installing from Source
 
+Install directly to your `$GOPATH/bin` directory:
+
+```bash
+go install github.com/wtfutil/wtf@latest
+```
+
 If you want to run the build command from within your `$GOPATH`:
 
 ```bash


### PR DESCRIPTION
Added instructions for installing the command directly with `go install`. I was taking a look at the project and this is how I installed it.