### PR TITLE
ci: Add the new Homebrew Tap to the release pipeline

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -35,6 +35,19 @@ homebrew_casks:
           if system_command("/usr/bin/xattr", args: ["-h"]).exit_status == 0
             system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/wtfutil"]
           end
+  - name: wtfutil
+    homepage: 'https://wtfutil.com'
+    description: 'The personal information dashboard for your terminal.'
+    repository:
+      owner: linodians
+      name: homebrew-tap
+    hooks:
+      post:
+        # This hook is needed until this binary is signed and notarized
+        install: |
+          if system_command("/usr/bin/xattr", args: ["-h"]).exit_status == 0
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/wtfutil"]
+          end
 
 announce:
   mastodon:


### PR DESCRIPTION
As part of the transition to the Linodians org, we're using a new tap. The old tap and the new one will both be active for a certain time frame.