### PR TITLE
Include module settings in module help

### DIFF
--- a/modules/airbrake/settings.go
+++ b/modules/airbrake/settings.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/olebedev/config"
 	"github.com/wtfutil/wtf/cfg"
+	"github.com/wtfutil/wtf/utils"
 )
 
 const (
@@ -31,6 +32,10 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	cfg.ModuleSecret(name, globalConfig, &settings.authToken).Load()
 
 	return &settings
+}
+
+func (widget *Widget) ConfigText() string {
+	return utils.HelpFromInterface(Settings{})
 }
 
 func getProjectID() int {

--- a/modules/asana/settings.go
+++ b/modules/asana/settings.go
@@ -46,3 +46,7 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 
 	return &settings
 }
+
+func (widget *Widget) ConfigText() string {
+	return utils.HelpFromInterface(Settings{})
+}

--- a/modules/azuredevops/settings.go
+++ b/modules/azuredevops/settings.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/olebedev/config"
 	"github.com/wtfutil/wtf/cfg"
+	"github.com/wtfutil/wtf/utils"
 )
 
 const (
@@ -39,4 +40,8 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 		Service(settings.orgURL).Load()
 
 	return &settings
+}
+
+func (widget *Widget) ConfigText() string {
+	return utils.HelpFromInterface(Settings{})
 }

--- a/modules/azurelogs/settings.go
+++ b/modules/azurelogs/settings.go
@@ -4,6 +4,7 @@ import (
 	"github.com/olebedev/config"
 
 	"github.com/wtfutil/wtf/cfg"
+	"github.com/wtfutil/wtf/utils"
 )
 
 const (
@@ -28,4 +29,8 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	}
 
 	return &settings
+}
+
+func (widget *Widget) ConfigText() string {
+	return utils.HelpFromInterface(Settings{})
 }

--- a/modules/bamboohr/settings.go
+++ b/modules/bamboohr/settings.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/olebedev/config"
 	"github.com/wtfutil/wtf/cfg"
+	"github.com/wtfutil/wtf/utils"
 )
 
 const (
@@ -30,4 +31,8 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	cfg.ModuleSecret(name, globalConfig, &settings.apiKey).Load()
 
 	return &settings
+}
+
+func (widget *Widget) ConfigText() string {
+	return utils.HelpFromInterface(Settings{})
 }

--- a/modules/buildkite/settings.go
+++ b/modules/buildkite/settings.go
@@ -43,6 +43,10 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	return &settings
 }
 
+func (widget *Widget) ConfigText() string {
+	return utils.HelpFromInterface(Settings{})
+}
+
 /* -------------------- Unexported Functions -------------------- */
 
 func buildPipelineSettings(ymlConfig *config.Config) []PipelineSettings {

--- a/modules/circleci/settings.go
+++ b/modules/circleci/settings.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/olebedev/config"
 	"github.com/wtfutil/wtf/cfg"
+	"github.com/wtfutil/wtf/utils"
 )
 
 const (
@@ -31,4 +32,8 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	cfg.ModuleSecret(name, globalConfig, &settings.apiKey).Load()
 
 	return &settings
+}
+
+func (widget *Widget) ConfigText() string {
+	return utils.HelpFromInterface(Settings{})
 }

--- a/modules/clocks/settings.go
+++ b/modules/clocks/settings.go
@@ -35,6 +35,10 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	return &settings
 }
 
+func (widget *Widget) ConfigText() string {
+	return utils.HelpFromInterface(Settings{})
+}
+
 func buildLocations(ymlConfig *config.Config) []Clock {
 	clocks := []Clock{}
 	locations, err := ymlConfig.Map("locations")

--- a/modules/cmdrunner/settings.go
+++ b/modules/cmdrunner/settings.go
@@ -50,3 +50,7 @@ func NewSettingsFromYAML(name string, moduleConfig *config.Config, globalConfig 
 
 	return &settings
 }
+
+func (widget *Widget) ConfigText() string {
+	return utils.HelpFromInterface(Settings{})
+}

--- a/modules/datadog/settings.go
+++ b/modules/datadog/settings.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/olebedev/config"
 	"github.com/wtfutil/wtf/cfg"
+	"github.com/wtfutil/wtf/utils"
 )
 
 const (
@@ -34,4 +35,8 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	cfg.ModuleSecret(name+"-app", globalConfig, &settings.applicationKey).Load()
 
 	return &settings
+}
+
+func (widget *Widget) ConfigText() string {
+	return utils.HelpFromInterface(Settings{})
 }

