### PR TITLE
chore: Migrate Gitlab Go module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,6 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/wtfutil/spotigopher v0.0.0-20191127141047-7d8168fe103a
 	github.com/wtfutil/todoist v0.5.0
-	github.com/xanzy/go-gitlab v0.96.0
 	github.com/zmb3/spotify v1.3.0
 	github.com/zorkian/go-datadog-api v2.30.0+incompatible
 	golang.org/x/oauth2 v0.33.0
@@ -75,6 +74,7 @@ require (
 	github.com/logrusorgru/aurora/v4 v4.0.0
 	github.com/muesli/reflow v0.3.0
 	github.com/prometheus-community/pro-bing v0.7.0
+	gitlab.com/gitlab-org/api/client-go v0.116.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -747,8 +747,6 @@ github.com/wtfutil/todoist v0.5.0 h1:sqn/kXCz3cNsoivfPvb3Ww3QvvHskYAOh1wSpaodPU0
 github.com/wtfutil/todoist v0.5.0/go.mod h1:bWQGh9tPjlHVD7ooTyNVFuNRngl64FepP9wYpF5ObBM=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
-github.com/xanzy/go-gitlab v0.96.0 h1:LGkZ+wSNMRtHIBaYE4Hq3dZVjprwHv3Y1+rhKU3WETs=
-github.com/xanzy/go-gitlab v0.96.0/go.mod h1:ETg8tcj4OhrB84UEgeE8dSuV/0h4BBL1uOV/qK0vlyI=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=
 github.com/xanzy/ssh-agent v0.3.3/go.mod h1:6dzNDKs0J9rVPHPhaGCukekBHKqfl+L3KghI1Bc68Uw=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
@@ -775,6 +773,8 @@ github.com/zmb3/spotify v1.3.0 h1:6Z2F1IMx0Hviq/dpf8nFwvKPppFEMXn8yfReSBVi16k=
 github.com/zmb3/spotify v1.3.0/go.mod h1:GD7AAEMUJVYc2Z7p2a2S0E3/5f/KxM/vOnErNr4j+Tw=
 github.com/zorkian/go-datadog-api v2.30.0+incompatible h1:R4ryGocppDqZZbnNc5EDR8xGWF/z/MxzWnqTUijDQes=
 github.com/zorkian/go-datadog-api v2.30.0+incompatible/go.mod h1:PkXwHX9CUQa/FpB9ZwAD45N1uhCW4MT/Wj7m36PbKss=
+gitlab.com/gitlab-org/api/client-go v0.116.0 h1:Dy534gtZPMrnm3fAcmQRMadrcoUyFO4FQ4rXlSAdHAw=
+gitlab.com/gitlab-org/api/client-go v0.116.0/go.mod h1:B29OfnZklmaoiR7uHANh9jTyfWEgmXvZLVEnosw2Dx0=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=

--- a/modules/gitlab/display.go
+++ b/modules/gitlab/display.go
@@ -3,7 +3,7 @@ package gitlab
 import (
 	"fmt"
 
-	"github.com/xanzy/go-gitlab"
+	glab "gitlab.com/gitlab-org/api/client-go"
 )
 
 func (widget *Widget) display() {
@@ -78,7 +78,7 @@ func (widget *Widget) displayMyIssues(project *GitlabProject, username string) s
 	return widget.renderIssues(issues)
 }
 
-func (widget *Widget) renderMergeRequests(mrs []*gitlab.MergeRequest) string {
+func (widget *Widget) renderMergeRequests(mrs []*glab.MergeRequest) string {
 
 	length := len(mrs)
 
@@ -98,7 +98,7 @@ func (widget *Widget) renderMergeRequests(mrs []*gitlab.MergeRequest) string {
 	return str
 }
 
-func (widget *Widget) renderIssues(issues []*gitlab.Issue) string {
+func (widget *Widget) renderIssues(issues []*glab.Issue) string {
 
 	length := len(issues)
 

--- a/modules/gitlab/gitlab_project.go
+++ b/modules/gitlab/gitlab_project.go
@@ -1,17 +1,17 @@
 package gitlab
 
 import (
-	glb "github.com/xanzy/go-gitlab"
+	glab "gitlab.com/gitlab-org/api/client-go"
 )
 
 type context struct {
-	client *glb.Client
-	user   *glb.User
+	client *glab.Client
+	user   *glab.User
 }
 
 func newContext(settings *Settings) (*context, error) {
 	baseURL := settings.domain
-	gitlabClient, _ := glb.NewClient(settings.apiKey, glb.WithBaseURL(baseURL))
+	gitlabClient, _ := glab.NewClient(settings.apiKey, glab.WithBaseURL(baseURL))
 
 	user, _, err := gitlabClient.Users.CurrentUser()
 
@@ -31,12 +31,12 @@ type GitlabProject struct {
 	context *context
 	path    string
 
-	MergeRequests         []*glb.MergeRequest
-	AssignedMergeRequests []*glb.MergeRequest
-	AuthoredMergeRequests []*glb.MergeRequest
-	AssignedIssues        []*glb.Issue
-	AuthoredIssues        []*glb.Issue
-	RemoteProject         *glb.Project
+	MergeRequests         []*glab.MergeRequest
+	AssignedMergeRequests []*glab.MergeRequest
+	AuthoredMergeRequests []*glab.MergeRequest
+	AssignedIssues        []*glab.Issue
+	AuthoredIssues        []*glab.Issue
+	RemoteProject         *glab.Project
 }
 
 func NewGitlabProject(context *context, projectPath string) *GitlabProject {
@@ -83,29 +83,29 @@ func (project *GitlabProject) StarCount() int {
 /* -------------------- Unexported Functions -------------------- */
 
 // myMergeRequests returns a list of merge requests
-func (project *GitlabProject) myMergeRequests() []*glb.MergeRequest {
+func (project *GitlabProject) myMergeRequests() []*glab.MergeRequest {
 	return project.AuthoredMergeRequests
 }
 
 // myAssignedMergeRequests returns a list of merge requests
 // assigned
-func (project *GitlabProject) myAssignedMergeRequests() []*glb.MergeRequest {
+func (project *GitlabProject) myAssignedMergeRequests() []*glab.MergeRequest {
 	return project.AssignedMergeRequests
 }
 
 // myAssignedIssues returns a list of issues
-func (project *GitlabProject) myAssignedIssues() []*glb.Issue {
+func (project *GitlabProject) myAssignedIssues() []*glab.Issue {
 	return project.AssignedIssues
 }
 
 // myIssues returns a list of issues
-func (project *GitlabProject) myIssues() []*glb.Issue {
+func (project *GitlabProject) myIssues() []*glab.Issue {
 	return project.AuthoredIssues
 }
 
-func (project *GitlabProject) loadMergeRequests() ([]*glb.MergeRequest, error) {
+func (project *GitlabProject) loadMergeRequests() ([]*glab.MergeRequest, error) {
 	state := "opened"
-	opts := glb.ListProjectMergeRequestsOptions{
+	opts := glab.ListProjectMergeRequestsOptions{
 		State: &state,
 	}
 
@@ -118,11 +118,11 @@ func (project *GitlabProject) loadMergeRequests() ([]*glb.MergeRequest, error) {
 	return mrs, nil
 }
 
-func (project *GitlabProject) loadAssignedMergeRequests() ([]*glb.MergeRequest, error) {
+func (project *GitlabProject) loadAssignedMergeRequests() ([]*glab.MergeRequest, error) {
 	state := "opened"
-	opts := glb.ListProjectMergeRequestsOptions{
+	opts := glab.ListProjectMergeRequestsOptions{
 		State:      &state,
-		AssigneeID: glb.AssigneeID(project.context.user.ID),
+		AssigneeID: glab.AssigneeID(project.context.user.ID),
 	}
 
 	mrs, _, err := project.context.client.MergeRequests.ListProjectMergeRequests(project.path, &opts)
@@ -134,9 +134,9 @@ func (project *GitlabProject) loadAssignedMergeRequests() ([]*glb.MergeRequest, 
 	return mrs, nil
 }
 
-func (project *GitlabProject) loadAuthoredMergeRequests() ([]*glb.MergeRequest, error) {
+func (project *GitlabProject) loadAuthoredMergeRequests() ([]*glab.MergeRequest, error) {
 	state := "opened"
-	opts := glb.ListProjectMergeRequestsOptions{
+	opts := glab.ListProjectMergeRequestsOptions{
 		State:    &state,
 		AuthorID: &project.context.user.ID,
 	}
@@ -150,11 +150,11 @@ func (project *GitlabProject) loadAuthoredMergeRequests() ([]*glb.MergeRequest, 
 	return mrs, nil
 }
 
-func (project *GitlabProject) loadAssignedIssues() ([]*glb.Issue, error) {
+func (project *GitlabProject) loadAssignedIssues() ([]*glab.Issue, error) {
 	state := "opened"
-	opts := glb.ListProjectIssuesOptions{
+	opts := glab.ListProjectIssuesOptions{
 		State:      &state,
-		AssigneeID: glb.AssigneeID(project.context.user.ID),
+		AssigneeID: glab.AssigneeID(project.context.user.ID),
 	}
 
 	issues, _, err := project.context.client.Issues.ListProjectIssues(project.path, &opts)
@@ -166,9 +166,9 @@ func (project *GitlabProject) loadAssignedIssues() ([]*glb.Issue, error) {
 	return issues, nil
 }
 
-func (project *GitlabProject) loadAuthoredIssues() ([]*glb.Issue, interface{}) {
+func (project *GitlabProject) loadAuthoredIssues() ([]*glab.Issue, interface{}) {
 	state := "opened"
-	opts := glb.ListProjectIssuesOptions{
+	opts := glab.ListProjectIssuesOptions{
 		State:    &state,
 		AuthorID: &project.context.user.ID,
 	}
@@ -182,7 +182,7 @@ func (project *GitlabProject) loadAuthoredIssues() ([]*glb.Issue, interface{}) {
 	return issues, nil
 }
 
-func (project *GitlabProject) loadRemoteProject() (*glb.Project, error) {
+func (project *GitlabProject) loadRemoteProject() (*glab.Project, error) {
 	projectsitory, _, err := project.context.client.Projects.GetProject(project.path, nil)
 
 	if err != nil {

--- a/modules/gitlabtodo/widget.go
+++ b/modules/gitlabtodo/widget.go
@@ -3,17 +3,18 @@ package gitlabtodo
 import (
 	"fmt"
 
-	"github.com/rivo/tview"
 	"github.com/wtfutil/wtf/utils"
 	"github.com/wtfutil/wtf/view"
-	gitlab "github.com/xanzy/go-gitlab"
+
+	"github.com/rivo/tview"
+	glab "gitlab.com/gitlab-org/api/client-go"
 )
 
 type Widget struct {
 	view.ScrollableWidget
 
-	todos        []*gitlab.Todo
-	gitlabClient *gitlab.Client
+	todos        []*glab.Todo
+	gitlabClient *glab.Client
 	settings     *Settings
 	err          error
 }
@@ -25,7 +26,7 @@ func NewWidget(tviewApp *tview.Application, redrawChan chan bool, pages *tview.P
 		settings: settings,
 	}
 
-	widget.gitlabClient, _ = gitlab.NewClient(settings.apiKey, gitlab.WithBaseURL(settings.domain))
+	widget.gitlabClient, _ = glab.NewClient(settings.apiKey, glab.WithBaseURL(settings.domain))
 
 	widget.SetRenderFunction(widget.Render)
 	widget.initializeKeyboardControls()
@@ -71,8 +72,8 @@ func (widget *Widget) content() (string, string, bool) {
 	return title, str, false
 }
 
-func (widget *Widget) getTodos() ([]*gitlab.Todo, error) {
-	opts := gitlab.ListTodosOptions{}
+func (widget *Widget) getTodos() ([]*glab.Todo, error) {
+	opts := glab.ListTodosOptions{}
 
 	todos, _, err := widget.gitlabClient.Todos.ListTodos(&opts)
 	if err != nil {
@@ -96,7 +97,7 @@ func (widget *Widget) trimTodoBody(body string) string {
 	return body
 }
 
-func (widget *Widget) contentFrom(todos []*gitlab.Todo) string {
+func (widget *Widget) contentFrom(todos []*glab.Todo) string {
 	var str string
 
 	for idx, todo := range todos {


### PR DESCRIPTION
The GitLab go module we were using has moved from a solo GitHub project to a part of GitLab on GitLab. This PR moves the project in the codebase.

Closes #1735
Closes #1770