### PR TITLE
pihole: Use API url with Token

### DIFF
--- a/modules/pihole/view.go
+++ b/modules/pihole/view.go
@@ -17,7 +17,9 @@ func getSummaryView(c http.Client, settings *Settings) string {
 
 	var s Status
 
-	s, err = getStatus(c, settings.apiUrl)
+	url := settings.apiUrl + "?status&auth=" + settings.token
+
+	s, err = getStatus(c, url)
 	if err != nil {
 		return err.Error()
 	}


### PR DESCRIPTION
Use API url with Token, this change is based on the recommendation posted [here](https://pi-hole.net/blog/2022/11/17/upcoming-changes-authentication-for-more-api-endpoints-required/#page-content). Pihole must be password protected and 3rd party apps must use a token.

Not using the token will return an empty response object that triggers the error `failed to retrieve status: check provided api URL and token json: cannot unmarshal array into Go value of type pihole.Status`

Using the correct token will allow the response to include the correct status `Status ENABLED`

eg:

```bash
curl http://pi.hole/admin/api.php?status&auth=${TOKEN}
{"status":"enabled"}
```
Verification:
* make test
* make && ./bin/wtfutil