### PR TITLE
chore: Adjust Dependabot settings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,14 +3,14 @@ updates:
 - package-ecosystem: gomod
   directory: "/"
   schedule:
-    interval: daily
-  open-pull-requests-limit: 10
+    interval: weekly
+  open-pull-requests-limit: 12
   assignees:
   - FelicianoTech
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:
-    interval: daily
-  open-pull-requests-limit: 10
+    interval: weekly
+  open-pull-requests-limit: 12
   assignees:
   - FelicianoTech


### PR DESCRIPTION
Allow for slightly more open PRs but reduce the frequency to a week.
