### PR TITLE
Fix docker client initialization

### DIFF
--- a/modules/docker/widget.go
+++ b/modules/docker/widget.go
@@ -24,7 +24,7 @@ func NewWidget(tviewApp *tview.Application, redrawChan chan bool, pages *tview.P
 
 	widget.View.SetScrollable(true)
 
-	cli, err := client.NewClientWithOpts()
+	cli, err := client.NewClientWithOpts(client.FromEnv)
 	if err != nil {
 		widget.displayBuffer = errors.Wrap(err, "could not create client").Error()
 	} else {


### PR DESCRIPTION
Fixes #1703 

As per [documentation](https://pkg.go.dev/github.com/docker/docker/client#hdr-Usage) for docker client it is recommended to initialize it from env with `client.FromEnv`:
> You use the library by constructing a client object using [NewClientWithOpts](https://pkg.go.dev/github.com/docker/docker/client#NewClientWithOpts) and calling methods on it. The client can be configured from environment variables by passing the [FromEnv](https://pkg.go.dev/github.com/docker/docker/client#FromEnv) option, or configured manually by passing any of the other available [Opts].

Another way is to initialize it manually with other `Opt`-s, which is more compex and I think is not required here.