### PR TITLE
Improve digitalclock module

### DIFF
--- a/modules/digitalclock/display.go
+++ b/modules/digitalclock/display.go
@@ -17,7 +17,15 @@ func renderWidget(widgetSettings Settings) string {
 	}
 
 	if widgetSettings.withDate {
-		outputStrings = append(outputStrings, getDate(widgetSettings.dateFormat, widgetSettings.withDatePrefix), getUTC(), getEpoch())
+		outputStrings = append(outputStrings, getDate(widgetSettings.dateFormat, widgetSettings.withDatePrefix))
+	}
+
+	if widgetSettings.withUTC {
+		outputStrings = append(outputStrings, getUTC())
+	}
+
+	if widgetSettings.withEpoch {
+		outputStrings = append(outputStrings, getEpoch())
 	}
 
 	return mergeLines(outputStrings)
@@ -25,6 +33,10 @@ func renderWidget(widgetSettings Settings) string {
 
 func (widget *Widget) display() {
 	widget.Redraw(func() (string, string, bool) {
-		return widget.CommonSettings().Title, renderWidget(*widget.settings), false
+		title := widget.CommonSettings().Title
+		if widget.settings.dateTitle {
+			title = getDate(widget.settings.dateFormat, false)
+		}
+		return title, renderWidget(*widget.settings), false
 	})
 }

--- a/modules/digitalclock/display.go
+++ b/modules/digitalclock/display.go
@@ -7,7 +7,7 @@ func mergeLines(outString []string) string {
 }
 
 func renderWidget(widgetSettings Settings) string {
-	outputStrings := []string{}
+	var outputStrings []string
 
 	clockString, needBorder := renderClock(widgetSettings)
 	if needBorder {

--- a/modules/digitalclock/fonts.go
+++ b/modules/digitalclock/fonts.go
@@ -79,10 +79,36 @@ func getBigFont() ClockFont {
 	return bigFont
 }
 
+func getBoldFont() ClockFont {
+    fontsMap := map[string][]string{
+        "1": {"██", "██", "██", "██", "██"},
+        "2": {"██████", "    ██", "██████", "██    ", "██████"},
+        "3": {"██████", "    ██", "██████", "    ██", "██████"},
+        "4": {"██  ██", "██  ██", "██████", "    ██", "    ██"},
+        "5": {"██████", "██    ", "██████", "    ██", "██████"},
+        "6": {"██████", "██    ", "██████", "██  ██", "██████"},
+        "7": {"██████", "    ██", "    ██", "    ██", "    ██"},
+        "8": {"██████", "██  ██", "██████", "██  ██", "██████"},
+        "9": {"██████", "██  ██", "██████", "    ██", "██████"},
+        "0": {"██████", "██  ██", "██  ██", "██  ██", "██████"},
+        ":": {"  ", "██", "  ", "██", "  "},
+        " ": {"  ", "  ", "  ", "  ", "  "},
+        "A": {"", "", "", "", "AM"},
+        "P": {"", "", "", "", "PM"},
+    }
+
+    boldFont := ClockFont{fontRows: 5, fonts: fontsMap}
+    return boldFont
+}
+
 // getFont returns appropriate font map based on the font settings
 func getFont(widgetSettings Settings) ClockFont {
-	if strings.ToLower(widgetSettings.font) == "digitalfont" {
-		return getDigitalFont()
-	}
-	return getBigFont()
+    switch strings.ToLower(widgetSettings.font) {
+    case "digitalfont":
+        return getDigitalFont()
+    case "boldfont":
+        return getBoldFont()
+    default:
+        return getBigFont()
+    }
 }

--- a/modules/digitalclock/fonts.go
+++ b/modules/digitalclock/fonts.go
@@ -80,35 +80,35 @@ func getBigFont() ClockFont {
 }
 
 func getBoldFont() ClockFont {
-    fontsMap := map[string][]string{
-        "1": {"██", "██", "██", "██", "██"},
-        "2": {"██████", "    ██", "██████", "██    ", "██████"},
-        "3": {"██████", "    ██", "██████", "    ██", "██████"},
-        "4": {"██  ██", "██  ██", "██████", "    ██", "    ██"},
-        "5": {"██████", "██    ", "██████", "    ██", "██████"},
-        "6": {"██████", "██    ", "██████", "██  ██", "██████"},
-        "7": {"██████", "    ██", "    ██", "    ██", "    ██"},
-        "8": {"██████", "██  ██", "██████", "██  ██", "██████"},
-        "9": {"██████", "██  ██", "██████", "    ██", "██████"},
-        "0": {"██████", "██  ██", "██  ██", "██  ██", "██████"},
-        ":": {"  ", "██", "  ", "██", "  "},
-        " ": {"  ", "  ", "  ", "  ", "  "},
-        "A": {"", "", "", "", "AM"},
-        "P": {"", "", "", "", "PM"},
-    }
+	fontsMap := map[string][]string{
+		"1": {"██", "██", "██", "██", "██"},
+		"2": {"██████", "    ██", "██████", "██    ", "██████"},
+		"3": {"██████", "    ██", "██████", "    ██", "██████"},
+		"4": {"██  ██", "██  ██", "██████", "    ██", "    ██"},
+		"5": {"██████", "██    ", "██████", "    ██", "██████"},
+		"6": {"██████", "██    ", "██████", "██  ██", "██████"},
+		"7": {"██████", "    ██", "    ██", "    ██", "    ██"},
+		"8": {"██████", "██  ██", "██████", "██  ██", "██████"},
+		"9": {"██████", "██  ██", "██████", "    ██", "██████"},
+		"0": {"██████", "██  ██", "██  ██", "██  ██", "██████"},
+		":": {"  ", "██", "  ", "██", "  "},
+		" ": {"  ", "  ", "  ", "  ", "  "},
+		"A": {"", "", "", "", "AM"},
+		"P": {"", "", "", "", "PM"},
+	}
 
-    boldFont := ClockFont{fontRows: 5, fonts: fontsMap}
-    return boldFont
+	boldFont := ClockFont{fontRows: 5, fonts: fontsMap}
+	return boldFont
 }
 
 // getFont returns appropriate font map based on the font settings
 func getFont(widgetSettings Settings) ClockFont {
-    switch strings.ToLower(widgetSettings.font) {
-    case "digitalfont":
-        return getDigitalFont()
-    case "boldfont":
-        return getBoldFont()
-    default:
-        return getBigFont()
-    }
+	switch strings.ToLower(widgetSettings.font) {
+	case "digitalfont":
+		return getDigitalFont()
+	case "boldfont":
+		return getBoldFont()
+	default:
+		return getBigFont()
+	}
 }

--- a/modules/digitalclock/settings.go
+++ b/modules/digitalclock/settings.go
@@ -18,8 +18,12 @@ type Settings struct {
 	font           string `help:"The font of the clock." values:"bigfont or digitalfont"`
 	hourFormat     string `help:"The format of the clock." values:"12 or 24"`
 	dateFormat     string `help:"The format of the date."`
+	dateTitle      bool   `help:"Whether or not to display date as widget title"`
 	withDate       bool   `help:"Whether or not to display date information"`
+	withUTC        bool   `help:"Whether or not to display UTC information"`
+	withEpoch      bool   `help:"Whether or not to display Epoch information"`
 	withDatePrefix bool   `help:"Whether or not to display Date: prefix"`
+	centerAlign    bool   `help:"Whether or not to use center align in widget"`
 }
 
 // NewSettingsFromYAML creates a new settings instance from a YAML config block
@@ -31,8 +35,12 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 		font:           ymlConfig.UString("font"),
 		hourFormat:     ymlConfig.UString("hourFormat", "24"),
 		dateFormat:     ymlConfig.UString("dateFormat", "Monday January 02 2006"),
+		dateTitle:      ymlConfig.UBool("dateTitle", false),
 		withDate:       ymlConfig.UBool("withDate", true),
+		withUTC:        ymlConfig.UBool("withUTC", true),
+		withEpoch:      ymlConfig.UBool("withEpoch", true),
 		withDatePrefix: ymlConfig.UBool("withDatePrefix", true),
+		centerAlign:    ymlConfig.UBool("centerAlign", false),
 	}
 
 	return &settings

--- a/modules/digitalclock/widget.go
+++ b/modules/digitalclock/widget.go
@@ -19,6 +19,9 @@ func NewWidget(tviewApp *tview.Application, redrawChan chan bool, settings *Sett
 
 		settings: settings,
 	}
+	if settings.centerAlign {
+		widget.View.SetTextAlign(tview.AlignCenter)
+	}
 
 	return &widget
 }


### PR DESCRIPTION
This PR will add some customization options for `digitalclock` module:

- Bold font (like tty-clock util)
- Enable date, UTC and epoch lines separately from each other
- Display date in widget title
- Widget center alignment
![widget screenshot](https://user-images.githubusercontent.com/66359355/236623903-6d22f3c1-39ec-4b3a-ace3-20e91f441728.png)

