### PR TITLE
Fix typos in help texts

### DIFF
--- a/cfg/common_settings.go
+++ b/cfg/common_settings.go
@@ -44,7 +44,7 @@ type Common struct {
 	Bordered        bool          `help:"Whether or not the module should be displayed with a border." values:"true, false" optional:"true" default:"true"`
 	Enabled         bool          `help:"Whether or not this module is executed and if its data displayed onscreen." values:"true, false" optional:"true" default:"false"`
 	Focusable       bool          `help:"Whether or  not this module is focusable." values:"true, false" optional:"true" default:"false"`
-	LanguageTag     string        `help:"The BCP 47 langauge tag to localize text to." values:"Any supported BCP 47 language tag." optional:"true" default:"en-CA"`
+	LanguageTag     string        `help:"The BCP 47 language tag to localize text to." values:"Any supported BCP 47 language tag." optional:"true" default:"en-CA"`
 	RefreshInterval time.Duration `help:"How often this module will update its data." values:"A positive integer followed by a time unit (ns, us, ms, s, m, h, or nothing which defaults to s)" optional:"true"`
 	Title           string        `help:"The title string to show when displaying this module" optional:"true"`
 

--- a/cfg/common_settings.go
+++ b/cfg/common_settings.go
@@ -179,7 +179,7 @@ func (common *Common) RowColor(idx int) string {
 	)
 }
 
-func (common *Common) RightAlignFormat(width int) string {
+func (*Common) RightAlignFormat(width int) string {
 	borderOffset := 2
 	return fmt.Sprintf("%%%ds", width-borderOffset)
 }
@@ -212,7 +212,7 @@ func (common *Common) SetDocumentationPath(path string) {
 // Validations aggregates all the validations from all the sub-sections in Common into a
 // single array of validations
 func (common *Common) Validations() []Validatable {
-	validatables := []Validatable{}
+	var validatables []Validatable
 
 	for _, validation := range common.PositionSettings.Validations.validations {
 		validatables = append(validatables, validation)

--- a/modules/feedreader/settings.go
+++ b/modules/feedreader/settings.go
@@ -30,11 +30,11 @@ type Settings struct {
 
 	feeds           []string        `help:"An array of RSS and Atom feed URLs"`
 	feedLimit       int             `help:"The maximum number of stories to display for each feed"`
-	showSource      bool            `help:"Wether or not to show feed source in front of item titles." values:"true or false" optional:"true" default:"true"`
-	showPublishDate bool            `help:"Wether or not to show publish date in front of item titles." values:"true or false" optional:"true" default:"false"`
+	showSource      bool            `help:"Whether or not to show feed source in front of item titles." values:"true or false" optional:"true" default:"true"`
+	showPublishDate bool            `help:"Whether or not to show publish date in front of item titles." values:"true or false" optional:"true" default:"false"`
 	dateFormat      string          `help:"Date format to use for publish dates" values:"Any valid Go time layout which is handled by Time.Format" optional:"true" default:"Jan 02"`
 	credentials     map[string]auth `help:"Map of private feed URLs with required authentication credentials"`
-	disableHTTP2    bool            `help:"Wether or not to use the HTTP/2 protocol. Certain sites, such as reddit.com, will not work unless HTTP/2 is disabled." values:"true or false" optional:"true" default:"false"`
+	disableHTTP2    bool            `help:"Whether or not to use the HTTP/2 protocol. Certain sites, such as reddit.com, will not work unless HTTP/2 is disabled." values:"true or false" optional:"true" default:"false"`
 	userAgent       string          `help:"HTTP User-Agent to use when fetching RSS feeds." optional:"true"`
 }
 


### PR DESCRIPTION
Fix typos in help texts (common settings and feedreader settings).