--- a/modules/devto/settings.go
+++ b/modules/devto/settings.go
@@ -4,6 +4,7 @@ import (
 	"github.com/olebedev/config"
 
 	"github.com/wtfutil/wtf/cfg"
+	"github.com/wtfutil/wtf/utils"
 )
 
 const (
@@ -33,4 +34,8 @@ func NewSettingsFromYAML(name string, yamlConfig *config.Config, globalConfig *c
 	}
 
 	return &settings
+}
+
+func (widget *Widget) ConfigText() string {
+	return utils.HelpFromInterface(Settings{})
 }

--- a/modules/digitalclock/settings.go
+++ b/modules/digitalclock/settings.go
@@ -3,6 +3,7 @@ package digitalclock
 import (
 	"github.com/olebedev/config"
 	"github.com/wtfutil/wtf/cfg"
+	"github.com/wtfutil/wtf/utils"
 )
 
 const (
@@ -44,4 +45,8 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	}
 
 	return &settings
+}
+
+func (widget *Widget) ConfigText() string {
+	return utils.HelpFromInterface(Settings{})
 }

--- a/modules/digitalocean/settings.go
+++ b/modules/digitalocean/settings.go
@@ -46,3 +46,7 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 
 	return &settings
 }
+
+func (widget *Widget) ConfigText() string {
+	return utils.HelpFromInterface(Settings{})
+}

--- a/modules/docker/settings.go
+++ b/modules/docker/settings.go
@@ -3,6 +3,7 @@ package docker
 import (
 	"github.com/olebedev/config"
 	"github.com/wtfutil/wtf/cfg"
+	"github.com/wtfutil/wtf/utils"
 )
 
 const (
@@ -25,4 +26,8 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	}
 
 	return &settings
+}
+
+func (widget *Widget) ConfigText() string {
+	return utils.HelpFromInterface(Settings{})
 }

--- a/modules/feedreader/settings.go
+++ b/modules/feedreader/settings.go
@@ -86,3 +86,7 @@ func NewSettingsFromYAML(name string, ymlConfig, globalConfig *config.Config) *S
 
 	return settings
 }
+
+func (widget *Widget) ConfigText() string {
+	return utils.HelpFromInterface(Settings{})
+}

--- a/modules/football/settings.go
+++ b/modules/football/settings.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/olebedev/config"
 	"github.com/wtfutil/wtf/cfg"
+	"github.com/wtfutil/wtf/utils"
 )
 
 const (
@@ -41,4 +42,8 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	settings.SetDocumentationPath("sports/football")
 
 	return &settings
+}
+
+func (widget *Widget) ConfigText() string {
+	return utils.HelpFromInterface(Settings{})
 }

--- a/modules/gcal/settings.go
+++ b/modules/gcal/settings.go
@@ -3,6 +3,7 @@ package gcal
 import (
 	"github.com/olebedev/config"
 	"github.com/wtfutil/wtf/cfg"
+	"github.com/wtfutil/wtf/utils"
 )
 
 const (
@@ -81,4 +82,8 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	settings.SetDocumentationPath("google/gcal")
 
 	return &settings
+}
+
+func (widget *Widget) ConfigText() string {
+	return utils.HelpFromInterface(Settings{})
 }

--- a/modules/gerrit/settings.go
+++ b/modules/gerrit/settings.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/olebedev/config"
 	"github.com/wtfutil/wtf/cfg"
