### PR TITLE
fix: Increase timeout for golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,5 @@
 run:
-  timeout: 2m
+  timeout: 3m
 
 linters:
   enable:


### PR DESCRIPTION
CI occasionally failed by timeout of golangci-lint and show logs like this, even if bump third-party library version.

```
Running [/home/runner/golangci-lint-1.50.0-linux-amd64/golangci-lint run --out-format=github-actions ./...] in [] ...
level=error msg="Timeout exceeded: try increasing it by passing --timeout option"

Error: golangci-lint exit with code 4
Ran golangci-lint in 165001ms
```

examples:
https://github.com/wtfutil/wtf/actions/runs/3277579517/jobs/5395037965

The time required may vary but I'd like to increase timeout limit.

I ran into this problem when I create pull request https://github.com/wtfutil/wtf/pull/1394 and I couldn't rerun because I don't have permission to do it except push something again.
