### PR TITLE
chore: Cleanup GoReleaser config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,12 +1,5 @@
 version: 2
 
-env:
-  - GO111MODULE=on
-  - GOPROXY="https://proxy.golang.org,direct"
-
-archives:
-  - id: default
-
 builds:
   - binary: wtfutil
     goos:
@@ -17,9 +10,8 @@ builds:
       - arm
       - arm64
 
-before:
-  hooks:
-    - make install
+archives:
+  - id: default
 
 homebrew_casks:
   - name: wtfutil


### PR DESCRIPTION
Reasons:

- `GO111MODULE` is removed as it is no longer relevant. The setting was dropped/ignored as of Go v1.17.
- `GOPROXY` is removed as what we have set is the default. What we have is already the default in both Go itself as well as in GitHub Actions.
- `archives:` this section has been moved to below the `builds:` section. This is not a requirement. I just wanted to config to follow the order a GoReleaser pipeline does. In GoReleaser, the archives section is dependent on builds. I'm hoping the order helps us logically walk through the config in the future if we need to troubleshoot something.