### PR TITLE
Bugfix/1855 jira deprecated endpoint

### DIFF
--- a/modules/jira/client.go
+++ b/modules/jira/client.go
@@ -196,24 +196,84 @@ func (widget *Widget) IssuesFor(username string, projects []string, jql string) 
 		query = append(query, jql)
 	}
 
-	v := url.Values{}
-
-	v.Set("jql", strings.Join(query, " AND "))
-
-	url := fmt.Sprintf("/rest/api/2/search?%s", v.Encode())
-
-	resp, err := widget.jiraRequest(url)
+	// Try the new API v3 search/jql endpoint
+	jqlQuery := strings.Join(query, " AND ")
+	searchResult, err := widget.searchWithNewAPI(jqlQuery)
 	if err != nil {
-		return &SearchResult{}, err
+		// If new API fails, return the error
+		return &SearchResult{}, fmt.Errorf("JIRA search failed: %v", err)
 	}
 
-	searchResult := &SearchResult{}
-	err = utils.ParseJSON(searchResult, bytes.NewReader(resp))
+	return searchResult, nil
+}
+
+// searchWithNewAPI uses the new /rest/api/3/search/jql endpoint
+func (widget *Widget) searchWithNewAPI(jql string) (*SearchResult, error) {
+	// First, get issue IDs using the new endpoint
+	v := url.Values{}
+	v.Set("jql", jql)
+	v.Set("maxResults", "20") // Limit to avoid too many API calls
+
+	jqlURL := fmt.Sprintf("/rest/api/3/search/jql?%s", v.Encode())
+
+	resp, err := widget.jiraRequest(jqlURL)
 	if err != nil {
 		return nil, err
 	}
 
+	// Parse the JQL response which contains issue IDs
+	type JQLSearchResult struct {
+		Issues []struct {
+			ID string `json:"id"`
+		} `json:"issues"`
+	}
+
+	jqlResult := &JQLSearchResult{}
+	err = utils.ParseJSON(jqlResult, bytes.NewReader(resp))
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse JQL search response: %v", err)
+	}
+
+	if len(jqlResult.Issues) == 0 {
+		// Return empty result if no issues found
+		return &SearchResult{Issues: []Issue{}}, nil
+	}
+
+	// Now get full issue details for each ID
+	searchResult := &SearchResult{Issues: []Issue{}}
+
+	for i, issue := range jqlResult.Issues {
+		// Limit to prevent too many API calls
+		if i >= 20 {
+			break
+		}
+
+		fullIssue, err := widget.getIssueByID(issue.ID)
+		if err != nil {
+			// Log error but continue with other issues
+			fmt.Printf("Error fetching issue %s: %v\n", issue.ID, err)
+			continue
+		}
+		searchResult.Issues = append(searchResult.Issues, *fullIssue)
+	}
+
 	return searchResult, nil
+} // getIssueByID fetches full issue details by ID
+func (widget *Widget) getIssueByID(issueID string) (*Issue, error) {
+	url := fmt.Sprintf("/rest/api/3/issue/%s", issueID)
+
+	resp, err := widget.jiraRequest(url)
+	if err != nil {
+		return nil, err
+	}
+
+	issue := &Issue{}
+	err = utils.ParseJSON(issue, bytes.NewReader(resp))
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse issue %s: %v", issueID, err)
+	}
+
+	return issue, nil
 }
 
 func buildJql(key string, value string) string {
@@ -251,7 +311,8 @@ func (widget *Widget) jiraRequest(path string) ([]byte, error) {
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
-		return nil, fmt.Errorf("%s", resp.Status)
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("JIRA API error - %s: %s (URL: %s)", resp.Status, string(body), url)
 	}
 
 	body, err := io.ReadAll(resp.Body)
@@ -293,7 +354,8 @@ func (widget *Widget) jiraPostRequest(path string, data []byte) ([]byte, error) 
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
-		return nil, fmt.Errorf("%s", resp.Status)
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("JIRA API POST error - %s: %s (URL: %s)", resp.Status, string(body), url)
 	}
 
 	body, err := io.ReadAll(resp.Body)

