### PR TITLE
Fixes resourceusage refreshing

### DIFF
--- a/modules/resourceusage/settings.go
+++ b/modules/resourceusage/settings.go
@@ -6,9 +6,9 @@ import (
 )
 
 const (
-	defaultFocusable = false
+	defaultFocusable       = false
 	defaultRefreshInterval = "1s"
-	defaultTitle     = "ResourceUsage"
+	defaultTitle           = "ResourceUsage"
 )
 
 type Settings struct {

--- a/modules/resourceusage/settings.go
+++ b/modules/resourceusage/settings.go
@@ -7,6 +7,7 @@ import (
 
 const (
 	defaultFocusable = false
+	defaultRefreshInterval = "1s"
 	defaultTitle     = "ResourceUsage"
 )
 
@@ -28,6 +29,7 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 		showMem:     ymlConfig.UBool("showMem", true),
 		showSwp:     ymlConfig.UBool("showSwp", true),
 	}
+	settings.Common.RefreshInterval = cfg.ParseTimeString(ymlConfig, "refreshInterval", defaultRefreshInterval)
 
 	return &settings
 }

--- a/modules/resourceusage/widget.go
+++ b/modules/resourceusage/widget.go
@@ -132,7 +132,6 @@ func (widget *Widget) Refresh() {
 
 	widget.View.Clear()
 	MakeGraph(widget)
-	widget.Base.RedrawChan <- true
 }
 
 /* -------------------- Unexported Functions -------------------- */

--- a/modules/resourceusage/widget.go
+++ b/modules/resourceusage/widget.go
@@ -132,6 +132,7 @@ func (widget *Widget) Refresh() {
 
 	widget.View.Clear()
 	MakeGraph(widget)
+	widget.Base.RedrawChan <- true
 }
 
 /* -------------------- Unexported Functions -------------------- */

--- a/view/bargraph.go
+++ b/view/bargraph.go
@@ -50,6 +50,7 @@ func NewBarGraph(tviewApp *tview.Application, redrawChan chan bool, _ string, co
 // time should be passed as a int64
 func (widget *BarGraph) BuildBars(data []Bar) {
 	widget.View.SetText(BuildStars(data, widget.maxStars, widget.starChar))
+	widget.Base.RedrawChan <- true
 }
 
 // BuildStars build the string to display


### PR DESCRIPTION
After the refresh refactor, it doesn't look like we are triggering a refresh of this module.
Additionally, the default refresh of 300s is quite high. Institute a lower refresh interval.

Fixes #1458 