### PR TITLE
update firewall module to use sudo ufw status properly

### DIFF
--- a/modules/security/firewall.go
+++ b/modules/security/firewall.go
@@ -44,23 +44,22 @@ func FirewallStealthState() string {
 
 func firewallStateLinux() string { // might be very Ubuntu specific
 	user, _ := user.Current()
+    cmd := exec.Command("sudo", "/usr/sbin/ufw", "status")
 
 	if strings.Contains(user.Username, "root") {
-		cmd := exec.Command("ufw", "status")
+		cmd = exec.Command("ufw", "status")
+    }
 
-		var o bytes.Buffer
-		cmd.Stdout = &o
-		if err := cmd.Run(); err != nil {
-			return "[red]NA[white]"
-		}
+	var o bytes.Buffer
+	cmd.Stdout = &o
+	if err := cmd.Run(); err != nil {
+		return "[red]NA[white]"
+	}
 
-		if strings.Contains(o.String(), "inactive") {
-			return "[red]Disabled[white]"
-		} else {
-			return "[green]Enabled[white]"
-		}
+	if strings.Contains(o.String(), "inactive") {
+		return "[red]Disabled[white]"
 	} else {
-		return "[red]N/A[white]"
+		return "[green]Enabled[white]"
 	}
 }
 


### PR DESCRIPTION
This re-orders the "ufw status" logic to assume it's being run as a regular user, and use "sudo /usr/sbin/ufw status". If the username is root, then instead use simply "ufw status".

This update does NOT take variable elevation commands like pbrun/dzdo/pbsudo into account. I may add that in a future update.
