### PR TITLE
fix: remove empty args string from default config

### DIFF
--- a/cfg/default_config_file.go
+++ b/cfg/default_config_file.go
@@ -91,7 +91,7 @@ const defaultConfigFile = `wtf:
       refreshInterval: 30
       wrapText: false
     uptime:
-      args: [""]
+      args: []
       cmd: "uptime"
       enabled: true
       position:


### PR DESCRIPTION
It seems that this https://github.com/wtfutil/wtf/issues/1197 issue was not fully adressed as a default install also broke because of the empty string args in uptime when I installed wtf by cloning the repo and using `go install .`

This completes https://github.com/wtfutil/wtf/pull/1296 and fixes https://github.com/wtfutil/wtf/issues/1197
