### PR TITLE
Don't serialize/deserialize the checked icons

### DIFF
--- a/checklist/checklist_item.go
+++ b/checklist/checklist_item.go
@@ -9,11 +9,11 @@ import (
 // See 'Todo' for an implementation example
 type ChecklistItem struct {
 	Checked       bool
-	CheckedIcon   string
+	CheckedIcon   string `yaml:"-"`
 	Date          *time.Time
 	Tags          []string
 	Text          string
-	UncheckedIcon string
+	UncheckedIcon string `yaml:"-"`
 }
 
 func NewChecklistItem(checked bool, date *time.Time, tags []string, text string, checkedIcon, uncheckedIcon string) *ChecklistItem {


### PR DESCRIPTION
Resolves #1523
These should really be driven by the base config, and these fields are really internal fields for convenience


Thanks for submitting a pull request. Please provide enough information so that others can review your pull request.


