### PR TITLE
mod: Feeds, pad aliases

### DIFF
--- a/modules/feedreader/widget.go
+++ b/modules/feedreader/widget.go
@@ -94,13 +94,23 @@ func NewWidget(tviewApp *tview.Application, redrawChan chan bool, pages *tview.P
 
 // Fetch retrieves RSS and Atom feed data
 func (widget *Widget) Fetch(feedURLs, aliases []string) ([]*FeedItem, error) {
+
 	var data []*FeedItem
 
+	// Allows us to right-pad alias so that the column lines up.
+	var aliasMaxChar int
+	for _, alias := range aliases {
+		aliasMaxChar = max(aliasMaxChar, len(alias))
+	}
+
 	for i, feedURL := range feedURLs {
+
 		var alias string
+
 		if aliases != nil && i < len(aliases) {
-			alias = aliases[i]
+			alias = fmt.Sprintf("%-*s", aliasMaxChar, aliases[i])
 		}
+
 		feedItems, err := widget.fetchForFeed(feedURL, alias)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
To add on to the new feature in #2000, this PR auto-pads the alias so that the user doesn't need to do it.

I was thinking of doing this for the feed titles as well, aka when an alias isn't used, but I decided against it. They are likely to be much longer and variable. With that, some titles might be padded by a lot, causing a lot of room to be taken up. We can always revisit.

Closes: #2048