### PR TITLE
feat: module/security - support iptables and nftables detection without higher privileges

### DIFF
--- a/modules/security/firewall.go
+++ b/modules/security/firewall.go
@@ -114,7 +114,7 @@ func checkIptables() string {
 		if strings.Contains(out, "Chain") && !strings.Contains(out, "0 references") {
 			return "[green]Enabled (iptables)[white]"
 		}
-		return "[yellow]Unable to check rules (iptables)[white]"
+		return "[yellow]Loaded but unable to check rules (iptables)[white]"
 	}
 	return ""
 }

--- a/modules/security/firewall.go
+++ b/modules/security/firewall.go
@@ -68,14 +68,11 @@ func checkUfw() string {
 
 	// Then check if service is running
 	cmd := exec.Command("systemctl", "is-active", "ufw")
-	out := utils.ExecuteCommand(cmd)
-
-	if strings.Contains(out, "active") {
+	err := cmd.Run()
+	if err == nil {
 		return "[green]Enabled (ufw)[white]"
-	} else if out != "" {
-		return "[red]Disabled (ufw)[white]"
 	}
-	return ""
+	return "[red]Disabled (ufw)[white]"
 }
 
 func checkNftables() string {
@@ -87,13 +84,11 @@ func checkNftables() string {
 
 	// Then check if service is running
 	cmd := exec.Command("systemctl", "is-active", "nftables")
-	out := utils.ExecuteCommand(cmd)
-	if strings.Contains(out, "active") {
+	err := cmd.Run()
+	if err == nil {
 		return "[green]Enabled (nftables)[white]"
-	} else if out != "" {
-		return "[red]Disabled (nftables)[white]"
 	}
-	return ""
+	return "[red]Disabled (nftables)[white]"
 }
 
 func checkIptables() string {


### PR DESCRIPTION
Change the detection method for ufw so as not to be obliged to change privileges such as described in the documentation  
https://github.com/wtfutil/wtfdocs/blob/8af8a1a46c81d993d09d1108a04bf493188328d9/docs/modules/security.md?plain=1#L52-L53

Check the status of firewalls with systemctl after having checked which are installed.

Will update the documentation if accepted 

closes https://github.com/wtfutil/wtf/issues/1717
