### PR TITLE
add module githuballrepos

### DIFF
--- a/app/widget_maker.go
+++ b/app/widget_maker.go
@@ -31,6 +31,7 @@ import (
 	"github.com/wtfutil/wtf/modules/gerrit"
 	"github.com/wtfutil/wtf/modules/git"
 	"github.com/wtfutil/wtf/modules/github"
+	"github.com/wtfutil/wtf/modules/githuballrepos"
 	"github.com/wtfutil/wtf/modules/gitlab"
 	"github.com/wtfutil/wtf/modules/gitlabtodo"
 	"github.com/wtfutil/wtf/modules/gitter"
@@ -198,6 +199,9 @@ func MakeWidget(
 	case "github":
 		settings := github.NewSettingsFromYAML(moduleName, moduleConfig, config)
 		widget = github.NewWidget(tviewApp, redrawChan, pages, settings)
+	case "githuballrepos":
+		settings := githuballrepos.NewSettingsFromYAML(moduleName, moduleConfig, config)
+		widget = githuballrepos.NewWidget(tviewApp, redrawChan, pages, settings)
 	case "gitlab":
 		settings := gitlab.NewSettingsFromYAML(moduleName, moduleConfig, config)
 		widget = gitlab.NewWidget(tviewApp, redrawChan, pages, settings)

--- a/modules/githuballrepos/cache.go
+++ b/modules/githuballrepos/cache.go
@@ -1,0 +1,107 @@
+package githuballrepos
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"io/fs"
+
+	"github.com/wtfutil/wtf/logger"
+)
+
+type Cacher interface {
+	Get() *WidgetData
+	Set(data *WidgetData)
+	IsValid() bool
+}
+
+const cacheDuration = 5 * time.Minute
+
+// Cache stores the widget data and its expiration time
+type Cache struct {
+	data       *WidgetData
+	expires    time.Time
+	configPath string
+}
+
+// NewCache creates a new Cache instance
+func NewCache(configPath string) *Cache {
+	cache := &Cache{
+		configPath: configPath,
+	}
+
+	// Ensure the cache directory exists
+	cacheDir := filepath.Dir(cache.configPath)
+	logger.Log(fmt.Sprintf("Cache directory: %s\n", cacheDir))
+	if err := os.MkdirAll(cacheDir, 0755); err != nil {
+		logger.Log(fmt.Sprintf("Error creating cache directory: %s\n", err))
+	}
+
+	cache.load()
+	return cache
+}
+
+// Set updates the cache with new data
+func (c *Cache) Set(data *WidgetData) {
+	c.data = data
+	c.expires = time.Now().Add(cacheDuration)
+	c.save()
+}
+
+// Get retrieves the cached data
+func (c *Cache) Get() *WidgetData {
+	return c.data
+}
+
+// IsValid checks if the cache is still valid
+func (c *Cache) IsValid() bool {
+	return c.data != nil && time.Now().Before(c.expires)
+}
+
+// save writes the cache data to disk
+func (c *Cache) save() {
+	cacheData := struct {
+		Data    *WidgetData `json:"data"`
+		Expires time.Time   `json:"expires"`
+	}{
+		Data:    c.data,
+		Expires: c.expires,
+	}
+
+	jsonData, err := json.Marshal(cacheData)
+	if err != nil {
+		logger.Log(fmt.Sprintf("Error marshaling cache data: %s\n", err))
+		return
+	}
+
+	if err := os.WriteFile(c.configPath, jsonData, fs.FileMode(0644)); err != nil {
+		logger.Log(fmt.Sprintf("Error writing cache file: %s\n", err))
+	}
+}
+
+// load reads the cache data from disk
+func (c *Cache) load() {
+	jsonData, err := os.ReadFile(c.configPath)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			logger.Log(fmt.Sprintf("Error reading cache file: %s\n", err))
+		}
+		return
+	}
+
+	var cacheData struct {
+		Data    *WidgetData `json:"data"`
+		Expires time.Time   `json:"expires"`
+	}
+
+	if err := json.Unmarshal(jsonData, &cacheData); err != nil {
+		logger.Log(fmt.Sprintf("Error unmarshaling cache data: %s\n", err))
+		return
+	}
+
+	c.data = cacheData.Data
+	c.expires = cacheData.Expires
+}

