### PR TITLE
Update dns.go for additional Linux DNS entries.

### DIFF
--- a/modules/security/dns.go
+++ b/modules/security/dns.go
@@ -36,8 +36,10 @@ func dnsLinux() []string {
 
 	for _, l := range lines {
 		if strings.HasPrefix(l, "IP4.DNS") {
-			parts := strings.Split(l, ":")
-			dns = append(dns, strings.TrimSpace(parts[1]))
+			parts := strings.SplitN(l, ":", 2)
+			if len(parts) == 2 {
+				dns = append(dns, strings.TrimSpace(parts[1]))
+			}
 		}
 	}
 	return dns


### PR DESCRIPTION
I am by no means a Go developer, so I'll be up front: This is AI generated code. I asked copilot why I'm only getting two out of three DNS entries returned by my first network device in `nmcli` and it thinks this is the solution, a "fragile split".



