### PR TITLE
Add a ping module

### DIFF
--- a/app/widget_maker.go
+++ b/app/widget_maker.go
@@ -87,6 +87,7 @@ import (
 	"github.com/wtfutil/wtf/modules/weatherservices/prettyweather"
 	"github.com/wtfutil/wtf/modules/weatherservices/weather"
 	"github.com/wtfutil/wtf/modules/zendesk"
+	"github.com/wtfutil/wtf/modules/ping"
 	"github.com/wtfutil/wtf/wtf"
 )
 
@@ -273,6 +274,9 @@ func MakeWidget(
 	case "pihole":
 		settings := pihole.NewSettingsFromYAML(moduleName, moduleConfig, config)
 		widget = pihole.NewWidget(tviewApp, redrawChan, pages, settings)
+	case "ping":
+		settings := ping.NewSettingsFromYAML(moduleName, moduleConfig, config)
+		widget = ping.NewWidget(tviewApp, redrawChan, settings)
 	case "power":
 		settings := power.NewSettingsFromYAML(moduleName, moduleConfig, config)
 		widget = power.NewWidget(tviewApp, redrawChan, settings)

--- a/modules/ping/settings.go
+++ b/modules/ping/settings.go
@@ -1,0 +1,53 @@
+package ping
+
+import (
+	"github.com/olebedev/config"
+	"github.com/wtfutil/wtf/cfg"
+)
+
+const (
+	defaultFocusable = false
+	defaultTitle     = "Pings"
+)
+
+type Target struct {
+	Name string
+	Host string
+	Up bool
+	Latency int
+}
+
+// Settings defines the configuration properties for this module
+type Settings struct {
+	common *cfg.Common
+	targets []Target
+
+    // Define your settings attributes here
+}
+
+// NewSettingsFromYAML creates a new settings instance from a YAML config block
+func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
+	settings := Settings{
+        common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+		targets:  buildTargets(ymlConfig),
+	}
+
+	return &settings
+}
+
+func buildTargets(ymlConfig *config.Config) []Target {
+	targets := []Target{}
+	yaml := ymlConfig.UList("targets")
+	for _, target := range yaml {
+		if target,ok := target.(map[string]interface{}); ok {
+			for k,v := range target {
+				name := k
+				host := v.(string)
+				t := Target{Name: name, Host: host, Up: false}
+				targets = append(targets, t)
+			}
+		}
+	}
+	return targets
+}
+

--- a/modules/ping/settings.go
+++ b/modules/ping/settings.go
@@ -11,21 +11,16 @@ const (
 )
 
 type Target struct {
-	Name string
-	Host string
-	Up bool
-	Latency int
+	Name string `help: "Name: The label to use for the host you want to ping"`
+	Host string `help: "Host: IP address or hostname to ping"`
+	Up bool // not meant to be set by user
 }
 
-// Settings defines the configuration properties for this module
 type Settings struct {
 	common *cfg.Common
 	targets []Target
-
-    // Define your settings attributes here
 }
 
-// NewSettingsFromYAML creates a new settings instance from a YAML config block
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 	settings := Settings{
         common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),

--- a/modules/ping/widget.go
+++ b/modules/ping/widget.go
@@ -2,6 +2,7 @@ package ping
 
 import (
 	"fmt"
+	"log"
 	"strings"
 	"sync"
 	"time"
@@ -54,17 +55,18 @@ func (widget *Widget) doPings() {
 					} else {
 						widget.targets[idx].Up = false
 					}
+				} else {
+					log.Fatalf("error sending ping: %v", err)
 				}
 			}
+
 		}()
 	}
 	wg.Wait()
 }
-// Refresh updates the onscreen contents of the widget
 func (widget *Widget) Refresh() {
 
 	widget.doPings()
-    // The last call should always be to the display function
     widget.display()
 }
 

--- a/modules/ping/widget.go
+++ b/modules/ping/widget.go
@@ -1,0 +1,100 @@
+package ping
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+	"github.com/rivo/tview"
+	"github.com/wtfutil/wtf/view"
+	"github.com/prometheus-community/pro-bing"
+)
+
+// Widget is the container for your module's data
+type Widget struct {
+	view.TextWidget
+	targets []Target
+
+	settings *Settings
+}
+
+// NewWidget creates and returns an instance of Widget
+func NewWidget(tviewApp *tview.Application, redrawChan chan bool, settings *Settings) *Widget {
+	widget := Widget{
+		TextWidget: view.NewTextWidget(tviewApp, redrawChan, nil, settings.common),
+
+		settings: settings,
+	}
+	widget.targets = widget.settings.targets
+
+	return &widget
+}
+
+/* -------------------- Exported Functions -------------------- */
+
+
+func (widget *Widget) doPings() {
+	var wg sync.WaitGroup
+	for i := range widget.targets {
+		idx := i
+		target := widget.targets[idx]
+		widget.targets[idx].Up = false // reset to false each time
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			pinger, err := probing.NewPinger(target.Host)
+			if err == nil {
+				pinger.Count = 1
+				pinger.Timeout = 10*time.Second
+				err = pinger.Run() // Blocks until finished.
+				if err == nil {
+					stats := pinger.Statistics() // get send/receive/duplicate/rtt stats
+					if stats.PacketsRecv > 0 {
+						widget.targets[idx].Up = true
+					} else {
+						widget.targets[idx].Up = false
+					}
+				}
+			}
+		}()
+	}
+	wg.Wait()
+}
+// Refresh updates the onscreen contents of the widget
+func (widget *Widget) Refresh() {
+
+	widget.doPings()
+    // The last call should always be to the display function
+    widget.display()
+}
+
+/* -------------------- Unexported Functions -------------------- */
+
+func (widget *Widget) content() string {
+	nameWidth := 12
+	for _,t := range widget.targets {
+		if len(t.Name) > nameWidth {
+			nameWidth = len(t.Name) + 2
+		}
+	}
+
+	s := []string{}
+	for _,t := range widget.targets {
+		var status string
+		if t.Up == true {
+			status = "[green]Up"
+		} else {
+			status = "[red]DOWN"
+		}
+		statusLine := fmt.Sprintf("[white]%-*s: %s", nameWidth, t.Name, status)
+		s = append(s, statusLine)
+	}
+
+	return strings.Join(s, "\n")
+}
+
+func (widget *Widget) display() {
+	widget.Redraw(func() (string, string, bool) {
+		return widget.CommonSettings().Title, widget.content(), false
+	})
+}


### PR DESCRIPTION
This adds a very basic Ping module, for when you need to see if a service is online but you can't / don't want to use a third-party API like updown.io. Sends an ICMP (or UDP) echo request and displays whether a response was received.

Note: sending ICMP is a privileged operation on some versions of Linux, so you either need to grant the wtf binary CAP_NET_RAW capability or allow unprivileged users to send UDP pings https://github.com/prometheus-community/pro-bing#linux

I haven't tested on Windows or anything other than Linux.

This is my first wtf module so there's probably a bunch of stuff that could be better / cleaner. Happy to make changes / improvements based on suggestions. 