--- a/modules/githuballrepos/client.go
+++ b/modules/githuballrepos/client.go
@@ -1,0 +1,146 @@
+package githuballrepos
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/shurcooL/githubv4"
+	"golang.org/x/oauth2"
+)
+
+type GitHubFetcher interface {
+	FetchData(orgs []string, username string) *WidgetData
+}
+
+// GitHubClient handles communication with the GitHub API
+type GitHubClient struct {
+	client *githubv4.Client
+}
+
+// NewGitHubClient creates a new GitHubClient
+func NewGitHubClient(token string) *GitHubClient {
+	src := oauth2.StaticTokenSource(
+		&oauth2.Token{AccessToken: token},
+	)
+	httpClient := oauth2.NewClient(context.Background(), src)
+
+	return &GitHubClient{
+		client: githubv4.NewClient(httpClient),
+	}
+}
+
+// FetchData retrieves all required data from GitHub
+func (c *GitHubClient) FetchData(orgs []string, username string) *WidgetData {
+	data := &WidgetData{
+		MyPRs:            make([]PR, 0),
+		PRReviewRequests: make([]PR, 0),
+		WatchedPRs:       make([]PR, 0),
+	}
+
+	for _, org := range orgs {
+		data.PRsOpenedByMe += c.fetchPRCount(org, username, "author")
+		data.PRReviewRequestsCount += c.fetchPRCount(org, username, "review-requested")
+		data.OpenIssuesCount += c.fetchIssueCount(org)
+
+		data.MyPRs = append(data.MyPRs, c.fetchPRs(org, username, "author")...)
+		data.PRReviewRequests = append(data.PRReviewRequests, c.fetchPRs(org, username, "review-requested")...)
+		data.WatchedPRs = append(data.WatchedPRs, c.fetchPRs(org, username, "involves")...)
+	}
+
+	return data
+}
+
+func (c *GitHubClient) fetchPRCount(org, username, filter string) int {
+	var query struct {
+		Search struct {
+			IssueCount int
+		} `graphql:"search(query: $query, type: ISSUE, first: 0)"`
+	}
+
+	variables := map[string]interface{}{
+		"query": githubv4.String(fmt.Sprintf("org:%s is:pr is:open %s:%s", org, filter, username)),
+	}
+
+	err := c.client.Query(context.Background(), &query, variables)
+	if err != nil {
+		// Handle error (log it, etc.)
+		return 0
+	}
+
+	return query.Search.IssueCount
+}
+
+func (c *GitHubClient) fetchIssueCount(org string) int {
+	var query struct {
+		Search struct {
+			IssueCount int
+		} `graphql:"search(query: $query, type: ISSUE, first: 0)"`
+	}
+
+	variables := map[string]interface{}{
+		"query": githubv4.String(fmt.Sprintf("org:%s is:issue is:open", org)),
+	}
+
+	err := c.client.Query(context.Background(), &query, variables)
+	if err != nil {
+		// Handle error (log it, etc.)
+		return 0
+	}
+
+	return query.Search.IssueCount
+}
+
+func (c *GitHubClient) fetchPRs(org, username, filter string) []PR {
+	var query struct {
+		Search struct {
+			Nodes []struct {
+				PullRequest struct {
+					Title  string
+					URL    string
+					Author struct {
+						Login string
+					}
+					Repository struct {
+						Name string
+					}
+				} `graphql:"... on PullRequest"`
+			}
+			PageInfo struct {
+				EndCursor   githubv4.String
+				HasNextPage bool
+			}
+		} `graphql:"search(query: $query, type: ISSUE, first: 100, after: $cursor)"`
+	}
+
+	variables := map[string]interface{}{
+		"query":  githubv4.String(fmt.Sprintf("org:%s is:pr is:open %s:%s", org, filter, username)),
+		"cursor": (*githubv4.String)(nil), // Null for first request
+	}
+
+	var allPRs []PR
+
+	for {
+		err := c.client.Query(context.Background(), &query, variables)
+		if err != nil {
+			// Handle error (log it, etc.)
+			break
+		}
+
+		for _, node := range query.Search.Nodes {
+			pr := node.PullRequest
+			allPRs = append(allPRs, PR{
+				Title:      pr.Title,
+				URL:        pr.URL,
+				Author:     pr.Author.Login,
+				Repository: pr.Repository.Name,
+			})
+		}
+
+		if !query.Search.PageInfo.HasNextPage {
+			break
+		}
+		variables["cursor"] = githubv4.NewString(query.Search.PageInfo.EndCursor)
+	}
+
+	return allPRs
+}

