### PR TITLE
Fix module help: Always include common attributes

### DIFF
--- a/utils/help_parser.go
+++ b/utils/help_parser.go
@@ -24,7 +24,7 @@ func HelpFromInterface(item interface{}) string {
 			kind = field.Type.Elem().Kind()
 		}
 
-		if field.Name == "common" {
+		if field.Name == "Common" {
 			result += HelpFromInterface(cfg.Common{})
 		}
 


### PR DESCRIPTION
Currently, the module help skips the common configuration attributes when module-specific attributes are printed.

Try:

```sh
wtf -m=git
```

Common attributes like `bordered` and `title` are missing.

The reason is that `HelpFromInterface` checks for field name `"common"` but it's actually `"Common"`.