### PR TITLE
Indicate we are resizable so that we are more like a tty

### DIFF
--- a/modules/cmdrunner/widget.go
+++ b/modules/cmdrunner/widget.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/creack/pty"
 	"github.com/rivo/tview"
+	"github.com/wtfutil/wtf/logger"
 	"github.com/wtfutil/wtf/view"
 )
 
@@ -161,7 +162,7 @@ func runCommandPty(widget *Widget, cmd *exec.Cmd) error {
 	go func() {
 		for range ch {
 			if err := pty.InheritSize(os.Stdin, f); err != nil {
-				panic(fmt.Sprintf("error resizing pty: %s", err))
+				logger.Log(fmt.Sprintf("error resizing pty: %s", err))
 			}
 		}
 	}()


### PR DESCRIPTION
This resolves #1267 and potentially other tty coloring bugs Taken from https://github.com/creack/pty#shell
'Resizing' seems to indicate more readily that we are interactive


Thanks for submitting a pull request. Please provide enough information so that others can review your pull request.


