### PR TITLE
Switch Homebrew support to cask

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -22,11 +22,19 @@ before:
   hooks:
     - make install
 
-brews:
-  -
-    name: wtfutil
+homebrew_casks:
+  - name: wtfutil
+    conflicts:
+      - formula: wtfutil
     homepage: 'https://wtfutil.com'
     description: 'The personal information dashboard for your terminal.'
     repository:
       owner: wtfutil
       name: homebrew-wtfutil
+    hooks:
+      post:
+        # This hook is needed until this binary is signed and notarized
+        install: |
+          if system_command("/usr/bin/xattr", args: ["-h"]).exit_status == 0
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/wtfutil"]
+          end


### PR DESCRIPTION
With the new version of GoReleaser (#1780), building a Homebrew formula as part of the publishing process is now deprecated. This PR updates the build to a cask.