--- a/modules/jira/client.go
+++ b/modules/jira/client.go
@@ -3,6 +3,7 @@ package jira
 import (
 	"bytes"
 	"crypto/tls"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -12,6 +13,65 @@ import (
 	"github.com/wtfutil/wtf/utils"
 )
 
+// JQLConversionRequest represents the request body for the JQL conversion API
+type JQLConversionRequest struct {
+	QueryStrings []string `json:"queryStrings"`
+}
+
+// JQLConversionResponse represents the response from the JQL conversion API
+type JQLConversionResponse struct {
+	QueryStrings []ConvertedQuery `json:"queryStrings"`
+}
+
+// ConvertedQuery represents a single converted JQL query
+type ConvertedQuery struct {
+	Query            string          `json:"query"`
+	ConvertedQuery   string          `json:"convertedQuery"`
+	UserMessages     []UserMessage   `json:"userMessages"`
+}
+
+// UserMessage represents messages about the conversion
+type UserMessage struct {
+	MessageKey string            `json:"messageKey"`
+	MessageArgs map[string]string `json:"messageArgs"`
+}
+
+// ConvertJQLWithUsername converts a JQL query containing username to account ID
+func (widget *Widget) ConvertJQLWithUsername(username string) (string, error) {
+	// Create a JQL query with the username that needs conversion
+	originalJQL := fmt.Sprintf("assignee = \"%s\"", username)
+	
+	// Prepare the request body
+	requestBody := JQLConversionRequest{
+		QueryStrings: []string{originalJQL},
+	}
+	
+	// Convert to JSON
+	jsonData, err := json.Marshal(requestBody)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal request: %v", err)
+	}
+	
+	// Make the POST request to the JQL conversion API
+	resp, err := widget.jiraPostRequest("/rest/api/3/jql/pdcleaner", jsonData)
+	if err != nil {
+		return "", err
+	}
+
+	var conversionResult JQLConversionResponse
+	err = utils.ParseJSON(&conversionResult, bytes.NewReader(resp))
+	if err != nil {
+		return "", err
+	}
+
+	if len(conversionResult.QueryStrings) == 0 {
+		return "", fmt.Errorf("no conversion result for username: %s", username)
+	}
+
+	// Return the converted JQL query part (just the assignee part)
+	convertedQuery := conversionResult.QueryStrings[0].ConvertedQuery
+	return convertedQuery, nil
+}
 // IssuesFor returns a collection of issues for a given collection of projects.
 // If username is provided, it scopes the issues to that person
 func (widget *Widget) IssuesFor(username string, projects []string, jql string) (*SearchResult, error) {
@@ -23,7 +83,12 @@ func (widget *Widget) IssuesFor(username string, projects []string, jql string) 
 	}
 
 	if username != "" {
-		query = append(query, buildJql("assignee", username))
+		// Convert JQL with username to account ID
+		convertedJQL, err := widget.ConvertJQLWithUsername(username)
+		if err != nil {
+			return &SearchResult{}, fmt.Errorf("failed to convert username %s to account ID: %v", username, err)
+		}
+		query = append(query, convertedJQL)
 	}
 
 	if jql != "" {
@@ -63,6 +128,48 @@ func (widget *Widget) jiraRequest(path string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	if widget.settings.personalAccessToken != "" {
+		req.Header.Set("Authorization", "Bearer "+widget.settings.personalAccessToken)
+	} else {
+		req.SetBasicAuth(widget.settings.email, widget.settings.apiKey)
+	}
+
+	httpClient := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: !widget.settings.verifyServerCertificate,
+			},
+			Proxy: http.ProxyFromEnvironment,
+		},
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return nil, fmt.Errorf("%s", resp.Status)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	return body, nil
+}
+
+func (widget *Widget) jiraPostRequest(path string, data []byte) ([]byte, error) {
+	url := fmt.Sprintf("%s%s", widget.settings.domain, path)
+
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(data))
+	if err != nil {
+		return nil, err
+	}
+	
+	req.Header.Set("Content-Type", "application/json")
 	if widget.settings.personalAccessToken != "" {
 		req.Header.Set("Authorization", "Bearer "+widget.settings.personalAccessToken)
 	} else {

--- a/modules/jira/client.go
+++ b/modules/jira/client.go
@@ -9,9 +9,28 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/wtfutil/wtf/utils"
 )
