### PR TITLE
List all configured DNS servers, not just 2

### DIFF
--- a/modules/security/dns.go
+++ b/modules/security/dns.go
@@ -40,6 +40,7 @@ func dnsLinux() []string {
 			dns = append(dns, strings.TrimSpace(parts[1]))
 		}
 	}
+
 	return dns
 }
 

--- a/modules/security/widget.go
+++ b/modules/security/widget.go
@@ -59,8 +59,14 @@ func (widget *Widget) content() (string, string, bool) {
 	str += "\n\n"
 
 	str += fmt.Sprintf(" [%s]DNS[white]\n", widget.settings.Colors.Subheading)
-	str += fmt.Sprintf("  %12s\n", data.DnsAt(0))
-	str += fmt.Sprintf("  %12s\n", data.DnsAt(1))
+	// If no DNS servers are found, display a single line of 'n/a'
+	if len(data.Dns) == 0 {
+		str += fmt.Sprintf(" %6s\n", "n/a")
+	} else {
+		for _, ip := range data.Dns {
+			str += fmt.Sprintf(" %12s\n", ip)
+		}
+	}
 	str += "\n"
 
 	return widget.CommonSettings().Title, str, false


### PR DESCRIPTION
This can make the widget much taller for the rare cases where someone has a lot of servers configured. I think the extra height it worth correctness.

In the future, I'd like to consider a setting to limit the number or intelligent widget sizing where a widget can consider the available room, and adjust its output.

This PR is an alternative solution to #1865.

