### PR TITLE
Fix transmission

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,8 +26,6 @@ require (
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/godbus/dbus v4.1.0+incompatible // indirect
 	github.com/google/go-github/v32 v32.1.0
-	github.com/hekmon/cunits v2.0.1+incompatible // indirect
-	github.com/hekmon/transmissionrpc v0.0.0-20190525133028-1d589625bacd
 	github.com/jedib0t/go-pretty/v6 v6.4.4
 	github.com/jessevdk/go-flags v1.5.0
 	github.com/logrusorgru/aurora v0.0.0-20190803045625-94edacc10f9b
@@ -73,6 +71,7 @@ require github.com/nicklaw5/helix/v2 v2.19.0
 require (
 	github.com/charmbracelet/bubbles v0.14.0
 	github.com/gdamore/tcell/v2 v2.6.0
+	github.com/hekmon/transmissionrpc/v2 v2.0.1
 	github.com/muesli/reflow v0.3.0
 )
 
@@ -133,6 +132,7 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.1 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
+	github.com/hekmon/cunits/v2 v2.1.0 // indirect
 	github.com/huandu/xstrings v1.2.0 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -331,10 +331,10 @@ github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO
 github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0mNTz8vQ=
 github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2pPBoIllUwCN7I=
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
-github.com/hekmon/cunits v2.0.1+incompatible h1:yy/Wq5YvNtrweqfeRjvrvMdBMH6axBrlL8t7arLlm5A=
-github.com/hekmon/cunits v2.0.1+incompatible/go.mod h1:0QdfIGGkucx1VgStMNiHOYn84t/Ru65b+D3z1QszVPc=
-github.com/hekmon/transmissionrpc v0.0.0-20190525133028-1d589625bacd h1:bZZYKxyrUV8EsKB5AjsPsJiWE7n0FDURijlSzYZVqAM=
-github.com/hekmon/transmissionrpc v0.0.0-20190525133028-1d589625bacd/go.mod h1:b1R6hlzo+gEUNWGh53mw9mPWyYyODdZu/qlVqT+W+PU=
+github.com/hekmon/cunits/v2 v2.1.0 h1:k6wIjc4PlacNOHwKEMBgWV2/c8jyD4eRMs5mR1BBhI0=
+github.com/hekmon/cunits/v2 v2.1.0/go.mod h1:9r1TycXYXaTmEWlAIfFV8JT+Xo59U96yUJAYHxzii2M=
+github.com/hekmon/transmissionrpc/v2 v2.0.1 h1:WkILCEdbNy3n/N/w7mi449waMPdH2AA1THyw7TfnN/w=
+github.com/hekmon/transmissionrpc/v2 v2.0.1/go.mod h1:+s96Pkg7dIP3h2PT3fzhXPvNb3OdLryh5J8PIvQg3aA=
 github.com/hinshun/vt10x v0.0.0-20180809195222-d55458df857c h1:kp3AxgXgDOmIJFR7bIwqFhwJ2qWar8tEQSE5XXhCfVk=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=

--- a/modules/transmission/display.go
+++ b/modules/transmission/display.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hekmon/transmissionrpc"
+	"github.com/hekmon/transmissionrpc/v2"
 	"github.com/rivo/tview"
 	"github.com/wtfutil/wtf/utils"
 )
@@ -53,7 +53,7 @@ func (widget *Widget) prettyTorrentName(name string) string {
 	return str
 }
 
-func (widget *Widget) torrentPercentDone(torrent *transmissionrpc.Torrent) string {
+func (widget *Widget) torrentPercentDone(torrent transmissionrpc.Torrent) string {
 	pctDone := *torrent.PercentDone
 	str := fmt.Sprintf("%3d%%↓", int(pctDone*100))
 
@@ -69,7 +69,7 @@ func (widget *Widget) torrentPercentDone(torrent *transmissionrpc.Torrent) strin
 	return str + "[white]"
 }
 
-func (widget *Widget) torrentSeedRatio(torrent *transmissionrpc.Torrent) string {
+func (widget *Widget) torrentSeedRatio(torrent transmissionrpc.Torrent) string {
 	seedRatio := *torrent.UploadRatio
 
 	if seedRatio < 0 {
@@ -79,7 +79,7 @@ func (widget *Widget) torrentSeedRatio(torrent *transmissionrpc.Torrent) string 
 	return fmt.Sprintf("[green]%3d%%↑", int(seedRatio*100))
 }
 
-func (widget *Widget) torrentState(torrent *transmissionrpc.Torrent) string {
+func (widget *Widget) torrentState(torrent transmissionrpc.Torrent) string {
 	str := ""
 
 	switch *torrent.Status {

--- a/modules/transmission/settings.go
+++ b/modules/transmission/settings.go
@@ -32,7 +32,7 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 		https:        ymlConfig.UBool("https", false),
 		password:     ymlConfig.UString("password"),
 		port:         uint16(ymlConfig.UInt("port", 9091)),
-		url:          ymlConfig.UString("url", "/transmission/"),
+		url:          ymlConfig.UString("url", ""),
 		username:     ymlConfig.UString("username", ""),
 		hideComplete: ymlConfig.UBool("hideComplete", false),
 	}


### PR DESCRIPTION
The upgrade by dependabot in  #1504 pointed out that v1 doesn't work with 'recent' versions of transmission This upgrades to the v2 library


Thanks for submitting a pull request. Please provide enough information so that others can review your pull request.


