### PR TITLE
Namespace the assert library for old testing files

### DIFF
--- a/checklist/checklist_item_test.go
+++ b/checklist/checklist_item_test.go
@@ -3,7 +3,7 @@ package checklist
 import (
 	"testing"
 
-	. "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func testChecklistItem() *ChecklistItem {
@@ -20,19 +20,19 @@ func testChecklistItem() *ChecklistItem {
 
 func Test_CheckMark(t *testing.T) {
 	item := testChecklistItem()
-	Equal(t, " ", item.CheckMark())
+	assert.Equal(t, " ", item.CheckMark())
 
 	item.Toggle()
-	Equal(t, "x", item.CheckMark())
+	assert.Equal(t, "x", item.CheckMark())
 }
 
 func Test_Toggle(t *testing.T) {
 	item := testChecklistItem()
-	Equal(t, false, item.Checked)
+	assert.Equal(t, false, item.Checked)
 
 	item.Toggle()
-	Equal(t, true, item.Checked)
+	assert.Equal(t, true, item.Checked)
 
 	item.Toggle()
-	Equal(t, false, item.Checked)
+	assert.Equal(t, false, item.Checked)
 }

--- a/utils/email_addresses_test.go
+++ b/utils/email_addresses_test.go
@@ -3,20 +3,20 @@ package utils
 import (
 	"testing"
 
-	. "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_NameFromEmail(t *testing.T) {
-	Equal(t, "", NameFromEmail(""))
-	Equal(t, "Chris Cummer", NameFromEmail("chris.cummer@me.com"))
+	assert.Equal(t, "", NameFromEmail(""))
+	assert.Equal(t, "Chris Cummer", NameFromEmail("chris.cummer@me.com"))
 }
 
 func Test_NamesFromEmails(t *testing.T) {
 	var result []string
 
 	result = NamesFromEmails([]string{})
-	Equal(t, []string{}, result)
+	assert.Equal(t, []string{}, result)
 
 	result = NamesFromEmails([]string{"chris.cummer@me.com", "chriscummer@me.com"})
-	Equal(t, []string{"Chris Cummer", "Chriscummer"}, result)
+	assert.Equal(t, []string{"Chris Cummer", "Chriscummer"}, result)
 }

--- a/utils/init_test.go
+++ b/utils/init_test.go
@@ -3,12 +3,12 @@ package utils
 import (
 	"testing"
 
-	. "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_Init(t *testing.T) {
 	Init("cats", []string{"dogs"})
 
-	Equal(t, OpenFileUtil, "cats")
-	Equal(t, OpenUrlUtil, []string{"dogs"})
+	assert.Equal(t, OpenFileUtil, "cats")
+	assert.Equal(t, OpenUrlUtil, []string{"dogs"})
 }


### PR DESCRIPTION
It looks like some older test files were "unwrapping" the assert package to the current context. I'm changing this because:

1. While it works, sometimes the linter flags this. I'm not sure why.
2. Other testing files don't do this. I want consistency.
3. The testify readme doesn't seem to recommend this approach. I rather follow their examples.