--- a/modules/githuballrepos/data.go
+++ b/modules/githuballrepos/data.go
@@ -1,0 +1,57 @@
+package githuballrepos
+
+import (
+	"fmt"
+	"strings"
+)
+
+// WidgetData holds all the data for the widget
+type WidgetData struct {
+	PRsOpenedByMe         int
+	PRReviewRequestsCount int
+	OpenIssuesCount       int
+
+	MyPRs            []PR
+	PRReviewRequests []PR
+	WatchedPRs       []PR
+}
+
+// PR represents a single pull request
+type PR struct {
+	Title      string
+	URL        string
+	Author     string
+	Repository string
+}
+
+// FormatCounters returns a formatted string of counters
+func (d *WidgetData) FormatCounters() string {
+	return fmt.Sprintf(
+		"PRs opened by me: %d\nPR review requests: %d\nOpen issues: %d\n",
+		d.PRsOpenedByMe,
+		d.PRReviewRequestsCount,
+		d.OpenIssuesCount,
+	)
+}
+
+// FormatPRs returns a formatted string of PRs
+func (d *WidgetData) FormatPRs() string {
+	var sb strings.Builder
+
+	sb.WriteString("[green]My PRs:[white]\n")
+	for _, pr := range d.MyPRs {
+		sb.WriteString(fmt.Sprintf("- %s (%s)\n", pr.Title, pr.Repository))
+	}
+
+	sb.WriteString("\n[yellow]PR Review Requests:[white]\n")
+	for _, pr := range d.PRReviewRequests {
+		sb.WriteString(fmt.Sprintf("- %s (%s)\n", pr.Title, pr.Repository))
+	}
+
+	sb.WriteString("\n[blue]Watched PRs:[white]\n")
+	for _, pr := range d.WatchedPRs {
+		sb.WriteString(fmt.Sprintf("- %s (%s by %s)\n", pr.Title, pr.Repository, pr.Author))
+	}
+
+	return sb.String()
+}

--- a/modules/githuballrepos/keyboard.go
+++ b/modules/githuballrepos/keyboard.go
@@ -1,0 +1,91 @@
+package githuballrepos
+
+import (
+	"fmt"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/wtfutil/wtf/logger"
+	"github.com/wtfutil/wtf/utils"
+)
+
+func (widget *Widget) initializeKeyboardControls() {
+
+	widget.InitializeHelpTextKeyboardControl(widget.ShowHelp)
+	widget.InitializeRefreshKeyboardControl(widget.Refresh)
+
+	widget.SetKeyboardChar("j", widget.Next, "Select next PR")
+	widget.SetKeyboardChar("k", widget.Prev, "Select previous PR")
+	widget.SetKeyboardChar("l", widget.nextTab, "Next tab")
+	widget.SetKeyboardChar("h", widget.prevTab, "Previous tab")
+	widget.SetKeyboardChar("o", widget.openSelected, "Open selected PR in browser")
+
+	widget.SetKeyboardKey(tcell.KeyDown, widget.Next, "Select next PR")
+	widget.SetKeyboardKey(tcell.KeyUp, widget.Prev, "Select previous PR")
+	widget.SetKeyboardKey(tcell.KeyRight, widget.nextTab, "Next tab")
+	widget.SetKeyboardKey(tcell.KeyLeft, widget.prevTab, "Previous tab")
+	widget.SetKeyboardKey(tcell.KeyEnter, widget.openSelected, "Open selected PR in browser")
+}
+
+func (widget *Widget) Next() {
+	logger.Log("Next called")
+	if widget.data == nil || len(widget.data.MyPRs) == 0 {
+		logger.Log("No data or empty MyPRs")
+		return
+	}
+	widget.selectedPRIndex = (widget.selectedPRIndex + 1) % len(widget.data.MyPRs)
+	widget.isItemSelected = true
+	logger.Log(fmt.Sprintf("Next completed. New index: %d\n", widget.selectedPRIndex))
+}
+
+func (widget *Widget) Prev() {
+	logger.Log("Prev called")
+	if widget.data == nil || len(widget.data.MyPRs) == 0 {
+		logger.Log("No data or empty MyPRs")
+		return
+	}
+	if widget.selectedPRIndex <= 0 {
+		widget.selectedPRIndex = len(widget.data.MyPRs) - 1
+	} else {
+		widget.selectedPRIndex--
+	}
+	widget.isItemSelected = true
+	logger.Log(fmt.Sprintf("Prev completed. New index: %d\n", widget.selectedPRIndex))
+}
+
+func (widget *Widget) nextTab() {
+	widget.currentTab = (widget.currentTab + 1) % 3
+	widget.selectedPRIndex = -1
+	widget.isItemSelected = false
+	if !widget.testMode {
+		widget.display()
+	}
+}
+
+func (widget *Widget) prevTab() {
+	widget.currentTab--
+	if widget.currentTab < 0 {
+		widget.currentTab = 2
+	}
+	widget.selectedPRIndex = -1
+	widget.isItemSelected = false
+
+	if !widget.testMode {
+		widget.display()
+	}
+}
+
+func (widget *Widget) openSelected() {
+	var prs []PR
+	switch widget.currentTab {
+	case 0:
+		prs = widget.data.MyPRs
+	case 1:
+		prs = widget.data.PRReviewRequests
+	case 2:
+		prs = widget.data.WatchedPRs
+	}
+
+	if widget.selectedPRIndex >= 0 && widget.selectedPRIndex < len(prs) {
+		utils.OpenFile(prs[widget.selectedPRIndex].URL)
+	}
+}

