### PR TITLE
yfinance: Reset color at end of each row

### DIFF
--- a/modules/stocks/yfinance/widget.go
+++ b/modules/stocks/yfinance/widget.go
@@ -60,7 +60,7 @@ func (widget *Widget) content() string {
 			yq.Symbol,
 			fmt.Sprintf("%8.2f %s", yq.MarketPrice, yq.Currency),
 			GetTrendIcon(yq.Trend),
-			fmt.Sprintf("[%s]%+6.2f (%+5.2f%%)", colors[yq.Trend], yq.MarketChange, yq.MarketChangePct),
+			fmt.Sprintf("[%s]%+6.2f (%+5.2f%%)[white]", colors[yq.Trend], yq.MarketChange, yq.MarketChangePct),
 		})
 	}
 


### PR DESCRIPTION
We need to reset the color at the end of the row so that the current row's color does not splash over the next one until we set its own color.

Resolves https://github.com/wtfutil/wtf/issues/1548