+	"github.com/wtfutil/wtf/utils"
 )
 
 const (
@@ -48,4 +49,8 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	settings.rows.odd = ymlConfig.UString("colors.rows.odd", "blue")
 
 	return &settings
+}
+
+func (widget *Widget) ConfigText() string {
+	return utils.HelpFromInterface(Settings{})
 }

--- a/modules/github/settings.go
+++ b/modules/github/settings.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/olebedev/config"
 	"github.com/wtfutil/wtf/cfg"
+	"github.com/wtfutil/wtf/utils"
 )
 
 const (
@@ -55,6 +56,10 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 		Service(settings.baseURL).Load()
 
 	return &settings
+}
+
+func (widget *Widget) ConfigText() string {
+	return utils.HelpFromInterface(Settings{})
 }
 
 /* -------------------- Unexported Functions -------------------- */

--- a/modules/gitlab/settings.go
+++ b/modules/gitlab/settings.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/olebedev/config"
 	"github.com/wtfutil/wtf/cfg"
+	"github.com/wtfutil/wtf/utils"
 )
 
 const (
@@ -38,4 +39,8 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	settings.projects = cfg.ParseAsMapOrList(ymlConfig, "projects")
 
 	return &settings
+}
+
+func (widget *Widget) ConfigText() string {
+	return utils.HelpFromInterface(Settings{})
 }

--- a/modules/gitlabtodo/settings.go
+++ b/modules/gitlabtodo/settings.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/olebedev/config"
 	"github.com/wtfutil/wtf/cfg"
+	"github.com/wtfutil/wtf/utils"
 )
 
 const (
@@ -36,4 +37,8 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 		Service(settings.domain).Load()
 
 	return &settings
+}
+
+func (widget *Widget) ConfigText() string {
+	return utils.HelpFromInterface(Settings{})
 }

--- a/modules/gitter/settings.go
+++ b/modules/gitter/settings.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/olebedev/config"
 	"github.com/wtfutil/wtf/cfg"
+	"github.com/wtfutil/wtf/utils"
 )
 
 const (
@@ -33,4 +34,8 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	cfg.ModuleSecret(name, globalConfig, &settings.apiToken).Load()
 
 	return &settings
+}
+
+func (widget *Widget) ConfigText() string {
+	return utils.HelpFromInterface(Settings{})
 }

--- a/modules/googleanalytics/settings.go
+++ b/modules/googleanalytics/settings.go
@@ -3,6 +3,7 @@ package googleanalytics
 import (
 	"github.com/olebedev/config"
 	"github.com/wtfutil/wtf/cfg"
+	"github.com/wtfutil/wtf/utils"
 )
 
 const (
@@ -33,4 +34,8 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	settings.SetDocumentationPath("google/analytics")
 
 	return &settings
+}
+
+func (widget *Widget) ConfigText() string {
+	return utils.HelpFromInterface(Settings{})
 }

--- a/modules/grafana/settings.go
+++ b/modules/grafana/settings.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/olebedev/config"
 	"github.com/wtfutil/wtf/cfg"
+	"github.com/wtfutil/wtf/utils"
 )
 
 const (
@@ -36,4 +37,8 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	settings.baseURI = strings.TrimSuffix(settings.baseURI, "/")
 
 	return &settings
+}
+
+func (widget *Widget) ConfigText() string {
+	return utils.HelpFromInterface(Settings{})
 }

--- a/modules/gspreadsheets/settings.go
+++ b/modules/gspreadsheets/settings.go
@@ -3,6 +3,7 @@ package gspreadsheets
 import (
 	"github.com/olebedev/config"
 	"github.com/wtfutil/wtf/cfg"
+	"github.com/wtfutil/wtf/utils"
 )
 
 const (
@@ -39,4 +40,8 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	settings.SetDocumentationPath("google/spreadsheet")
 
 	return &settings
+}
+
+func (widget *Widget) ConfigText() string {
+	return utils.HelpFromInterface(Settings{})
 }

