### PR TITLE
Feedreader: Add aliases option for custom feed names

### DIFF
--- a/modules/feedreader/settings.go
+++ b/modules/feedreader/settings.go
@@ -29,6 +29,7 @@ type Settings struct {
 	colors
 
 	feeds           []string        `help:"An array of RSS and Atom feed URLs"`
+	aliases         []string        `help:"An array of feed name aliases (should be the same length as feeds)"`
 	feedLimit       int             `help:"The maximum number of stories to display for each feed"`
 	showSource      bool            `help:"Wether or not to show feed source in front of item titles." values:"true or false" optional:"true" default:"true"`
 	showPublishDate bool            `help:"Wether or not to show publish date in front of item titles." values:"true or false" optional:"true" default:"false"`
@@ -43,6 +44,7 @@ func NewSettingsFromYAML(name string, ymlConfig, globalConfig *config.Config) *S
 	settings := &Settings{
 		Common:          cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 		feeds:           utils.ToStrs(ymlConfig.UList("feeds")),
+		aliases:         utils.ToStrs(ymlConfig.UList("aliases")),
 		feedLimit:       ymlConfig.UInt("feedLimit", -1),
 		showSource:      ymlConfig.UBool("showSource", true),
 		showPublishDate: ymlConfig.UBool("showPublishDate", false),

--- a/modules/feedreader/widget.go
+++ b/modules/feedreader/widget.go
@@ -93,11 +93,15 @@ func NewWidget(tviewApp *tview.Application, redrawChan chan bool, pages *tview.P
 /* -------------------- Exported Functions -------------------- */
 
 // Fetch retrieves RSS and Atom feed data
-func (widget *Widget) Fetch(feedURLs []string) ([]*FeedItem, error) {
+func (widget *Widget) Fetch(feedURLs, aliases []string) ([]*FeedItem, error) {
 	var data []*FeedItem
 
-	for _, feedURL := range feedURLs {
-		feedItems, err := widget.fetchForFeed(feedURL)
+	for i, feedURL := range feedURLs {
+		var alias string
+		if aliases != nil && i < len(aliases) {
+			alias = aliases[i]
+		}
+		feedItems, err := widget.fetchForFeed(feedURL, alias)
 		if err != nil {
 			return nil, err
 		}
@@ -112,7 +116,7 @@ func (widget *Widget) Fetch(feedURLs []string) ([]*FeedItem, error) {
 
 // Refresh updates the data in the widget
 func (widget *Widget) Refresh() {
-	feedItems, err := widget.Fetch(widget.settings.feeds)
+	feedItems, err := widget.Fetch(widget.settings.feeds, widget.settings.aliases)
 	if err != nil {
 		widget.err = err
 		widget.stories = nil
@@ -133,7 +137,7 @@ func (widget *Widget) Render() {
 
 /* -------------------- Unexported Functions -------------------- */
 
-func (widget *Widget) fetchForFeed(feedURL string) ([]*FeedItem, error) {
+func (widget *Widget) fetchForFeed(feedURL, alias string) ([]*FeedItem, error) {
 	var (
 		feed *gofeed.Feed
 		err  error
@@ -166,6 +170,9 @@ func (widget *Widget) fetchForFeed(feedURL string) ([]*FeedItem, error) {
 			item:        gofeedItem,
 			sourceTitle: feed.Title,
 			viewed:      false,
+		}
+		if alias != "" {
+			feedItem.sourceTitle = alias
 		}
 
 		feedItems = append(feedItems, feedItem)


### PR DESCRIPTION
Some news feeds have super long titles which don't leave much space for the actual message. Hiding them is sometimes not desired when you have multiple feeds in your widget.

This pull request adds a new `aliases` setting.

### Example usage:

```yaml
    feedreader:
      feeds:
        - https://www.tagesschau.de/index~rss2.xml
        - https://www.heise.de/rss/heise-atom.xml
      aliases:
        - "tagesschau"
        - "heise     "
      showPublishDate: true
```

### Before:

<img width="1068" height="257" alt="2026-02-12 14 07 40 1068x257 Region" src="https://github.com/user-attachments/assets/7e360ede-de6d-447c-86bf-376583d501b8" />

### After (with aliases):

<img width="1073" height="260" alt="2026-02-12 14 06 55 1073x260 Region" src="https://github.com/user-attachments/assets/f24cb876-e341-4002-9476-76a3590e3a31" />