### PR TITLE
Fix linting issues regarding fmt.Errorf

### DIFF
--- a/modules/buildkite/client.go
+++ b/modules/buildkite/client.go
@@ -60,7 +60,7 @@ func (widget *Widget) recentBuilds(pipeline PipelineSettings) ([]Build, error) {
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
-		return nil, fmt.Errorf(resp.Status)
+		return nil, fmt.Errorf("%s", resp.Status)
 	}
 
 	builds := []Build{}

--- a/modules/circleci/client.go
+++ b/modules/circleci/client.go
@@ -66,7 +66,7 @@ func (client *Client) circleRequest(path string) ([]byte, error) {
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
-		return nil, fmt.Errorf(resp.Status)
+		return nil, fmt.Errorf("%s", resp.Status)
 	}
 
 	body, err := io.ReadAll(resp.Body)

--- a/modules/covid/client.go
+++ b/modules/covid/client.go
@@ -14,7 +14,7 @@ func LatestCases() (*Cases, error) {
 	latestURL := covidTrackerAPIURL + "latest"
 	resp, err := http.Get(latestURL)
 	if resp.StatusCode != 200 {
-		return nil, fmt.Errorf(resp.Status)
+		return nil, fmt.Errorf("%s", resp.Status)
 	}
 	if err != nil {
 		return nil, err
@@ -37,7 +37,7 @@ func (widget *Widget) LatestCountryCases(countries []interface{}) ([]*Cases, err
 		countryURL := covidTrackerAPIURL + "locations?source=jhu&country_code=" + name.(string)
 		resp, err := http.Get(countryURL)
 		if resp.StatusCode != 200 {
-			return nil, fmt.Errorf(resp.Status)
+			return nil, fmt.Errorf("%s", resp.Status)
 		}
 		if err != nil {
 			return nil, err

--- a/modules/gitter/client.go
+++ b/modules/gitter/client.go
@@ -69,7 +69,7 @@ func apiRequest(path, apiToken string) (*http.Response, error) {
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
-		return nil, fmt.Errorf(resp.Status)
+		return nil, fmt.Errorf("%s", resp.Status)
 	}
 
 	return resp, nil

--- a/modules/hackernews/client.go
+++ b/modules/hackernews/client.go
@@ -67,7 +67,7 @@ func apiRequest(path string) ([]byte, error) {
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
-		return nil, fmt.Errorf(resp.Status)
+		return nil, fmt.Errorf("%s", resp.Status)
 	}
 
 	body, err := io.ReadAll(resp.Body)

--- a/modules/healthchecks/widget.go
+++ b/modules/healthchecks/widget.go
@@ -172,7 +172,7 @@ func (widget *Widget) getExistingChecks() ([]Checks, error) {
 	}
 
 	if resp.StatusCode != 200 {
-		return nil, fmt.Errorf(resp.Status)
+		return nil, fmt.Errorf("%s", resp.Status)
 	}
 
 	defer func() { _ = resp.Body.Close() }()

--- a/modules/jira/client.go
+++ b/modules/jira/client.go
@@ -85,7 +85,7 @@ func (widget *Widget) jiraRequest(path string) ([]byte, error) {
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
-		return nil, fmt.Errorf(resp.Status)
+		return nil, fmt.Errorf("%s", resp.Status)
 	}
 
 	body, err := io.ReadAll(resp.Body)

--- a/modules/pivotal/client.go
+++ b/modules/pivotal/client.go
@@ -73,7 +73,7 @@ func (pivotal *PivotalClient) apiv5(resource string) (*Resource, error) {
 	Err := Error{}
 	err = json.Unmarshal([]byte(string(data)), &Err)
 	if err == nil && Err.Error != "" {
-		return nil, fmt.Errorf(Err.Error)
+		return nil, fmt.Errorf("%s", Err.Error)
 	}
 
 	return &Resource{Response: &resp, Raw: string(data)}, nil

--- a/modules/rollbar/client.go
+++ b/modules/rollbar/client.go
@@ -53,7 +53,7 @@ func rollbarItemRequest(accessToken, assignedToName string, activeOnly bool) (*h
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
-		return nil, fmt.Errorf(resp.Status)
+		return nil, fmt.Errorf("%s", resp.Status)
 	}
 
 	return resp, nil

--- a/modules/stocks/finnhub/client.go
+++ b/modules/stocks/finnhub/client.go
@@ -73,7 +73,7 @@ func (client *Client) finnhubRequest(symbol string) (*http.Response, error) {
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
-		return nil, fmt.Errorf(resp.Status)
+		return nil, fmt.Errorf("%s", resp.Status)
 	}
 
 	return resp, nil

--- a/modules/subreddit/api.go
+++ b/modules/subreddit/api.go
@@ -37,7 +37,7 @@ func GetLinks(subreddit string, sortMode string, topTimePeriod string) ([]Link, 
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode > 299 {
-		return nil, fmt.Errorf(resp.Status)
+		return nil, fmt.Errorf("%s", resp.Status)
 	}
 	var m RedditDocument
 	err = utils.ParseJSON(&m, resp.Body)

--- a/modules/travisci/client.go
+++ b/modules/travisci/client.go
@@ -70,7 +70,7 @@ func travisBuildRequest(settings *Settings) (*http.Response, error) {
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
-		return nil, fmt.Errorf(resp.Status)
+		return nil, fmt.Errorf("%s", resp.Status)
 	}
 
 	return resp, nil

--- a/modules/updown/widget.go
+++ b/modules/updown/widget.go
@@ -183,7 +183,7 @@ func (widget *Widget) getExistingChecks() ([]Check, error) {
 	}
 
 	if resp.StatusCode != 200 {
-		return nil, fmt.Errorf(resp.Status)
+		return nil, fmt.Errorf("%s", resp.Status)
 	}
 
 	defer func() { _ = resp.Body.Close() }()

--- a/modules/weatherservices/arpansagovau/client.go
+++ b/modules/weatherservices/arpansagovau/client.go
@@ -68,7 +68,7 @@ func apiRequest() (*http.Response, error) {
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != 200 {
-		return nil, fmt.Errorf(resp.Status)
+		return nil, fmt.Errorf("%s", resp.Status)
 	}
 
 	return resp, nil


### PR DESCRIPTION
When upgrading to Go v1.24, I uncovered a new linting issue that affected most module clients. This PR corrects all of them in one go.