### PR TITLE
Git command fix for Windows

### DIFF
--- a/modules/git/git_repo.go
+++ b/modules/git/git_repo.go
@@ -32,7 +32,7 @@ func NewGitRepo(repoPath string, commitCount int, commitFormat, dateFormat strin
 func (repo *GitRepo) branch() string {
 	arg := []string{repo.gitDir(), repo.workTree(), "rev-parse", "--abbrev-ref", "HEAD"}
 
-	cmd := exec.Command("git", arg...)
+	cmd := exec.Command(__go_cmd, arg...)
 	str := utils.ExecuteCommand(cmd)
 
 	return str
@@ -41,7 +41,7 @@ func (repo *GitRepo) branch() string {
 func (repo *GitRepo) changedFiles() []string {
 	arg := []string{repo.gitDir(), repo.workTree(), "status", "--porcelain"}
 
-	cmd := exec.Command("git", arg...)
+	cmd := exec.Command(__go_cmd, arg...)
 	str := utils.ExecuteCommand(cmd)
 
 	data := strings.Split(str, "\n")
@@ -56,7 +56,7 @@ func (repo *GitRepo) commits(commitCount int, commitFormat, dateFormat string) [
 
 	arg := []string{repo.gitDir(), repo.workTree(), "log", dateStr, numStr, commitStr}
 
-	cmd := exec.Command("git", arg...)
+	cmd := exec.Command(__go_cmd, arg...)
 	str := utils.ExecuteCommand(cmd)
 
 	data := strings.Split(str, "\n")
@@ -66,21 +66,21 @@ func (repo *GitRepo) commits(commitCount int, commitFormat, dateFormat string) [
 
 func (repo *GitRepo) repository() string {
 	arg := []string{repo.gitDir(), repo.workTree(), "rev-parse", "--show-toplevel"}
-	cmd := exec.Command("git", arg...)
+	cmd := exec.Command(__go_cmd, arg...)
 	str := utils.ExecuteCommand(cmd)
 
 	return str
 }
 func (repo *GitRepo) pull() string {
 	arg := []string{repo.gitDir(), repo.workTree(), "pull"}
-	cmd := exec.Command("git", arg...)
+	cmd := exec.Command(__go_cmd, arg...)
 	str := utils.ExecuteCommand(cmd)
 	return str
 }
 
 func (repo *GitRepo) checkout(branch string) string {
 	arg := []string{repo.gitDir(), repo.workTree(), "checkout", branch}
-	cmd := exec.Command("git", arg...)
+	cmd := exec.Command(__go_cmd, arg...)
 	str := utils.ExecuteCommand(cmd)
 	return str
 }

--- a/modules/git/variables.go
+++ b/modules/git/variables.go
@@ -2,9 +2,6 @@
 
 package git
 
-import "os"
-
 const (
-	__path_seperator = string(os.PathSeparator)
 	__go_cmd         = "git"
 )

--- a/modules/git/variables.go
+++ b/modules/git/variables.go
@@ -3,5 +3,5 @@
 package git
 
 const (
-	__go_cmd         = "git"
+	__go_cmd = "git"
 )

--- a/modules/git/variables.go
+++ b/modules/git/variables.go
@@ -1,0 +1,10 @@
+//go:build !windows
+
+package git
+
+import "os"
+
+const (
+	__path_seperator = string(os.PathSeparator)
+	__go_cmd         = "git"
+)

--- a/modules/git/variables_win.go
+++ b/modules/git/variables_win.go
@@ -2,9 +2,6 @@
 
 package git
 
-import "os"
-
 const (
-	__path_seperator = string(os.PathSeparator)
-	__go_cmd         = "git.exe"
+	__go_cmd = "git.exe"
 )

--- a/modules/git/variables_win.go
+++ b/modules/git/variables_win.go
@@ -1,0 +1,10 @@
+//go:build windows
+
+package git
+
+import "os"
+
+const (
+	__path_seperator = string(os.PathSeparator)
+	__go_cmd         = "git.exe"
+)

--- a/modules/git/widget.go
+++ b/modules/git/widget.go
@@ -151,7 +151,7 @@ func (widget *Widget) gitRepos(repoPaths []string) []*GitRepo {
 	repos := []*GitRepo{}
 
 	for _, repoPath := range repoPaths {
-		if strings.HasSuffix(repoPath, __path_seperator) {
+		if strings.HasSuffix(repoPath, string(os.PathSeparator)) {
 			repos = append(repos, widget.findGitRepositories(make([]*GitRepo, 0), repoPath)...)
 
 		} else {
@@ -170,7 +170,7 @@ func (widget *Widget) gitRepos(repoPaths []string) []*GitRepo {
 }
 
 func (widget *Widget) findGitRepositories(repositories []*GitRepo, directory string) []*GitRepo {
-	directory = strings.TrimSuffix(directory, __path_seperator)
+	directory = strings.TrimSuffix(directory, string(os.PathSeparator))
 
 	files, err := os.ReadDir(directory)
 	if err != nil {
@@ -181,10 +181,10 @@ func (widget *Widget) findGitRepositories(repositories []*GitRepo, directory str
 
 	for _, file := range files {
 		if file.IsDir() {
-			path = directory + __path_seperator + file.Name()
+			path = directory + string(os.PathSeparator) + file.Name()
 
 			if file.Name() == ".git" {
-				path = strings.TrimSuffix(path, __path_seperator+".git")
+				path = strings.TrimSuffix(path, string(os.PathSeparator)+".git")
 
 				repo := NewGitRepo(
 					path,

--- a/modules/git/widget.go
+++ b/modules/git/widget.go
@@ -151,7 +151,7 @@ func (widget *Widget) gitRepos(repoPaths []string) []*GitRepo {
 	repos := []*GitRepo{}
 
 	for _, repoPath := range repoPaths {
-		if strings.HasSuffix(repoPath, "/") {
+		if strings.HasSuffix(repoPath, __path_seperator) {
 			repos = append(repos, widget.findGitRepositories(make([]*GitRepo, 0), repoPath)...)
 
 		} else {
@@ -170,7 +170,7 @@ func (widget *Widget) gitRepos(repoPaths []string) []*GitRepo {
 }
 
 func (widget *Widget) findGitRepositories(repositories []*GitRepo, directory string) []*GitRepo {
-	directory = strings.TrimSuffix(directory, "/")
+	directory = strings.TrimSuffix(directory, __path_seperator)
 
 	files, err := os.ReadDir(directory)
 	if err != nil {
@@ -181,10 +181,10 @@ func (widget *Widget) findGitRepositories(repositories []*GitRepo, directory str
 
 	for _, file := range files {
 		if file.IsDir() {
-			path = directory + "/" + file.Name()
+			path = directory + __path_seperator + file.Name()
 
 			if file.Name() == ".git" {
-				path = strings.TrimSuffix(path, "/.git")
+				path = strings.TrimSuffix(path, __path_seperator+".git")
 
 				repo := NewGitRepo(
 					path,


### PR DESCRIPTION
### What changes:
 - Use `__go_cmd` variable in `exec.Command` which will be-
   - `git.exe` for Windows
   - `git` for all others
 - Use `os.PathSeparator` instead of `"/"`

### Discusstion:
Please refer to this discusstion- #1422