### PR TITLE
abort handleRedraws goroutine when reading from closed channel

### DIFF
--- a/app/wtf_app.go
+++ b/app/wtf_app.go
@@ -11,6 +11,7 @@ import (
 	"github.com/olebedev/config"
 	"github.com/radovskyb/watcher"
 	"github.com/rivo/tview"
+
 	"github.com/wtfutil/wtf/cfg"
 	"github.com/wtfutil/wtf/support"
 	"github.com/wtfutil/wtf/utils"
@@ -93,7 +94,10 @@ func handleRedraws(tviewApp *tview.Application, redrawChan chan bool) {
 	}
 
 	for {
-		data := <-redrawChan
+		data, ok := <-redrawChan
+		if !ok {
+			return
+		}
 
 		if data {
 			tviewApp.Draw()


### PR DESCRIPTION
Fixed https://github.com/wtfutil/wtf/issues/1478

The goroutine is expected to be stopped by closing the channel (see wtfApp.Stop()). But as the channel receive is not checked the handleRedraws goroutine turns into an indefinite loop.