--- a/modules/hackernews/settings.go
+++ b/modules/hackernews/settings.go
@@ -3,6 +3,7 @@ package hackernews
 import (
 	"github.com/olebedev/config"
 	"github.com/wtfutil/wtf/cfg"
+	"github.com/wtfutil/wtf/utils"
 )
 
 const (
@@ -27,4 +28,8 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	}
 
 	return &settings
+}
+
+func (widget *Widget) ConfigText() string {
+	return utils.HelpFromInterface(Settings{})
 }

--- a/modules/healthchecks/settings.go
+++ b/modules/healthchecks/settings.go
@@ -36,3 +36,7 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 
 	return &settings
 }
+
+func (widget *Widget) ConfigText() string {
+	return utils.HelpFromInterface(Settings{})
+}

--- a/modules/hibp/settings.go
+++ b/modules/hibp/settings.go
@@ -54,6 +54,10 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	return settings
 }
 
+func (widget *Widget) ConfigText() string {
+	return utils.HelpFromInterface(Settings{})
+}
+
 // HasSince returns TRUE if there's a valid "since" value setting, FALSE if there is not
 func (sett *Settings) HasSince() bool {
 	if sett.since == "" {

--- a/modules/jenkins/settings.go
+++ b/modules/jenkins/settings.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/olebedev/config"
 	"github.com/wtfutil/wtf/cfg"
+	"github.com/wtfutil/wtf/utils"
 )
 
 const (
@@ -40,4 +41,8 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 		Service(settings.url).Load()
 
 	return &settings
+}
+
+func (widget *Widget) ConfigText() string {
+	return utils.HelpFromInterface(Settings{})
 }

--- a/modules/jira/settings.go
+++ b/modules/jira/settings.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/olebedev/config"
 	"github.com/wtfutil/wtf/cfg"
+	"github.com/wtfutil/wtf/utils"
 )
 
 const (
@@ -56,6 +57,10 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	settings.projects = settings.arrayifyProjects(ymlConfig)
 
 	return &settings
+}
+
+func (widget *Widget) ConfigText() string {
+	return utils.HelpFromInterface(Settings{})
 }
 
 /* -------------------- Unexported functions -------------------- */

--- a/modules/krisinformation/settings.go
+++ b/modules/krisinformation/settings.go
@@ -3,6 +3,7 @@ package krisinformation
 import (
 	"github.com/olebedev/config"
 	"github.com/wtfutil/wtf/cfg"
+	"github.com/wtfutil/wtf/utils"
 )
 
 const (
@@ -41,4 +42,8 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	}
 
 	return &settings
+}
+
+func (widget *Widget) ConfigText() string {
+	return utils.HelpFromInterface(Settings{})
 }

--- a/modules/kubernetes/settings.go
+++ b/modules/kubernetes/settings.go
@@ -35,3 +35,7 @@ func NewSettingsFromYAML(name string, moduleConfig *config.Config, globalConfig 
 
 	return &settings
 }
+
+func (widget *Widget) ConfigText() string {
+	return utils.HelpFromInterface(Settings{})
+}

--- a/modules/logger/settings.go
+++ b/modules/logger/settings.go
@@ -3,6 +3,7 @@ package logger
 import (
 	"github.com/olebedev/config"
 	"github.com/wtfutil/wtf/cfg"
+	"github.com/wtfutil/wtf/utils"
 )
 
 const (
@@ -20,4 +21,8 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	}
 
 	return &settings
+}
+
+func (widget *Widget) ConfigText() string {
+	return utils.HelpFromInterface(Settings{})
 }

--- a/modules/lunarphase/settings.go
+++ b/modules/lunarphase/settings.go
@@ -3,6 +3,7 @@ package lunarphase
 import (
 	"github.com/olebedev/config"
 	"github.com/wtfutil/wtf/cfg"
+	"github.com/wtfutil/wtf/utils"
 )
 
 const (
@@ -30,4 +31,8 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	settings.SetDocumentationPath("lunarphase")
 
 	return &settings
+}
+
+func (widget *Widget) ConfigText() string {
+	return utils.HelpFromInterface(Settings{})
 }

