### PR TITLE
Suppress pty errors

### DIFF
--- a/modules/cmdrunner/settings.go
+++ b/modules/cmdrunner/settings.go
@@ -19,6 +19,7 @@ type Settings struct {
 	cmd        string   `help:"The terminal command to be run, withouth the arguments. Ie: ping, whoami, curl."`
 	tail       bool     `help:"Automatically scroll to the end of the command output."`
 	pty        bool     `help:"Run the command in a pseudo-terminal. Some apps will behave differently if they feel in a terminal. For example, some apps will produce colorized output in a terminal, and non-colorized output otherwise. Default false" optional:"true"`
+	ptySuppressErrors bool `help:"Do not display pty errors. Some apps producing colorized output may result in trailing errors. This will attempt to hide them, use only when necessary. Default false" optional:"true"`
 	maxLines   int      `help:"Maximum number of lines kept in the buffer."`
 	workingDir string   `help:"Working directory for command to run in" optional:"true"`
 
@@ -36,6 +37,7 @@ func NewSettingsFromYAML(name string, moduleConfig *config.Config, globalConfig 
 		workingDir: moduleConfig.UString("workingDir", "."),
 		cmd:        moduleConfig.UString("cmd"),
 		pty:        moduleConfig.UBool("pty", false),
+		ptySuppressErrors: moduleConfig.UBool("ptySuppressErrors", false),
 		tail:       moduleConfig.UBool("tail", false),
 		maxLines:   moduleConfig.UInt("maxLines", 256),
 	}

--- a/modules/cmdrunner/settings.go
+++ b/modules/cmdrunner/settings.go
@@ -15,13 +15,13 @@ const (
 type Settings struct {
 	*cfg.Common
 
-	args       []string `help:"The arguments to the command, with each item as an element in an array. Example: for curl -I cisco.com, the arguments array would be ['-I', 'cisco.com']."`
-	cmd        string   `help:"The terminal command to be run, withouth the arguments. Ie: ping, whoami, curl."`
-	tail       bool     `help:"Automatically scroll to the end of the command output."`
-	pty        bool     `help:"Run the command in a pseudo-terminal. Some apps will behave differently if they feel in a terminal. For example, some apps will produce colorized output in a terminal, and non-colorized output otherwise. Default false" optional:"true"`
-	ptySuppressErrors bool `help:"Do not display pty errors. Some apps producing colorized output may result in trailing errors. This will attempt to hide them, use only when necessary. Default false" optional:"true"`
-	maxLines   int      `help:"Maximum number of lines kept in the buffer."`
-	workingDir string   `help:"Working directory for command to run in" optional:"true"`
+	args              []string `help:"The arguments to the command, with each item as an element in an array. Example: for curl -I cisco.com, the arguments array would be ['-I', 'cisco.com']."`
+	cmd               string   `help:"The terminal command to be run, withouth the arguments. Ie: ping, whoami, curl."`
+	tail              bool     `help:"Automatically scroll to the end of the command output."`
+	pty               bool     `help:"Run the command in a pseudo-terminal. Some apps will behave differently if they feel in a terminal. For example, some apps will produce colorized output in a terminal, and non-colorized output otherwise. Default false" optional:"true"`
+	ptySuppressErrors bool     `help:"Do not display pty errors. Some apps producing colorized output may result in trailing errors. This will attempt to hide them, use only when necessary. Default false" optional:"true"`
+	maxLines          int      `help:"Maximum number of lines kept in the buffer."`
+	workingDir        string   `help:"Working directory for command to run in" optional:"true"`
 
 	// The dimensions of the module
 	width  int
@@ -33,13 +33,13 @@ func NewSettingsFromYAML(name string, moduleConfig *config.Config, globalConfig 
 	settings := Settings{
 		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, moduleConfig, globalConfig),
 
-		args:       utils.ToStrs(moduleConfig.UList("args")),
-		workingDir: moduleConfig.UString("workingDir", "."),
-		cmd:        moduleConfig.UString("cmd"),
-		pty:        moduleConfig.UBool("pty", false),
+		args:              utils.ToStrs(moduleConfig.UList("args")),
+		workingDir:        moduleConfig.UString("workingDir", "."),
+		cmd:               moduleConfig.UString("cmd"),
+		pty:               moduleConfig.UBool("pty", false),
 		ptySuppressErrors: moduleConfig.UBool("ptySuppressErrors", false),
-		tail:       moduleConfig.UBool("tail", false),
-		maxLines:   moduleConfig.UInt("maxLines", 256),
+		tail:              moduleConfig.UBool("tail", false),
+		maxLines:          moduleConfig.UInt("maxLines", 256),
 	}
 
 	width, height, err := utils.CalculateDimensions(moduleConfig, globalConfig)

--- a/modules/cmdrunner/widget.go
+++ b/modules/cmdrunner/widget.go
@@ -1,8 +1,8 @@
 package cmdrunner
 
 import (
-	"errors"
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"os"

--- a/modules/cmdrunner/widget.go
+++ b/modules/cmdrunner/widget.go
@@ -151,7 +151,8 @@ func runCommandPty(widget *Widget, cmd *exec.Cmd) error {
 	f, err := pty.Start(cmd)
 	// The command has exited, print any error messages
 	if err != nil {
-		return err
+		//return err
+		return cmd.Wait()
 	}
 
 	// Make sure to close the pty at the end.

--- a/modules/cmdrunner/widget.go
+++ b/modules/cmdrunner/widget.go
@@ -177,8 +177,8 @@ func runCommandPty(widget *Widget, cmd *exec.Cmd) error {
 	// Extract output
 	_, err = io.Copy(widget.buffer, f)
 	if err != nil {
-		if errors.Is(err, syscall.EIO) || strings.Contains(err.Error(), "input/output error") {
-			err = nil
+		if widget.settings.ptySuppressErrors && errors.Is(err, syscall.EIO) {
+			return cmd.Wait()
 		}
 		return err
 	}

--- a/modules/cmdrunner/widget.go
+++ b/modules/cmdrunner/widget.go
@@ -151,8 +151,11 @@ func runCommandPty(widget *Widget, cmd *exec.Cmd) error {
 	f, err := pty.Start(cmd)
 	// The command has exited, print any error messages
 	if err != nil {
-		//return err
-		return cmd.Wait()
+		if widget.settings.ptySuppressErrors {
+			return cmd.Wait()
+		} else {
+			return err
+		}
 	}
 
 	// Make sure to close the pty at the end.

--- a/modules/cmdrunner/widget.go
+++ b/modules/cmdrunner/widget.go
@@ -1,6 +1,7 @@
 package cmdrunner
 
 import (
+	"errors"
 	"bytes"
 	"fmt"
 	"io"
@@ -172,6 +173,9 @@ func runCommandPty(widget *Widget, cmd *exec.Cmd) error {
 	// Extract output
 	_, err = io.Copy(widget.buffer, f)
 	if err != nil {
+		if errors.Is(err, syscall.EIO) || strings.Contains(err.Error(), "input/output error") {
+			err = nil
+		}
 		return err
 	}
 	return cmd.Wait()


### PR DESCRIPTION
This PR introduces a "ptySuppressErrors" flag that can be used to hide some of the common pty error messages that can occur.

Common, at least to me.  😄  I think many of these issues are due to the tools, not wtf, but it can be difficult to smooth out the output.  Yesterday I really wanted a graph on my board, and I found this as the only way to make it happen.

<img width="1132" height="1518" alt="image" src="https://github.com/user-attachments/assets/a2da25c6-1fc3-404a-a427-3f8981255ab4" />

<img width="1132" height="1518" alt="image" src="https://github.com/user-attachments/assets/e600c8dd-e034-4de1-8e6e-d339f39c1328" />