+
+// UserIDCache represent a cached username to account ID mapping
+type UserIDCache struct {
+	AccountID string
+	ExpiresAt time.Time
+}
+
+// UserIDCacheMap holds the cache with thread safety
+type UserIDCacheMap struct {
+	cache map[string]UserIDCache
+	mutex sync.RWMutex
+}
+
+// Global cache instance
+var userIDCache = &UserIDCacheMap{
+	cache: make(map[string]UserIDCache),
+}
 
 // JQLConversionRequest represents the request body for the JQL conversion API
 type JQLConversionRequest struct {
@@ -25,33 +44,86 @@ type JQLConversionResponse struct {
 
 // ConvertedQuery represents a single converted JQL query
 type ConvertedQuery struct {
-	Query            string          `json:"query"`
-	ConvertedQuery   string          `json:"convertedQuery"`
-	UserMessages     []UserMessage   `json:"userMessages"`
+	Query          string        `json:"query"`
+	ConvertedQuery string        `json:"convertedQuery"`
+	UserMessages   []UserMessage `json:"userMessages"`
 }
 
 // UserMessage represents messages about the conversion
 type UserMessage struct {
-	MessageKey string            `json:"messageKey"`
+	MessageKey  string            `json:"messageKey"`
 	MessageArgs map[string]string `json:"messageArgs"`
+}
+
+// Get retrieves a cache account ID for a username
+func (c *UserIDCacheMap) Get(username string) (string, bool) {
+	c.mutex.RLock()
+	entry, exists := c.cache[username]
+	if !exists {
+		c.mutex.RUnlock()
+		return "", false
+	}
+
+	// Check if cache entry has expired
+	if time.Now().After(entry.ExpiresAt) {
+		c.mutex.RUnlock()
+		// Remove expired entry - upgrade to write lock
+		c.mutex.Lock()
+		delete(c.cache, username)
+		c.mutex.Unlock()
+		return "", false
+	}
+
+	accountID := entry.AccountID
+	c.mutex.RUnlock()
+	return accountID, true
+}
+
+// Set stores a username to account ID mapping with expiration
+func (c *UserIDCacheMap) Set(username, accountID string, duration time.Duration) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	c.cache[username] = UserIDCache{
+		AccountID: accountID,
+		ExpiresAt: time.Now().Add(duration),
+	}
+}
+
+// Clear removes all expired entries from the cache
+func (c *UserIDCacheMap) Clear() {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	now := time.Now()
+	for username, entry := range c.cache {
+		if now.After(entry.ExpiresAt) {
+			delete(c.cache, username)
+		}
+	}
 }
 
 // ConvertJQLWithUsername converts a JQL query containing username to account ID
 func (widget *Widget) ConvertJQLWithUsername(username string) (string, error) {
+	// Check cache first
+	if accountID, found := userIDCache.Get(username); found {
+		return fmt.Sprintf("assignee = \"%s\"", accountID), nil
+	}
+
 	// Create a JQL query with the username that needs conversion
 	originalJQL := fmt.Sprintf("assignee = \"%s\"", username)
-	
+
 	// Prepare the request body
 	requestBody := JQLConversionRequest{
 		QueryStrings: []string{originalJQL},
 	}
-	
+
 	// Convert to JSON
 	jsonData, err := json.Marshal(requestBody)
 	if err != nil {
 		return "", fmt.Errorf("failed to marshal request: %v", err)
 	}
-	
+
 	// Make the POST request to the JQL conversion API
 	resp, err := widget.jiraPostRequest("/rest/api/3/jql/pdcleaner", jsonData)
 	if err != nil {
@@ -70,8 +142,37 @@ func (widget *Widget) ConvertJQLWithUsername(username string) (string, error) {
 
 	// Return the converted JQL query part (just the assignee part)
 	convertedQuery := conversionResult.QueryStrings[0].ConvertedQuery
+
+	// Extract account ID properly
+	accountID := extractAccountIDFromJQL(convertedQuery)
+	if accountID == "" {
+		return "", fmt.Errorf("failed to extract account ID from converted query: %s", convertedQuery)
+	}
+
+	// Cache the result for 10 minutes
+	userIDCache.Set(username, accountID, 10*time.Minute)
+
 	return convertedQuery, nil
 }
+
+// extractAccountIDFromJQL extracts the account ID from a converted JQL query
+func extractAccountIDFromJQL(jql string) string {
+	// Example: "assignee = \"account:5b10ac8d82e05b22cc7d4ef5\""
+	// We want to extract: "account:5b10ac8d82e05b22cc7d4ef5"
+
+	start := strings.Index(jql, "\"")
+	if start == -1 {
+		return ""
+	}
+
+	end := strings.LastIndex(jql, "\"")
+	if end == -1 || end <= start {
+		return ""
+	}
+
+	return jql[start+1 : end]
+}
+
 // IssuesFor returns a collection of issues for a given collection of projects.
 // If username is provided, it scopes the issues to that person
 func (widget *Widget) IssuesFor(username string, projects []string, jql string) (*SearchResult, error) {
@@ -168,7 +269,7 @@ func (widget *Widget) jiraPostRequest(path string, data []byte) ([]byte, error) 
 	if err != nil {
 		return nil, err
 	}
-	
+
 	req.Header.Set("Content-Type", "application/json")
 	if widget.settings.personalAccessToken != "" {
 		req.Header.Set("Authorization", "Bearer "+widget.settings.personalAccessToken)

--- a/modules/jira/client_test.go
+++ b/modules/jira/client_test.go
@@ -1,0 +1,290 @@
+package jira
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"gotest.tools/assert"
+)
+
+func TestUserIDCacheMap_SetAndGet(t *testing.T) {
+	cache := &UserIDCacheMap{
+		cache: make(map[string]UserIDCache),
+	}
+
+	// Test setting and getting a value
+	username := "testuser"
+	accountID := "account:123456789"
+	duration := 5 * time.Minute
+
+	cache.Set(username, accountID, duration)
+
+	// Test successful retrieval
+	retrievedID, found := cache.Get(username)
+	assert.Equal(t, true, found)
+	assert.Equal(t, accountID, retrievedID)
+}
+
+func TestUserIDCacheMap_GetNonExistent(t *testing.T) {
+	cache := &UserIDCacheMap{
+		cache: make(map[string]UserIDCache),
+	}
+
+	// Test getting non-existent value
+	retrievedID, found := cache.Get("nonexistent")
+	assert.Equal(t, false, found)
+	assert.Equal(t, "", retrievedID)
+}
+
+func TestUserIDCacheMap_GetExpired(t *testing.T) {
+	cache := &UserIDCacheMap{
+		cache: make(map[string]UserIDCache),
+	}
+
+	// Set an entry that expires immediately
+	username := "expireduser"
+	accountID := "account:987654321"
+	cache.Set(username, accountID, -1*time.Second) // Already expired
+
+	// Test that expired entry is not returned and is cleaned up
+	retrievedID, found := cache.Get(username)
+	assert.Equal(t, false, found)
+	assert.Equal(t, "", retrievedID)
+
+	// Verify the expired entry was removed from cache
+	cache.mutex.RLock()
+	_, exists := cache.cache[username]
+	cache.mutex.RUnlock()
+	assert.Equal(t, false, exists)
+}
+
+func TestUserIDCacheMap_Clear(t *testing.T) {
+	cache := &UserIDCacheMap{
+		cache: make(map[string]UserIDCache),
+	}
+
+	// Add a valid entry and an expired entry
+	cache.Set("validuser", "account:111", 5*time.Minute)
+	cache.Set("expireduser", "account:222", -1*time.Second)
+
+	// Clear expired entries
+	cache.Clear()
+
+	// Valid entry should still exist
+	_, found := cache.Get("validuser")
+	assert.Equal(t, true, found)
+
+	// Expired entry should be gone
+	cache.mutex.RLock()
+	_, exists := cache.cache["expireduser"]
+	cache.mutex.RUnlock()
+	assert.Equal(t, false, exists)
+}
+
+func TestExtractAccountIDFromJQL(t *testing.T) {
+	tests := []struct {
+		name     string
+		jql      string
+		expected string
+	}{
+		{
+			name:     "valid account ID",
+			jql:      `assignee = "account:5b10ac8d82e05b22cc7d4ef5"`,
+			expected: "account:5b10ac8d82e05b22cc7d4ef5",
+		},
+		{
+			name:     "single quotes",
+			jql:      `assignee = 'account:123456789'`,
+			expected: "", // Our function only handles double quotes
+		},
+		{
+			name:     "no quotes",
+			jql:      `assignee = account:123456789`,
+			expected: "",
+		},
+		{
+			name:     "empty string",
+			jql:      "",
+			expected: "",
+		},
+		{
+			name:     "malformed JQL",
+			jql:      `assignee = "incomplete`,
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := extractAccountIDFromJQL(tt.jql)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestConvertJQLWithUsername_CacheHit(t *testing.T) {
+	// Setup a mock widget (minimal setup for testing)
+	widget := &Widget{}
+
+	// Clear and setup cache
+	userIDCache = &UserIDCacheMap{
+		cache: make(map[string]UserIDCache),
+	}
+
+	// Pre-populate cache
+	username := "cacheduser"
+	accountID := "account:cached123"
+	userIDCache.Set(username, accountID, 5*time.Minute)
+
+	// Test that cached value is returned without API call
+	result, err := widget.ConvertJQLWithUsername(username)
+
+	assert.NilError(t, err)
+	assert.Equal(t, `assignee = "account:cached123"`, result)
+}
+
+func TestConvertJQLWithUsername_APICalls(t *testing.T) {
+	// Create a mock JIRA server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify it's a POST request to the right endpoint
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/rest/api/3/jql/pdcleaner", r.URL.Path)
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+		// Mock response
+		response := JQLConversionResponse{
+			QueryStrings: []ConvertedQuery{
+				{
+					Query:          `assignee = "testuser"`,
+					ConvertedQuery: `assignee = "account:5b10ac8d82e05b22cc7d4ef5"`,
+					UserMessages:   []UserMessage{},
+				},
+			},
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	// Setup widget with mock server
+	widget := &Widget{
+		settings: &Settings{
+			domain: server.URL,
+		},
+	}
+
+	// Clear cache
+	userIDCache = &UserIDCacheMap{
+		cache: make(map[string]UserIDCache),
+	}
+
+	// Test API call
+	result, err := widget.ConvertJQLWithUsername("testuser")
+
+	assert.NilError(t, err)
+	assert.Equal(t, `assignee = "account:5b10ac8d82e05b22cc7d4ef5"`, result)
+
+	// Verify it was cached
+	cachedID, found := userIDCache.Get("testuser")
+	assert.Equal(t, true, found)
+	assert.Equal(t, "account:5b10ac8d82e05b22cc7d4ef5", cachedID)
+}
+
+func TestConvertJQLWithUsername_APIError(t *testing.T) {
+	// Create a mock server that returns an error
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("Internal Server Error"))
+	}))
+	defer server.Close()
+
+	// Setup widget with mock server
+	widget := &Widget{
+		settings: &Settings{
+			domain: server.URL,
+		},
+	}
+
+	// Clear cache
+	userIDCache = &UserIDCacheMap{
+		cache: make(map[string]UserIDCache),
+	}
+
+	// Test API error handling
+	result, err := widget.ConvertJQLWithUsername("testuser")
+
+	assert.Error(t, err, "500 Internal Server Error")
+	assert.Equal(t, "", result)
+}
+
+func TestConvertJQLWithUsername_EmptyResponse(t *testing.T) {
+	// Create a mock server that returns empty response
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		response := JQLConversionResponse{
+			QueryStrings: []ConvertedQuery{},
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	// Setup widget with mock server
+	widget := &Widget{
+		settings: &Settings{
+			domain: server.URL,
+		},
+	}
+
+	// Clear cache
+	userIDCache = &UserIDCacheMap{
+		cache: make(map[string]UserIDCache),
+	}
+
+	// Test empty response handling
+	result, err := widget.ConvertJQLWithUsername("testuser")
+
+	assert.Error(t, err, "no conversion result for username: testuser")
+	assert.Equal(t, "", result)
+}
+
+func TestConvertJQLWithUsername_InvalidAccountID(t *testing.T) {
+	// Create a mock server that returns malformed JQL
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		response := JQLConversionResponse{
+			QueryStrings: []ConvertedQuery{
+				{
+					Query:          `assignee = "testuser"`,
+					ConvertedQuery: `assignee = malformed_without_quotes`,
+					UserMessages:   []UserMessage{},
+				},
+			},
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	// Setup widget with mock server
+	widget := &Widget{
+		settings: &Settings{
+			domain: server.URL,
+		},
+	}
+
+	// Clear cache
+	userIDCache = &UserIDCacheMap{
+		cache: make(map[string]UserIDCache),
+	}
+
+	// Test invalid account ID handling
+	result, err := widget.ConvertJQLWithUsername("testuser")
+
+	assert.ErrorContains(t, err, "failed to extract account ID from converted query")
+	assert.Equal(t, "", result)
+}

--- a/modules/jira/client_test.go
+++ b/modules/jira/client_test.go
@@ -166,7 +166,7 @@ func TestConvertJQLWithUsername_APICalls(t *testing.T) {
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(response)
+		_ = json.NewEncoder(w).Encode(response)
 	}))
 	defer server.Close()
 
@@ -198,7 +198,7 @@ func TestConvertJQLWithUsername_APIError(t *testing.T) {
 	// Create a mock server that returns an error
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
-		w.Write([]byte("Internal Server Error"))
+		_, _ = w.Write([]byte("Internal Server Error"))
 	}))
 	defer server.Close()
 
@@ -229,7 +229,7 @@ func TestConvertJQLWithUsername_EmptyResponse(t *testing.T) {
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(response)
+		_ = json.NewEncoder(w).Encode(response)
 	}))
 	defer server.Close()
 
