### PR TITLE
Add protocol version configuration to `ipinfo` module and update dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -87,7 +87,7 @@ require (
 	github.com/PuerkitoBio/purell v1.1.1 // indirect
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
 	github.com/acomagu/bufpipe v1.0.3 // indirect
-	github.com/andybalholm/brotli v1.0.1 // indirect
+	github.com/andybalholm/brotli v1.0.4 // indirect
 	github.com/andybalholm/cascadia v1.1.0 // indirect
 	github.com/aokoli/goutils v1.1.0 // indirect
 	github.com/apache/thrift v0.12.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -114,6 +114,8 @@ github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/andybalholm/brotli v1.0.1 h1:KqhlKozYbRtJvsPrrEeXcO+N2l6NYT5A2QAFmSULpEc=
 github.com/andybalholm/brotli v1.0.1/go.mod h1:loMXtMfwqflxFJPmdbJO0a3KNoPuLBgiu3qAvBg8x/Y=
+github.com/andybalholm/brotli v1.0.4 h1:V7DdXeJtZscaqfNuAdSRuRFzuiKlHSC/Zh3zl9qY3JY=
+github.com/andybalholm/brotli v1.0.4/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
 github.com/andybalholm/cascadia v1.1.0 h1:BuuO6sSfQNFRu1LppgbD25Hr2vLYW25JvxHs5zzsLTo=
 github.com/andybalholm/cascadia v1.1.0/go.mod h1:GsXiBklL0woXo1j/WYWtSYYC4ouU9PqHO0sqidkEA4Y=
 github.com/andygrunwald/go-gerrit v0.0.0-20190825170856-5959a9bf9ff8 h1:9PvNa6zH6gOW4VVfbAx5rjDLpxunG+RSaXQB+8TEv4w=

--- a/modules/ipaddresses/ipinfo/settings.go
+++ b/modules/ipaddresses/ipinfo/settings.go
@@ -1,26 +1,68 @@
 package ipinfo
 
 import (
+	"errors"
+	"fmt"
 	"github.com/olebedev/config"
 	"github.com/wtfutil/wtf/cfg"
+	log "github.com/wtfutil/wtf/logger"
 )
 
 const (
-	defaultFocusable = false
-	defaultTitle     = "IPInfo"
+	defaultFocusable                 = false
+	defaultTitle                     = "IPInfo"
+	ipV4             protocolVersion = "v4"
+	ipV6             protocolVersion = "v6"
+	auto             protocolVersion = "auto"
 )
+
+type protocolVersion string
+
+func (pv protocolVersion) String() string {
+	switch pv {
+	case ipV4:
+		return "v4"
+	case ipV6:
+		return "v6"
+	default:
+		return "auto"
+	}
+}
+
+func newProtocolVersion(str string) (protocolVersion, error) {
+	switch str {
+	case "v4":
+		return ipV4, nil
+	case "v6":
+		return ipV6, nil
+	case "auto":
+		return auto, nil
+	default:
+		return "", errors.New(fmt.Sprintf("%s module: Unsupported protocol version: '%s'", defaultTitle, str))
+	}
+}
 
 type Settings struct {
 	*cfg.Common
 
-	apiToken string `help:"An api token" optional:"true"`
+	apiToken        string          `help:"An api token" optional:"true"`
+	protocolVersion protocolVersion `help:"IP protocol version to display. Possible options are: 'v4' to show only IpV4 address, 'v6' to show only IpV6 address and 'auto' (default) to show the address preferred by OS." optional:"true"`
 }
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := Settings{
 		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
-		apiToken: ymlConfig.UString("apiToken", ""),
+		apiToken:        ymlConfig.UString("apiToken", ""),
+		protocolVersion: auto,
+	}
+
+	pv, err := newProtocolVersion(ymlConfig.UString("protocolVersion", auto.String()))
+	if err != nil {
+		log.Log(err.Error())
+		log.Log(fmt.Sprintf("%s module: Use '%s' protocol version as a default", defaultTitle, auto))
+	} else {
+		settings.protocolVersion = pv
 	}
 
 	settings.SetDocumentationPath("ipaddress/ipinfo")

--- a/modules/ipaddresses/ipinfo/settings.go
+++ b/modules/ipaddresses/ipinfo/settings.go
@@ -1,7 +1,6 @@
 package ipinfo
 
 import (
-	"errors"
 	"fmt"
 	"github.com/olebedev/config"
 	"github.com/wtfutil/wtf/cfg"
@@ -38,7 +37,7 @@ func newProtocolVersion(str string) (protocolVersion, error) {
 	case "auto":
 		return auto, nil
 	default:
-		return "", errors.New(fmt.Sprintf("%s module: Unsupported protocol version: '%s'", defaultTitle, str))
+		return "", fmt.Errorf("%s module: Unsupported protocol version: '%s'", defaultTitle, str)
 	}
 }
 

--- a/modules/ipaddresses/ipinfo/widget.go
+++ b/modules/ipaddresses/ipinfo/widget.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	log "github.com/wtfutil/wtf/logger"
 	"net"
 	"net/http"
 	"text/template"
@@ -52,7 +53,7 @@ func (widget *Widget) Refresh() {
 func (widget *Widget) ipinfo() {
 	client := &http.Client{}
 	var url string
-	ip, ipv6 := getMyIP()
+	ip, ipv6 := getMyIP(widget.settings.protocolVersion)
 	if ipv6 {
 		url = fmt.Sprintf("https://ipinfo.io/%s", ip.String())
 	} else {
@@ -127,8 +128,11 @@ func formatableText(key, value string) string {
 // It does so by dialing out to a site known to have both an A and AAAA DNS records (IPv6)
 // The 'net' package is allowed to decide how to connect, connecting to both IPv4 or IPv6 address
 // depending on the availbility of IP protocols.
-func getMyIP() (ip net.IP, v6 bool) {
-	conn, err := net.Dial("tcp", "fast.com:80")
+func getMyIP(version protocolVersion) (ip net.IP, v6 bool) {
+	log.Log(fmt.Sprintf("Protocol version: %s", version))
+	log.Log(fmt.Sprintf("Network: %s", version.toNetwork()))
+	//fmt.Println("Protocol version: ", version)
+	conn, err := net.Dial(version.toNetwork(), "fast.com:80")
 	if err != nil {
 		return
 	}
@@ -139,4 +143,15 @@ func getMyIP() (ip net.IP, v6 bool) {
 	v6 = ip.To4() == nil
 
 	return
+}
+
+func (pv protocolVersion) toNetwork() string {
+	switch pv {
+	case ipV4:
+		return "tcp4"
+	case ipV6:
+		return "tcp6"
+	default:
+		return "tcp"
+	}
 }


### PR DESCRIPTION
* Add `protocolVersion` to the `ipinfo` module to select IP protocol version to use
* Update `github.com/andybalholm/brotli` dependency. Otherwise, the project doesn't compile locally.

Fixes #1110 


