### PR TITLE
Healthchecks module: Support title setting, add additional statuses

### DIFF
--- a/modules/healthchecks/widget.go
+++ b/modules/healthchecks/widget.go
@@ -87,7 +87,7 @@ func (widget *Widget) content() (string, string, bool) {
 		}
 	}
 
-	title := fmt.Sprintf("Healthchecks (%d/%d)", numUp, len(widget.checks))
+	title := fmt.Sprintf("%v (%d/%d)", widget.CommonSettings().Title, numUp, len(widget.checks))
 
 	if widget.err != nil {
 		return title, widget.err.Error(), true
@@ -113,6 +113,8 @@ func (widget *Widget) contentFrom(checks []Checks) string {
 			prefix += "[green] + "
 		case "down":
 			prefix += "[red] - "
+		case "paused", "new":
+			prefix += "[lightgray] × "
 		default:
 			prefix += "[yellow] ~ "
 		}


### PR DESCRIPTION
Two additions to the Healthchecks.io module
- Honor the title setting from common settings.
- Support two additional healthcheck statuses defined in the healthchecks API (New and Paused).