--- a/modules/mercurial/settings.go
+++ b/modules/mercurial/settings.go
@@ -3,6 +3,7 @@ package mercurial
 import (
 	"github.com/olebedev/config"
 	"github.com/wtfutil/wtf/cfg"
+	"github.com/wtfutil/wtf/utils"
 )
 
 const (
@@ -29,4 +30,8 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	}
 
 	return &settings
+}
+
+func (widget *Widget) ConfigText() string {
+	return utils.HelpFromInterface(Settings{})
 }

--- a/modules/nbascore/settings.go
+++ b/modules/nbascore/settings.go
@@ -3,6 +3,7 @@ package nbascore
 import (
 	"github.com/olebedev/config"
 	"github.com/wtfutil/wtf/cfg"
+	"github.com/wtfutil/wtf/utils"
 )
 
 const (
@@ -22,4 +23,8 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	settings.SetDocumentationPath("sports/nbascore")
 
 	return &settings
+}
+
+func (widget *Widget) ConfigText() string {
+	return utils.HelpFromInterface(Settings{})
 }

--- a/modules/newrelic/settings.go
+++ b/modules/newrelic/settings.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/olebedev/config"
 	"github.com/wtfutil/wtf/cfg"
+	"github.com/wtfutil/wtf/utils"
 )
 
 const (
@@ -33,4 +34,8 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	cfg.ModuleSecret(name, globalConfig, &settings.apiKey).Load()
 
 	return &settings
+}
+
+func (widget *Widget) ConfigText() string {
+	return utils.HelpFromInterface(Settings{})
 }

--- a/modules/nextbus/settings.go
+++ b/modules/nextbus/settings.go
@@ -3,6 +3,7 @@ package nextbus
 import (
 	"github.com/olebedev/config"
 	"github.com/wtfutil/wtf/cfg"
+	"github.com/wtfutil/wtf/utils"
 )
 
 const (
@@ -30,4 +31,8 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	}
 
 	return &settings
+}
+
+func (widget *Widget) ConfigText() string {
+	return utils.HelpFromInterface(Settings{})
 }

--- a/modules/opsgenie/settings.go
+++ b/modules/opsgenie/settings.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/olebedev/config"
 	"github.com/wtfutil/wtf/cfg"
+	"github.com/wtfutil/wtf/utils"
 )
 
 const (
@@ -38,6 +39,10 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	settings.schedule = settings.arrayifySchedules(ymlConfig)
 
 	return &settings
+}
+
+func (widget *Widget) ConfigText() string {
+	return utils.HelpFromInterface(Settings{})
 }
 
 // arrayifySchedules figures out if we're dealing with a single project or an array of projects

--- a/modules/pagerduty/settings.go
+++ b/modules/pagerduty/settings.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/olebedev/config"
 	"github.com/wtfutil/wtf/cfg"
+	"github.com/wtfutil/wtf/utils"
 )
 
 const (
@@ -46,4 +47,8 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	cfg.ModuleSecret(name, globalConfig, &settings.apiKey).Load()
 
 	return &settings
+}
+
+func (widget *Widget) ConfigText() string {
+	return utils.HelpFromInterface(Settings{})
 }

--- a/modules/pihole/settings.go
+++ b/modules/pihole/settings.go
@@ -3,6 +3,7 @@ package pihole
 import (
 	"github.com/olebedev/config"
 	"github.com/wtfutil/wtf/cfg"
+	"github.com/wtfutil/wtf/utils"
 )
 
 const (
@@ -40,4 +41,8 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 		Service(settings.apiUrl).Load()
 
 	return &settings
+}
+
+func (widget *Widget) ConfigText() string {
+	return utils.HelpFromInterface(Settings{})
 }

--- a/modules/ping/settings.go
+++ b/modules/ping/settings.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/olebedev/config"
 	"github.com/wtfutil/wtf/cfg"
