### PR TITLE
Suggestion for reverse chronological order for Clock configuration

### DIFF
--- a/modules/clocks/clock_collection.go
+++ b/modules/clocks/clock_collection.go
@@ -14,6 +14,8 @@ func (clocks *ClockCollection) Sorted(sortOrder string) []Clock {
 		//no-op
 	} else if sortOrder == "chronological" {
 		clocks.SortedChronologically()
+	} else if sortOrder == "reversechronological" {
+		clocks.SortedReverseChronologically()
 	} else {
 		clocks.SortedAlphabetically()
 	}
@@ -37,5 +39,15 @@ func (clocks *ClockCollection) SortedChronologically() {
 		other := clocks.Clocks[j]
 
 		return clock.ToLocal(now).String() < other.ToLocal(now).String()
+	})
+}
+
+func (clocks *ClockCollection) SortedReverseChronologically() {
+	now := time.Now()
+	sort.Slice(clocks.Clocks, func(i, j int) bool {
+		clock := clocks.Clocks[i]
+		other := clocks.Clocks[j]
+
+		return clock.ToLocal(now).String() > other.ToLocal(now).String()
 	})
 }


### PR DESCRIPTION
Added implementation of reverse chronological order as a configuration parameter for the Clocks module.

Since there is a chronological order, which is very nifty, it can nice to have it reversed. I use it for colleagues and service vendors in other time zones.