--- a/modules/githuballrepos/settings.go
+++ b/modules/githuballrepos/settings.go
@@ -1,0 +1,52 @@
+package githuballrepos
+
+import (
+	"os/user"
+	"path/filepath"
+	"strings"
+
+	"github.com/olebedev/config"
+	"github.com/wtfutil/wtf/cfg"
+)
+
+// Settings defines the configuration properties for this module
+type Settings struct {
+	common *cfg.Common
+
+	APIKey        string   `help:"Your GitHub API token."`
+	Organizations []string `help:"List of GitHub organizations and user accounts to monitor."`
+	Username      string   `help:"Your GitHub username."`
+	CachePath     string   `help:"The path to the cache file for this module."`
+}
+
+// NewSettingsFromYAML creates a new settings instance from a YAML config block
+func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
+	settings := &Settings{
+		common: cfg.NewCommonSettingsFromModule(name, "githuballrepos", true, ymlConfig, globalConfig),
+
+		APIKey:    ymlConfig.UString("apiKey", ""),
+		Username:  ymlConfig.UString("username", ""),
+		CachePath: expandHomeDir(ymlConfig.UString("cache", "~/.config/wtf/.cache/githuballrepos/")),
+	}
+
+	// Convert []interface{} to []string for Organizations
+	orgInterfaces := ymlConfig.UList("organizations")
+	settings.Organizations = make([]string, len(orgInterfaces))
+	for i, org := range orgInterfaces {
+		settings.Organizations[i] = org.(string)
+	}
+
+	return settings
+}
+
+// expandHomeDir replaces the `~` in the path with the user's home directory
+func expandHomeDir(path string) string {
+	if strings.HasPrefix(path, "~/") {
+		usr, err := user.Current()
+		if err != nil {
+			return path
+		}
+		return filepath.Join(usr.HomeDir, path[2:])
+	}
+	return path
+}

