### PR TITLE
Make mempool fee API URL configurable

### DIFF
--- a/modules/cryptocurrency/mempool/settings.go
+++ b/modules/cryptocurrency/mempool/settings.go
@@ -3,18 +3,20 @@ package mempool
 import (
 	"github.com/olebedev/config"
 	"github.com/wtfutil/wtf/cfg"
+	"github.com/wtfutil/wtf/utils"
 )
 
 const (
 	defaultFocusable = false
 	defaultTitle     = "mempool"
+	defaultAPIURL    = "https://mempool.space/api/v1/fees/recommended"
 )
 
 // Settings defines the configuration properties for this module
 type Settings struct {
 	common *cfg.Common
 
-	// Define your settings attributes here
+	apiURL string `help:"Fee recommendation endpoint URL." optional:"true"`
 }
 
 // NewSettingsFromYAML creates a new settings instance from a YAML config block
@@ -22,8 +24,12 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	settings := Settings{
 		common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
-		// Configure your settings attributes here. See http://github.com/olebedev/config for type details
+		apiURL: ymlConfig.UString("apiURL", defaultAPIURL),
 	}
 
 	return &settings
+}
+
+func (widget *Widget) ConfigText() string {
+	return utils.HelpFromInterface(Settings{})
 }

--- a/modules/cryptocurrency/mempool/widget.go
+++ b/modules/cryptocurrency/mempool/widget.go
@@ -44,23 +44,22 @@ func (widget *Widget) Refresh() {
 /* -------------------- Unexported Functions -------------------- */
 
 func (widget *Widget) content() string {
-	return getBTCTxFees()
+	return getBTCTxFees(widget.settings.apiURL)
 }
 
-func getBTCTxFees() string {
-	url := "https://mempool.space/api/v1/fees/recommended"
-	resp, err := http.Get(url)
+func getBTCTxFees(apiURL string) string {
+	resp, err := http.Get(apiURL)
 	if err != nil {
-		logger.Log(fmt.Sprintf("[mempool] Error: Failed to make request to mempool. Reason: %s", err))
-		return "[mempool] error callng mempool API"
+		logger.Log(fmt.Sprintf("[mempool] Error: Failed to make request to fee API. Reason: %s", err))
+		return "[mempool] error calling fee API"
 	}
 	defer resp.Body.Close()
 
 	parsed := feeStruct{}
 	err = utils.ParseJSON(&parsed, resp.Body)
 	if err != nil {
-		logger.Log(fmt.Sprintf("[mempool] Error: Failed to decode JSON data from mempool. Reason: %s", err))
-		return "[mempool] error parsing JSON from mempool API"
+		logger.Log(fmt.Sprintf("[mempool] Error: Failed to decode JSON data from fee API. Reason: %s", err))
+		return "[mempool] error parsing JSON from fee API"
 	}
 
 	finalStr := ""


### PR DESCRIPTION
This keeps the mempool widget defaulting to mempool.space, but lets users set an alternate compatible fee endpoint with `apiURL`.

I work on Satoshi API, so the concrete use case I tested this against is a mempool-compatible hosted fee endpoint:

`https://bitcoinsapi.com/api/v1/compat/mempool/fees/recommended`

The change is intentionally generic: no default changes, no new dependency, and self-hosted mempool.space-compatible URLs work the same way.

Verification:
- `go test ./modules/cryptocurrency/mempool` not run locally because `go`/`gofmt` are not installed in this Windows environment.
- `git diff --check` passed.