### PR TITLE
Add keyboard controls to lunarphase module

### DIFF
--- a/app/widget_maker.go
+++ b/app/widget_maker.go
@@ -249,7 +249,7 @@ func MakeWidget(
 		widget = mercurial.NewWidget(tviewApp, redrawChan, pages, settings)
 	case "lunarphase":
 		settings := lunarphase.NewSettingsFromYAML(moduleName, moduleConfig, config)
-		widget = lunarphase.NewWidget(tviewApp, redrawChan, settings)
+		widget = lunarphase.NewWidget(tviewApp, redrawChan, pages, settings)
 	case "mempool":
 		settings := mempool.NewSettingsFromYAML(moduleName, moduleConfig, config)
 		widget = mempool.NewWidget(tviewApp, redrawChan, pages, settings)

--- a/app/widget_maker.go
+++ b/app/widget_maker.go
@@ -244,12 +244,12 @@ func MakeWidget(
 	case "logger":
 		settings := logger.NewSettingsFromYAML(moduleName, moduleConfig, config)
 		widget = logger.NewWidget(tviewApp, redrawChan, settings)
-	case "mercurial":
-		settings := mercurial.NewSettingsFromYAML(moduleName, moduleConfig, config)
-		widget = mercurial.NewWidget(tviewApp, redrawChan, pages, settings)
 	case "lunarphase":
 		settings := lunarphase.NewSettingsFromYAML(moduleName, moduleConfig, config)
 		widget = lunarphase.NewWidget(tviewApp, redrawChan, pages, settings)
+	case "mercurial":
+		settings := mercurial.NewSettingsFromYAML(moduleName, moduleConfig, config)
+		widget = mercurial.NewWidget(tviewApp, redrawChan, pages, settings)
 	case "mempool":
 		settings := mempool.NewSettingsFromYAML(moduleName, moduleConfig, config)
 		widget = mempool.NewWidget(tviewApp, redrawChan, pages, settings)

--- a/modules/lunarphase/keyboard.go
+++ b/modules/lunarphase/keyboard.go
@@ -8,6 +8,7 @@ func (widget *Widget) initializeKeyboardControls() {
 
 	widget.SetKeyboardChar("n", widget.NextDay, "Show next day lunar phase")
 	widget.SetKeyboardChar("p", widget.PrevDay, "Show previous day lunar phase")
+	widget.SetKeyboardChar("t", widget.Today, "Show today lunar phase")
 	widget.SetKeyboardChar("N", widget.NextWeek, "Show next week lunar phase")
 	widget.SetKeyboardChar("P", widget.PrevWeek, "Show previous week lunar phase")
 	widget.SetKeyboardChar("o", widget.OpenMoonPhase, "Open 'Moon Phase for Today' in browser")

--- a/modules/lunarphase/keyboard.go
+++ b/modules/lunarphase/keyboard.go
@@ -1,0 +1,21 @@
+package lunarphase
+
+import "github.com/gdamore/tcell/v2"
+
+func (widget *Widget) initializeKeyboardControls() {
+	widget.InitializeHelpTextKeyboardControl(widget.ShowHelp)
+	widget.InitializeRefreshKeyboardControl(widget.Refresh)
+
+	widget.SetKeyboardChar("n", widget.NextDay, "Show next day lunar phase")
+	widget.SetKeyboardChar("p", widget.PrevDay, "Show previous day lunar phase")
+	widget.SetKeyboardChar("N", widget.NextWeek, "Show next week lunar phase")
+	widget.SetKeyboardChar("P", widget.PrevWeek, "Show previous week lunar phase")
+	widget.SetKeyboardChar("o", widget.OpenMoonPhase, "Open 'Moon Phase for Today' in browser")
+
+	widget.SetKeyboardKey(tcell.KeyLeft, widget.PrevDay, "Show previous day lunar phase")
+	widget.SetKeyboardKey(tcell.KeyRight, widget.NextDay, "Show next day lunar phase")
+	widget.SetKeyboardKey(tcell.KeyUp, widget.NextWeek, "Show next week lunar phase")
+	widget.SetKeyboardKey(tcell.KeyDown, widget.PrevWeek, "Show previous week lunar phase")
+	widget.SetKeyboardKey(tcell.KeyEnter, widget.OpenMoonPhase, "Open 'Moon Phase for Today' in browser")
+	widget.SetKeyboardKey(tcell.KeyCtrlD, widget.DisableWidget, "Disable/Enable this widget instance")
+}

--- a/modules/lunarphase/settings.go
+++ b/modules/lunarphase/settings.go
@@ -15,7 +15,7 @@ const (
 type Settings struct {
 	*cfg.Common
 
-	language string
+	language       string
 	requestTimeout int
 }
 
@@ -23,7 +23,7 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	settings := Settings{
 		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
-		language: ymlConfig.UString("language", "en"),
+		language:       ymlConfig.UString("language", "en"),
 		requestTimeout: ymlConfig.UInt("timeout", 30),
 	}
 

--- a/modules/lunarphase/settings.go
+++ b/modules/lunarphase/settings.go
@@ -6,14 +6,17 @@ import (
 )
 
 const (
-	defaultFocusable = false
+	defaultFocusable = true
 	defaultTitle     = "Phase of the Moon"
+	dateFormat       = "2006-01-02"
+	phaseFormat      = "01-02-2006"
 )
 
 type Settings struct {
 	*cfg.Common
 
 	language string
+	requestTimeout int
 }
 
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
@@ -21,6 +24,7 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
 		language: ymlConfig.UString("language", "en"),
+		requestTimeout: ymlConfig.UInt("timeout", 30),
 	}
 
 	settings.SetDocumentationPath("lunarphase")

--- a/modules/lunarphase/widget.go
+++ b/modules/lunarphase/widget.go
@@ -4,42 +4,63 @@ import (
 	"io"
 	"net/http"
 	"strings"
+    "time"
 
 	"github.com/rivo/tview"
+	"github.com/wtfutil/wtf/utils"
 	"github.com/wtfutil/wtf/view"
 	"github.com/wtfutil/wtf/wtf"
 )
 
 type Widget struct {
-	view.TextWidget
+	view.ScrollableWidget
 
-	result   string
-	settings *Settings
+	day       string
+	date      time.Time
+	result    string
+	settings  *Settings
+	timeout   time.Duration
+	titleBase string
 }
 
-func NewWidget(tviewApp *tview.Application, redrawChan chan bool, settings *Settings) *Widget {
-	widget := Widget{
-		TextWidget: view.NewTextWidget(tviewApp, redrawChan, nil, settings.Common),
-
+func NewWidget(tviewApp *tview.Application, redrawChan chan bool, pages *tview.Pages, settings *Settings) *Widget {
+	widget := &Widget{
+		ScrollableWidget: view.NewScrollableWidget(tviewApp, redrawChan, pages, settings.Common),
 		settings: settings,
 	}
 
-	return &widget
+    widget.titleBase = widget.settings.Title
+	widget.timeout = time.Duration(widget.settings.requestTimeout) * time.Second
+    widget.date = time.Now()
+    widget.day = widget.date.Format(dateFormat)
+
+	widget.SetRenderFunction(widget.Refresh)
+	widget.initializeKeyboardControls()
+
+	return widget
 }
 
 func (widget *Widget) Refresh() {
 	widget.lunarPhase()
+
+	if !widget.settings.Enabled {
+		widget.View.Clear()
+		return
+	}
+	widget.settings.Common.Title = widget.titleBase + " " + widget.day
 
 	widget.Redraw(func() (string, string, bool) { return widget.CommonSettings().Title, widget.result, false })
 }
 
 // this method reads the config and calls wttr.in for lunar phase
 func (widget *Widget) lunarPhase() {
-	client := &http.Client{}
+	client := &http.Client{
+		Timeout: widget.timeout,
+	}
 
 	language := widget.settings.language
 
-	req, err := http.NewRequest("GET", "https://wttr.in/Moon?AF"+language, http.NoBody)
+	req, err := http.NewRequest("GET", "https://wttr.in/Moon@" + widget.day + "?AF&lang=" + language, http.NoBody)
 	if err != nil {
 		widget.result = err.Error()
 		return
@@ -51,7 +72,6 @@ func (widget *Widget) lunarPhase() {
 	if err != nil {
 		widget.result = err.Error()
 		return
-
 	}
 	defer func() { _ = response.Body.Close() }()
 
@@ -62,4 +82,52 @@ func (widget *Widget) lunarPhase() {
 	}
 
 	widget.result = strings.TrimSpace(wtf.ASCIItoTviewColors(string(contents)))
+}
+
+// NextDay shows the next day's lunar phase (KeyRight / 'n')
+func (widget *Widget) NextDay() {
+	tomorrow := widget.date.AddDate(0, 0, 1)
+	widget.setDay(tomorrow)
+}
+
+// NextWeek shows the next week's lunar phase (KeyUp / 'N')
+func (widget *Widget) NextWeek() {
+	nextweek := widget.date.AddDate(0, 0, 7)
+	widget.setDay(nextweek)
+}
+
+// PrevDay shows the previous day's lunar phase (KeyLeft / 'p')
+func (widget *Widget) PrevDay() {
+	yesterday := widget.date.AddDate(0, 0, -1)
+	widget.setDay(yesterday)
+}
+
+// PrevWeek shows the previous week's lunar phase (KeyDown / 'P')
+func (widget *Widget) PrevWeek() {
+	lastweek := widget.date.AddDate(0, 0, -7)
+	widget.setDay(lastweek)
+}
+
+func (widget *Widget) setDay(ts time.Time) {
+	widget.date = ts
+    widget.day = widget.date.Format(dateFormat)
+	widget.Refresh()
+}
+
+// Open nineplanets.org in a browser (Enter / 'o')
+func (widget *Widget) OpenMoonPhase() {
+	phasedate := widget.date.Format(phaseFormat)
+	utils.OpenFile("https://nineplanets.org/moon/phase/" + phasedate + "/")
+}
+
+// Disable/Enable the widget (Ctrl-D)
+func (widget *Widget) DisableWidget() {
+
+	if widget.settings.Enabled {
+		widget.settings.Enabled = false
+	} else {
+		widget.settings.Enabled = true
+	}
+
+	widget.Refresh()
 }

--- a/modules/lunarphase/widget.go
+++ b/modules/lunarphase/widget.go
@@ -23,7 +23,6 @@ type Widget struct {
 	settings  *Settings
 	timeout   time.Duration
 	titleBase string
-	today     string
 }
 
 func NewWidget(tviewApp *tview.Application, redrawChan chan bool, pages *tview.Pages, settings *Settings) *Widget {

--- a/modules/lunarphase/widget.go
+++ b/modules/lunarphase/widget.go
@@ -4,7 +4,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
-    "time"
+	"time"
 
 	"github.com/rivo/tview"
 	"github.com/wtfutil/wtf/utils"
@@ -26,13 +26,13 @@ type Widget struct {
 func NewWidget(tviewApp *tview.Application, redrawChan chan bool, pages *tview.Pages, settings *Settings) *Widget {
 	widget := &Widget{
 		ScrollableWidget: view.NewScrollableWidget(tviewApp, redrawChan, pages, settings.Common),
-		settings: settings,
+		settings:         settings,
 	}
 
-    widget.titleBase = widget.settings.Title
+	widget.titleBase = widget.settings.Title
 	widget.timeout = time.Duration(widget.settings.requestTimeout) * time.Second
-    widget.date = time.Now()
-    widget.day = widget.date.Format(dateFormat)
+	widget.date = time.Now()
+	widget.day = widget.date.Format(dateFormat)
 
 	widget.SetRenderFunction(widget.Refresh)
 	widget.initializeKeyboardControls()
@@ -60,7 +60,7 @@ func (widget *Widget) lunarPhase() {
 
 	language := widget.settings.language
 
-	req, err := http.NewRequest("GET", "https://wttr.in/Moon@" + widget.day + "?AF&lang=" + language, http.NoBody)
+	req, err := http.NewRequest("GET", "https://wttr.in/Moon@"+widget.day+"?AF&lang="+language, http.NoBody)
 	if err != nil {
 		widget.result = err.Error()
 		return
@@ -110,7 +110,7 @@ func (widget *Widget) PrevWeek() {
 
 func (widget *Widget) setDay(ts time.Time) {
 	widget.date = ts
-    widget.day = widget.date.Format(dateFormat)
+	widget.day = widget.date.Format(dateFormat)
 	widget.Refresh()
 }
 


### PR DESCRIPTION
This pull request adds keyboard control for the `lunarphase` module to display the next day/week lunar phase, previous day/week lunar phase, enable/disable widget display, and open a site displaying more info on the currently selected day's lunar phase in a browser.

Corresponding documentation will be submitted in a pull request to wtfdocs
