### PR TITLE
Reviewers is deprecated for dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,16 +5,12 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
-  reviewers:
-  - senorprogrammer
   assignees:
-  - senorprogrammer
+  - FelicianoTech
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:
     interval: daily
   open-pull-requests-limit: 10
-  reviewers:
-  - senorprogrammer
   assignees:
-  - senorprogrammer
+  - FelicianoTech


### PR DESCRIPTION
GitHub wants this to be specified in CODEOWNERS instead. For now, not setting it at all but relieving Chris of GitHub notifications. For assignments, adding myself.

ref: https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/