--- a/modules/githuballrepos/widget.go
+++ b/modules/githuballrepos/widget.go
@@ -1,0 +1,175 @@
+package githuballrepos
+
+import (
+	"time"
+
+	"github.com/rivo/tview"
+	"github.com/wtfutil/wtf/logger"
+	"github.com/wtfutil/wtf/view"
+)
+
+// Widget is the main struct for the GitHubAllRepos module
+type Widget struct {
+	view.TextWidget
+
+	settings *Settings
+	data     *WidgetData
+	cache    Cacher
+	client   GitHubFetcher
+
+	currentTab      int
+	selectedPRIndex int
+	isItemSelected  bool
+	lastUpdateTime  time.Time
+	isSelected      bool
+	carouselChan    chan bool
+
+	testMode bool
+}
+
+// NewWidget creates and returns an instance of Widget
+func NewWidget(app *tview.Application, redrawChan chan bool, pages *tview.Pages, settings *Settings) *Widget {
+	widget := &Widget{
+		TextWidget:      view.NewTextWidget(app, redrawChan, pages, settings.common),
+		settings:        settings,
+		data:            &WidgetData{},
+		cache:           NewCache(settings.CachePath),
+		client:          NewGitHubClient(settings.APIKey),
+		currentTab:      0,
+		selectedPRIndex: -1,
+		isItemSelected:  false,
+		isSelected:      false,
+		carouselChan:    make(chan bool),
+	}
+
+	widget.View.SetWrap(false)
+	widget.View.SetScrollable(true)
+
+	widget.View.SetTitle(settings.common.Title)
+
+	widget.initializeKeyboardControls()
+	widget.startCarousel()
+
+	logger.Log("GitHubAllRepos widget created")
+
+	return widget
+}
+
+// Refresh updates the onscreen contents of the widget
+func (widget *Widget) Refresh() {
+
+	logger.Log("Refresh started")
+	if widget.cache.IsValid() {
+
+		logger.Log("Cache is valid")
+		widget.data = widget.cache.Get()
+	} else {
+		logger.Log("Fetching new data")
+		widget.data = widget.client.FetchData(widget.settings.Organizations, widget.settings.Username)
+		widget.cache.Set(widget.data)
+	}
+	widget.lastUpdateTime = time.Now()
+	logger.Log("Refresh completed")
+
+	if !widget.testMode {
+		widget.display()
+	}
+}
+
+func (widget *Widget) display() {
+	widget.Redraw(func() (string, string, bool) {
+		return widget.CommonSettings().Title, widget.content(), false
+	})
+}
+
+func (widget *Widget) content() string {
+	var str string
+
+	// Display counters
+	str += "[yellow]Counters:[white]\n"
+	str += widget.data.FormatCounters()
+
+	// Display tabs
+	str += "\n[blue]Tabs:[white] "
+	tabs := []string{"My PRs", "PR Review Requests", "Watched PRs"}
+	for i, tab := range tabs {
+		if i == widget.currentTab {
+			str += "[green]" + tab + "[white] "
+		} else {
+			str += tab + " "
+		}
+	}
+	str += "\n\n"
+
+	// Display PRs for the current tab
+	var prs []PR
+	switch widget.currentTab {
+	case 0:
+		prs = widget.data.MyPRs
+	case 1:
+		prs = widget.data.PRReviewRequests
+	case 2:
+		prs = widget.data.WatchedPRs
+	}
+
+	for i, pr := range prs {
+		if i == widget.selectedPRIndex {
+			str += "[green]> " + pr.Title + " (" + pr.Repository + ")[white]\n"
+		} else {
+			str += "  " + pr.Title + " (" + pr.Repository + ")\n"
+		}
+	}
+
+	return str
+}
+
+func (widget *Widget) startCarousel() {
+	go func() {
+		ticker := time.NewTicker(10 * time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				if !widget.isSelected && !widget.isItemSelected {
+					widget.nextTabWithoutRefresh()
+					widget.Refresh()
+				}
+			case isSelected := <-widget.carouselChan:
+				if isSelected {
+					ticker.Stop()
+				} else {
+					ticker = time.NewTicker(10 * time.Second)
+				}
+			}
+		}
+	}()
+}
+
+func (widget *Widget) nextTabWithoutRefresh() {
+	widget.currentTab = (widget.currentTab + 1) % 3
+	widget.selectedPRIndex = -1
+}
+
+// SetSelected sets the selection state of the widget
+func (widget *Widget) SetSelected(selected bool) {
+	widget.isSelected = selected
+	if !selected {
+		widget.isItemSelected = false
+		widget.selectedPRIndex = -1
+	}
+	widget.carouselChan <- selected
+	widget.Refresh()
+}
+
+// Implements the Focusable interface
+func (widget *Widget) Focused() {
+	widget.SetSelected(true)
+	widget.Refresh()
+}
+
+// Implements the Focusable interface
+func (widget *Widget) Unfocused() {
+	widget.SetSelected(false)
+	widget.selectedPRIndex = -1
+	widget.Refresh()
+}