@@ -266,7 +266,7 @@ func TestConvertJQLWithUsername_InvalidAccountID(t *testing.T) {
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(response)
+		_ = json.NewEncoder(w).Encode(response)
 	}))
 	defer server.Close()
 

--- a/modules/jira/client_test.go
+++ b/modules/jira/client_test.go
@@ -217,7 +217,7 @@ func TestConvertJQLWithUsername_APIError(t *testing.T) {
 	// Test API error handling
 	result, err := widget.ConvertJQLWithUsername("testuser")
 
-	assert.Error(t, err, "500 Internal Server Error")
+	assert.ErrorContains(t, err, "500 Internal Server Error")
 	assert.Equal(t, "", result)
 }
 


### PR DESCRIPTION
fixes #1855

This pull request introduces a new caching mechanism and logic for converting JIRA usernames to account IDs, and updates the search flow to use the new JIRA API v3 endpoints. It also adds unit tests for the new caching and conversion logic. These changes improve the efficiency and reliability of user-based JIRA queries, reduce redundant API calls, and enhance error handling and test coverage.

**JIRA Username-to-AccountID Conversion and Caching:**

* Added a thread-safe cache (`UserIDCacheMap`) to store mappings from JIRA usernames to account IDs, with expiration logic to avoid unnecessary API requests.
* Implemented the `ConvertJQLWithUsername` method, which converts a JQL query containing a username to use the corresponding account ID, leveraging the cache and calling the `/rest/api/3/jql/pdcleaner` endpoint when needed.
* Added helper functions for extracting account IDs from JQL strings and for cache management (`extractAccountIDFromJQL`, `Set`, `Get`, `Clear`).

**JIRA API Usage and Search Improvements:**

* Refactored the `IssuesFor` method to use the new API v3 search endpoint (`/rest/api/3/search/jql`) and fetch full issue details by ID, improving compatibility and future-proofing.
* Improved error handling in both GET and POST JIRA API requests, providing more informative error messages including response bodies and request URLs.

**Testing and Reliability:**

* Added unit tests in `client_test.go` to cover the caching logic, JQL conversion, error cases, and integration with mocked JIRA endpoints, ensuring robust and predictable behaviour.