### PR TITLE
Fixes for todo module highlighting.

### DIFF
--- a/modules/gcal/display.go
+++ b/modules/gcal/display.go
@@ -21,7 +21,7 @@ func (widget *Widget) content() (string, string, bool) {
 		return title, widget.err.Error(), true
 	}
 
-	if (calEvents == nil) || (len(calEvents) == 0) {
+	if len(calEvents) == 0 {
 		return title, "No calendar events", false
 	}
 

--- a/modules/todo/display.go
+++ b/modules/todo/display.go
@@ -122,7 +122,11 @@ func (widget *Widget) RowColor(idx int, hidden int, checked bool) string {
 	}
 
 	if checked {
-		return widget.settings.Colors.Checked
+		return fmt.Sprintf(
+			"%s:%s",
+			widget.settings.Colors.Checked,
+			widget.CommonSettings().Colors.Background,
+		)
 	} else {
 		return widget.CommonSettings().RowColor(idx - hidden)
 	}
@@ -133,7 +137,7 @@ func (widget *Widget) formattedItemLine(idx int, hidden int, currItem *checklist
 
 	todoDate := currItem.Date
 	row := fmt.Sprintf(
-		` [%s]|%s| `,
+		`[%s] |%s| `,
 		rowColor,
 		currItem.CheckMark(),
 	)

--- a/modules/uptimekuma/widget.go
+++ b/modules/uptimekuma/widget.go
@@ -141,14 +141,14 @@ func (widget *Widget) content() string {
 	if statusCounts[DOWN] == 0 {
 		downColor = "green"
 	}
-	builder.WriteString(fmt.Sprintf("[%s] Up: [green]%d", textColor, statusCounts[UP]))
-	builder.WriteString(fmt.Sprintf("[%s] (%.1f%%)", textColor, avgUptime))
-	builder.WriteString(fmt.Sprintf("[%s], Down: [%s]%d", textColor, downColor, statusCounts[DOWN]))
+	fmt.Fprintf(&builder, "[%s] Up: [green]%d", textColor, statusCounts[UP])
+	fmt.Fprintf(&builder, "[%s] (%.1f%%)", textColor, avgUptime)
+	fmt.Fprintf(&builder, "[%s], Down: [%s]%d", textColor, downColor, statusCounts[DOWN])
 	if statusCounts[MAINTENANCE] > 0 {
-		builder.WriteString(fmt.Sprintf("[%s], Maint: [%s]%d", textColor, "blue", statusCounts[MAINTENANCE]))
+		fmt.Fprintf(&builder, "[%s], Maint: [%s]%d", textColor, "blue", statusCounts[MAINTENANCE])
 	}
 	if statusCounts[PENDING] > 0 {
-		builder.WriteString(fmt.Sprintf("[%s], Pend: [%s]%d", textColor, "orange", statusCounts[PENDING]))
+		fmt.Fprintf(&builder, "[%s], Pend: [%s]%d", textColor, "orange", statusCounts[PENDING])
 	}
 
 	if widget.statusData.Incident != nil {
@@ -157,9 +157,9 @@ func (widget *Widget) content() string {
 		created, err := time.Parse(layout, widget.statusData.Incident.CreatedDate)
 		if err == nil {
 			hoursAgo := time.Since(created).Hours()
-			builder.WriteString(fmt.Sprintf("[%s]\n Incident: %.0fh ago", textColor, hoursAgo))
+			fmt.Fprintf(&builder, "[%s]\n Incident: %.0fh ago", textColor, hoursAgo)
 		} else {
-			builder.WriteString(fmt.Sprintf("[%s]\n Incident [unparsable date]", textColor))
+			fmt.Fprintf(&builder, "[%s]\n Incident [unparsable date]", textColor)
 		}
 	}
 

--- a/view/bargraph.go
+++ b/view/bargraph.go
@@ -86,16 +86,15 @@ func BuildStars(data []Bar, maxStars int, starChar string) string {
 		}
 
 		//write the line
-		_, err := buffer.WriteString(
-			fmt.Sprintf(
-				"%s%s[[%s]%s[default]%s] %s\n",
-				bar.Label,
-				strings.Repeat(" ", longestLabel-len(bar.Label)),
-				labelColor,
-				strings.Repeat(starChar, starCount),
-				strings.Repeat(" ", maxStars-starCount),
-				label,
-			),
+		_, err := fmt.Fprintf(
+			&buffer,
+			"%s%s[[%s]%s[default]%s] %s\n",
+			bar.Label,
+			strings.Repeat(" ", longestLabel-len(bar.Label)),
+			labelColor,
+			strings.Repeat(starChar, starCount),
+			strings.Repeat(" ", maxStars-starCount),
+			label,
 		)
 		if err != nil {
 			return ""


### PR DESCRIPTION
Space at the beginning of item was placed before the row color formatting which caused the leading space on the next line to be highlighted. 

Added background color for checked item to prevent highlight leaking. Tried several different ways, but ended up with the same thing @hxw did in his patch.

Fixes #1807
