### PR TITLE
closes config and file watcher when stop is called.

### DIFF
--- a/app/wtf_app.go
+++ b/app/wtf_app.go
@@ -31,6 +31,7 @@ type WtfApp struct {
 	pages          *tview.Pages
 	validator      *ModuleValidator
 	widgets        []wtf.Wtfable
+	configWatcher  *watcher.Watcher
 
 	// The redrawChan channel is used to allow modules to signal back to the main loop that
 	// the screen needs to be explicitly redrawn, instead of waiting for tcell to redraw
@@ -136,6 +137,9 @@ func (wtfApp *WtfApp) Start() {
 // Stop kills all the currently-running widgets in this app
 func (wtfApp *WtfApp) Stop() {
 	wtfApp.stopAllWidgets()
+	if wtfApp.configWatcher != nil {
+		wtfApp.configWatcher.Close()
+	}
 	close(wtfApp.redrawChan)
 }
 
@@ -203,7 +207,8 @@ func (wtfApp *WtfApp) scheduleWidgets() {
 }
 
 func (wtfApp *WtfApp) watchForConfigChanges() {
-	watch := watcher.New()
+	wtfApp.configWatcher = watcher.New()
+	watch := wtfApp.configWatcher
 
 	// Notify write events
 	watch.FilterOps(watcher.Write)

--- a/modules/textfile/widget.go
+++ b/modules/textfile/widget.go
@@ -25,7 +25,8 @@ type Widget struct {
 	view.MultiSourceWidget
 	view.TextWidget
 
-	settings *Settings
+	settings    *Settings
+	fileWatcher *watcher.Watcher
 }
 
 // NewWidget creates a new instance of a widget
@@ -128,7 +129,8 @@ func (widget *Widget) plainText() string {
 }
 
 func (widget *Widget) watchForFileChanges() {
-	watch := watcher.New()
+	widget.fileWatcher = watcher.New()
+	watch := widget.fileWatcher
 	watch.FilterOps(watcher.Write)
 
 	go func() {
@@ -143,6 +145,7 @@ func (widget *Widget) watchForFileChanges() {
 				return
 			case quit := <-widget.QuitChan():
 				if quit {
+					watch.Close()
 					return
 				}
 			}


### PR DESCRIPTION
The watchers created in both watchForConfigChanges() (wtf-app.go) and watchForFileChanges() (modules/textfile/widget.go) aren't closed when the application is told to stop.  
This PR adds the config watcher to the wtfApp instance so it can be closed in the Stop function after the widgets are closed. It does the same thing for the textfile widget so it can close the filewatcher when told to quit.  

Not sure if this fixes the raspberry pi issue (hangs after reload) as I'm unable to find the historic PR, but I suspect the leftover watcher may at least contribute to the issue.