--- a/modules/githuballrepos/widget_test.go
+++ b/modules/githuballrepos/widget_test.go
@@ -1,0 +1,236 @@
+package githuballrepos
+
+import (
+	"testing"
+	"time"
+
+	"github.com/olebedev/config"
+	"github.com/rivo/tview"
+	"github.com/stretchr/testify/assert"
+	"github.com/wtfutil/wtf/cfg"
+	"github.com/wtfutil/wtf/logger"
+)
+
+type mockCache struct{}
+
+func (m *mockCache) Get() *WidgetData {
+	logger.Log("Mock cache: Get called")
+	return &WidgetData{}
+}
+
+func (m *mockCache) Set(data *WidgetData) {
+	logger.Log("Mock cache: Set called")
+}
+
+func (m *mockCache) IsValid() bool {
+	logger.Log("Mock cache: IsValid called")
+	return false
+}
+
+type mockGitHubClient struct{}
+
+func (m *mockGitHubClient) FetchData(orgs []string, username string) *WidgetData {
+	logger.Log("Mock GitHub client: FetchData called")
+	return &WidgetData{}
+}
+
+func Test_Refresh(t *testing.T) {
+	widget := createTestWidget()
+
+	done := make(chan bool)
+	go func() {
+		logger.Log("Starting Refresh")
+		widget.Refresh()
+		logger.Log("Refresh completed")
+		done <- true
+	}()
+
+	select {
+	case <-done:
+		// Test passed
+	case <-time.After(5 * time.Second):
+		t.Fatal("Test timed out")
+	}
+
+	assert.NotNil(t, widget.data)
+	assert.True(t, time.Since(widget.lastUpdateTime) < time.Second)
+}
+
+func Test_NewWidget(t *testing.T) {
+	app := tview.NewApplication()
+	pages := tview.NewPages()
+
+	mockYmlConfig, _ := config.ParseYaml(`
+common:
+  refreshInterval: 1
+  title: "Mock Title"
+`)
+	mockGlobalConfig, _ := config.ParseYaml(`
+wtf:
+  colors:
+    background: "black"
+    border:
+      focusable: "darkslateblue"
+      focused: "orange"
+      normal: "gray"
+`)
+
+	settings := &Settings{
+		common: cfg.NewCommonSettingsFromModule(
+			"githuballrepos",
+			"githuballrepos",
+			true,
+			mockYmlConfig,
+			mockGlobalConfig,
+		),
+		APIKey:        "mock_api_key",
+		Organizations: []string{"org1", "org2"},
+		Username:      "mock_username",
+		CachePath:     "/tmp/mock_cache",
+	}
+
+	widget := NewWidget(app, make(chan bool), pages, settings)
+
+	assert.NotNil(t, widget)
+	assert.Equal(t, "githuballrepos", widget.CommonSettings().Title)
+	assert.False(t, widget.isItemSelected)
+	assert.Equal(t, -1, widget.selectedPRIndex)
+	assert.Equal(t, 0, widget.currentTab)
+}
+
+func Test_Next(t *testing.T) {
+	widget := createTestWidget()
+	widget.data = &WidgetData{
+		MyPRs: []PR{{Title: "PR1"}, {Title: "PR2"}, {Title: "PR3"}},
+	}
+
+	widget.Next()
+
+	assert.Equal(t, 0, widget.selectedPRIndex)
+	assert.True(t, widget.isItemSelected)
+
+	widget.Next()
+	assert.Equal(t, 1, widget.selectedPRIndex)
+
+	widget.Next()
+	assert.Equal(t, 2, widget.selectedPRIndex)
+
+	widget.Next()
+	assert.Equal(t, 0, widget.selectedPRIndex)
+}
+
+func Test_Prev(t *testing.T) {
+	widget := createTestWidget()
+	widget.data = &WidgetData{
+		MyPRs: []PR{{Title: "PR1"}, {Title: "PR2"}, {Title: "PR3"}},
+	}
+
+	widget.Prev()
+	assert.Equal(t, 2, widget.selectedPRIndex)
+	assert.True(t, widget.isItemSelected)
+
+	widget.Prev()
+	assert.Equal(t, 1, widget.selectedPRIndex)
+
+	widget.Prev()
+	assert.Equal(t, 0, widget.selectedPRIndex)
+
+	widget.Prev()
+	assert.Equal(t, 2, widget.selectedPRIndex)
+}
+
+func Test_NextTab(t *testing.T) {
+	widget := createTestWidget()
+	widget.isItemSelected = true
+	widget.selectedPRIndex = 1
+
+	widget.nextTab()
+	assert.Equal(t, 1, widget.currentTab)
+	assert.Equal(t, -1, widget.selectedPRIndex)
+	assert.False(t, widget.isItemSelected)
+
+	widget.nextTab()
+	assert.Equal(t, 2, widget.currentTab)
+
+	widget.nextTab()
+	assert.Equal(t, 0, widget.currentTab)
+}
+
+func Test_PrevTab(t *testing.T) {
+	widget := createTestWidget()
+	widget.isItemSelected = true
+	widget.selectedPRIndex = 1
+
+	widget.prevTab()
+	assert.Equal(t, 2, widget.currentTab)
+	assert.Equal(t, -1, widget.selectedPRIndex)
+	assert.False(t, widget.isItemSelected)
+
+	widget.prevTab()
+	assert.Equal(t, 1, widget.currentTab)
+
+	widget.prevTab()
+	assert.Equal(t, 0, widget.currentTab)
+}
+
+func Test_SetSelected(t *testing.T) {
+	widget := createTestWidget()
+	widget.isItemSelected = true
+	widget.selectedPRIndex = 1
+
+	widget.SetSelected(false)
+	assert.False(t, widget.isSelected)
+	assert.False(t, widget.isItemSelected)
+	assert.Equal(t, -1, widget.selectedPRIndex)
+
+	widget.SetSelected(true)
+	assert.True(t, widget.isSelected)
+	assert.False(t, widget.isItemSelected)
+	assert.Equal(t, -1, widget.selectedPRIndex)
+}
+
+func createTestWidget() *Widget {
+	logger.Log("Creating widget")
+
+	app := tview.NewApplication()
+	pages := tview.NewPages()
+
+	mockYmlConfig, _ := config.ParseYaml(`
+common:
+  refreshInterval: 1
+  title: "Mock Title"
+`)
+	mockGlobalConfig, _ := config.ParseYaml(`
+wtf:
+  colors:
+    background: "black"
+    border:
+      focusable: "darkslateblue"
+      focused: "orange"
+      normal: "gray"
+`)
+
+	settings := &Settings{
+		common: cfg.NewCommonSettingsFromModule(
+			"githuballrepos",
+			"Mock Title", // Use "Mock Title" here instead of "githuballrepos"
+			true,
+			mockYmlConfig,
+			mockGlobalConfig,
+		),
+		APIKey:        "mock_api_key",
+		Organizations: []string{"org1", "org2"},
+		Username:      "mock_username",
+		CachePath:     "/tmp/mock_cache",
+	}
+
+	widget := NewWidget(app, make(chan bool), pages, settings)
+
+	// Replace cache and client with mocks
+	widget.cache = &mockCache{}
+	widget.client = &mockGitHubClient{}
+	widget.testMode = true
+
+	logger.Log("Widget created")
+	return widget
+}


### PR DESCRIPTION
Thanks for submitting a pull request. Please provide enough information so that others can review your pull request.

## GithubAllRepos 

This module provides an overview of GitHub PRs across all repos in selected organizations.
It contains counters for Your PRs, Review Requests, Open Issues
And list with 3 tabs: Your PRs, Review Requests, Watched PRs

PRs are selectable, you can select any PR, scroll across tabs, and open PRs in the browser.
When no PR is selected, tabs are carouseled.

![Screenshot 2024-10-10 at 20 31 16](https://github.com/user-attachments/assets/3fee0685-93ac-4116-8ca5-d1725edc34bc)

## Config example:

```yaml
    githuballrepos:
      title: github prs
      apiKey: "redacted"
      baseURL: ""
      position:
        top: 0
        left: 0
        height: 2
        width: 2
      refreshInterval: 15m
      username: "k2589"
      organizations:
        - "k2589"
        - "some-organization"
      cache: "~/.config/wtf/.cache/githuballrepos/" # data from GitHub is cached on disk to this folder

```






