### PR TITLE
Don't wrap tarball files in a directory

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,7 +6,6 @@ env:
 
 archives:
   - id: default
-    wrap_in_directory: true
 
 builds:
   - binary: wtfutil


### PR DESCRIPTION
This change will allow us to provide easier command-line instructions for binary installs.