+	"github.com/wtfutil/wtf/utils"
 )
 
 const (
@@ -30,6 +31,10 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	}
 
 	return &settings
+}
+
+func (widget *Widget) ConfigText() string {
+	return utils.HelpFromInterface(Settings{})
 }
 
 func buildhosts(ymlConfig *config.Config) []Host {

--- a/modules/pivotal/settings.go
+++ b/modules/pivotal/settings.go
@@ -2,9 +2,11 @@ package pivotal
 
 import (
 	"fmt"
+	"os"
+
 	"github.com/olebedev/config"
 	"github.com/wtfutil/wtf/cfg"
-	"os"
+	"github.com/wtfutil/wtf/utils"
 )
 
 const (
@@ -44,6 +46,10 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	cfg.ModuleSecret(name, globalConfig, &settings.apiToken).Load()
 
 	return &settings
+}
+
+func (widget *Widget) ConfigText() string {
+	return utils.HelpFromInterface(Settings{})
 }
 
 func parseCustomQueries(ymlConfig *config.Config) []customQuery {

--- a/modules/pocket/settings.go
+++ b/modules/pocket/settings.go
@@ -3,6 +3,7 @@ package pocket
 import (
 	"github.com/olebedev/config"
 	"github.com/wtfutil/wtf/cfg"
+	"github.com/wtfutil/wtf/utils"
 )
 
 const (
@@ -27,4 +28,8 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	cfg.ModuleSecret(name, globalConfig, &settings.consumerKey).Load()
 
 	return &settings
+}
+
+func (widget *Widget) ConfigText() string {
+	return utils.HelpFromInterface(Settings{})
 }

--- a/modules/progress/settings.go
+++ b/modules/progress/settings.go
@@ -3,6 +3,7 @@ package progress
 import (
 	"github.com/olebedev/config"
 	"github.com/wtfutil/wtf/cfg"
+	"github.com/wtfutil/wtf/utils"
 )
 
 const (
@@ -53,4 +54,8 @@ func NewSettingsFromYAML(name string, ymlConfig, globalConfig *config.Config) *S
 	settings.solid = ymlConfig.UString("colors.solid", "")
 
 	return &settings
+}
+
+func (widget *Widget) ConfigText() string {
+	return utils.HelpFromInterface(Settings{})
 }

--- a/modules/resourceusage/settings.go
+++ b/modules/resourceusage/settings.go
@@ -3,6 +3,7 @@ package resourceusage
 import (
 	"github.com/olebedev/config"
 	"github.com/wtfutil/wtf/cfg"
+	"github.com/wtfutil/wtf/utils"
 )
 
 const (
@@ -32,4 +33,8 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	settings.RefreshInterval = cfg.ParseTimeString(ymlConfig, "refreshInterval", defaultRefreshInterval)
 
 	return &settings
+}
+
+func (widget *Widget) ConfigText() string {
+	return utils.HelpFromInterface(Settings{})
 }

--- a/modules/rollbar/settings.go
+++ b/modules/rollbar/settings.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/olebedev/config"
 	"github.com/wtfutil/wtf/cfg"
+	"github.com/wtfutil/wtf/utils"
 )
 
 const (
@@ -39,4 +40,8 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	cfg.ModuleSecret(name, globalConfig, &settings.accessToken).Load()
 
 	return &settings
+}
+
+func (widget *Widget) ConfigText() string {
+	return utils.HelpFromInterface(Settings{})
 }

--- a/modules/spotify/settings.go
+++ b/modules/spotify/settings.go
@@ -3,6 +3,7 @@ package spotify
 import (
 	"github.com/olebedev/config"
 	"github.com/wtfutil/wtf/cfg"
+	"github.com/wtfutil/wtf/utils"
 )
 
 const (
@@ -29,4 +30,8 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	settings.text = ymlConfig.UString("colors.text", "white")
 
 	return &settings
+}
+
+func (widget *Widget) ConfigText() string {
+	return utils.HelpFromInterface(Settings{})
 }

--- a/modules/spotifyweb/settings.go
+++ b/modules/spotifyweb/settings.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/olebedev/config"
 	"github.com/wtfutil/wtf/cfg"
+	"github.com/wtfutil/wtf/utils"
 )
 
 const (
@@ -33,4 +34,8 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	cfg.ModuleSecret(name, globalConfig, &settings.secretKey).Load()
 
 	return &settings
+}
+
+func (widget *Widget) ConfigText() string {
+	return utils.HelpFromInterface(Settings{})
 }

