### PR TITLE
fix: golangci lint was not passing anymore

### DIFF
--- a/modules/gitter/widget.go
+++ b/modules/gitter/widget.go
@@ -68,7 +68,7 @@ func (widget *Widget) display() {
 
 func (widget *Widget) content() (string, string, bool) {
 	title := fmt.Sprintf("%s - %s", widget.CommonSettings().Title, widget.settings.roomURI)
-	if widget.messages == nil || len(widget.messages) == 0 {
+	if len(widget.messages) == 0 {
 		return title, "No Messages To Display", false
 	}
 	var str string


### PR DESCRIPTION
This PR https://github.com/wtfutil/wtf/pull/1706 fixes the issue too but also did lots of things so opening a simpler PR just for fixing the CI 

before
```bash
❯ golangci-lint run --color=always ./... --timeout=10m
WARN [lintersdb] The name "vet" is deprecated. The linter has been renamed to: govet. 
modules/gitter/widget.go:71:5: S1009: should omit nil check; len() for nil slices is defined as zero (gosimple)
        if widget.messages == nil || len(widget.messages) == 0 {
           ^
```
now it passes the ci

edit : 
fixes #1721 