--- a/modules/steam/settings.go
+++ b/modules/steam/settings.go
@@ -31,3 +31,7 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	}
 	return &settings
 }
+
+func (widget *Widget) ConfigText() string {
+	return utils.HelpFromInterface(Settings{})
+}

--- a/modules/subreddit/settings.go
+++ b/modules/subreddit/settings.go
@@ -3,6 +3,7 @@ package subreddit
 import (
 	"github.com/olebedev/config"
 	"github.com/wtfutil/wtf/cfg"
+	"github.com/wtfutil/wtf/utils"
 )
 
 const (
@@ -32,4 +33,8 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	}
 
 	return &settings
+}
+
+func (widget *Widget) ConfigText() string {
+	return utils.HelpFromInterface(Settings{})
 }

--- a/modules/textfile/settings.go
+++ b/modules/textfile/settings.go
@@ -3,6 +3,7 @@ package textfile
 import (
 	"github.com/olebedev/config"
 	"github.com/wtfutil/wtf/cfg"
+	"github.com/wtfutil/wtf/utils"
 )
 
 const (
@@ -33,4 +34,8 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	}
 
 	return &settings
+}
+
+func (widget *Widget) ConfigText() string {
+	return utils.HelpFromInterface(Settings{})
 }

--- a/modules/todo/settings.go
+++ b/modules/todo/settings.go
@@ -3,6 +3,7 @@ package todo
 import (
 	"github.com/olebedev/config"
 	"github.com/wtfutil/wtf/cfg"
+	"github.com/wtfutil/wtf/utils"
 )
 
 const (
@@ -74,4 +75,8 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	}
 
 	return &settings
+}
+
+func (widget *Widget) ConfigText() string {
+	return utils.HelpFromInterface(Settings{})
 }

--- a/modules/todo_plus/settings.go
+++ b/modules/todo_plus/settings.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/olebedev/config"
 	"github.com/wtfutil/wtf/cfg"
+	"github.com/wtfutil/wtf/utils"
 )
 
 const (
@@ -31,6 +32,10 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	}
 
 	return &settings
+}
+
+func (widget *Widget) ConfigText() string {
+	return utils.HelpFromInterface(Settings{})
 }
 
 func FromTodoist(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {

--- a/modules/transmission/settings.go
+++ b/modules/transmission/settings.go
@@ -3,6 +3,7 @@ package transmission
 import (
 	"github.com/olebedev/config"
 	"github.com/wtfutil/wtf/cfg"
+	"github.com/wtfutil/wtf/utils"
 )
 
 const (
@@ -38,4 +39,8 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	}
 
 	return &settings
+}
+
+func (widget *Widget) ConfigText() string {
+	return utils.HelpFromInterface(Settings{})
 }

--- a/modules/travisci/settings.go
+++ b/modules/travisci/settings.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/olebedev/config"
 	"github.com/wtfutil/wtf/cfg"
+	"github.com/wtfutil/wtf/utils"
 )
 
 const (
@@ -39,4 +40,8 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 		Service(settings.baseURL).Load()
 
 	return &settings
+}
+
+func (widget *Widget) ConfigText() string {
+	return utils.HelpFromInterface(Settings{})
 }

--- a/modules/twitch/settings.go
+++ b/modules/twitch/settings.go
@@ -59,3 +59,7 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	}
 	return &settings
 }
+
+func (widget *Widget) ConfigText() string {
+	return utils.HelpFromInterface(Settings{})
+}

--- a/modules/twitter/settings.go
+++ b/modules/twitter/settings.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/olebedev/config"
 	"github.com/wtfutil/wtf/cfg"
+	"github.com/wtfutil/wtf/utils"
 )
 
 const (
@@ -36,4 +37,8 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	settings.SetDocumentationPath("twitter/tweets")
 
 	return &settings
+}
+
+func (widget *Widget) ConfigText() string {
+	return utils.HelpFromInterface(Settings{})
 }

--- a/modules/twitterstats/settings.go
+++ b/modules/twitterstats/settings.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/olebedev/config"
 	"github.com/wtfutil/wtf/cfg"
+	"github.com/wtfutil/wtf/utils"
 )
 
 const (
@@ -35,4 +36,8 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	settings.SetDocumentationPath("twitter/stats")
 
 	return &settings
+}
+
+func (widget *Widget) ConfigText() string {
+	return utils.HelpFromInterface(Settings{})
 }

--- a/modules/updown/settings.go
+++ b/modules/updown/settings.go
@@ -33,3 +33,7 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 
 	return &settings
 }
+
+func (widget *Widget) ConfigText() string {
+	return utils.HelpFromInterface(Settings{})
+}

--- a/modules/uptimekuma/settings.go
+++ b/modules/uptimekuma/settings.go
@@ -3,6 +3,7 @@ package uptimekuma
 import (
 	"github.com/olebedev/config"
 	"github.com/wtfutil/wtf/cfg"
+	"github.com/wtfutil/wtf/utils"
 )
 
 const (
@@ -26,4 +27,8 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	}
 
 	return &settings
+}
+
+func (widget *Widget) ConfigText() string {
+	return utils.HelpFromInterface(Settings{})
 }

--- a/modules/uptimerobot/settings.go
+++ b/modules/uptimerobot/settings.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/olebedev/config"
 	"github.com/wtfutil/wtf/cfg"
+	"github.com/wtfutil/wtf/utils"
 )
 
 const (
@@ -34,4 +35,8 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 		Service("https://api.uptimerobot.com").Load()
 
 	return &settings
+}
+
+func (widget *Widget) ConfigText() string {
+	return utils.HelpFromInterface(Settings{})
 }

--- a/modules/urlcheck/settings.go
+++ b/modules/urlcheck/settings.go
@@ -3,6 +3,7 @@ package urlcheck
 import (
 	"github.com/olebedev/config"
 	"github.com/wtfutil/wtf/cfg"
+	"github.com/wtfutil/wtf/utils"
 )
 
 const (
@@ -25,4 +26,8 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	}
 	settings.urls = cfg.ParseAsMapOrList(ymlConfig, "urls")
 	return &settings
+}
+
+func (widget *Widget) ConfigText() string {
+	return utils.HelpFromInterface(Settings{})
 }

--- a/modules/victorops/settings.go
+++ b/modules/victorops/settings.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/olebedev/config"
 	"github.com/wtfutil/wtf/cfg"
+	"github.com/wtfutil/wtf/utils"
 )
 
 const (
@@ -32,4 +33,8 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	cfg.ModuleSecret(name, globalConfig, &settings.apiKey).Load()
 
 	return &settings
+}
+
+func (widget *Widget) ConfigText() string {
+	return utils.HelpFromInterface(Settings{})
 }

--- a/modules/zendesk/settings.go
+++ b/modules/zendesk/settings.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/olebedev/config"
 	"github.com/wtfutil/wtf/cfg"
+	"github.com/wtfutil/wtf/utils"
 )
 
 const (
@@ -34,4 +35,8 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	cfg.ModuleSecret(name, globalConfig, &settings.apiKey).Load()
 
 	return &settings
+}
+
+func (widget *Widget) ConfigText() string {
+	return utils.HelpFromInterface(Settings{})
 }


### PR DESCRIPTION
Currently, `wtf -m=<module>` lists only _common_ settings for all modules except for the `git` module.

This pull requests adds a `ConfigText()` function to all modules that define at least one additional (_module-specific_) setting.