### PR TITLE
UptimeRobot: colorize percentage to work with both dark and light bg

### DIFF
--- a/modules/uptimerobot/widget.go
+++ b/modules/uptimerobot/widget.go
@@ -5,11 +5,14 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 
 	"github.com/rivo/tview"
+	"github.com/wtfutil/wtf/utils"
 	"github.com/wtfutil/wtf/view"
 )
 
@@ -111,8 +114,7 @@ func (widget *Widget) contentFrom(monitors []Monitor) string {
 			prefix += "[yellow] ~ "
 		}
 
-		str += fmt.Sprintf(`%s%s [gray](%s)[white]
-`,
+		str += fmt.Sprintf("%s%s [white](%s)\n",
 			prefix,
 			monitor.Name,
 			formatUptimes(monitor.Uptime),
@@ -124,17 +126,18 @@ func (widget *Widget) contentFrom(monitors []Monitor) string {
 
 func formatUptimes(str string) string {
 	splits := strings.Split(str, "-")
-	str = ""
-	for i, s := range splits {
-		if i != 0 {
-			str += "|"
+	parts := make([]string, 0, len(splits))
+	for _, s := range splits {
+		if f, err := strconv.ParseFloat(s, 64); err == nil {
+			parts = append(parts, utils.ColorizeUptimePercent(math.Round(f*10)/10)+"%")
+		} else {
+			s = s[:5]
+			s = strings.TrimRight(s, "0")
+			s = strings.TrimRight(s, ".") + "%"
+			parts = append(parts, s)
 		}
-		s = s[:5]
-		s = strings.TrimRight(s, "0")
-		s = strings.TrimRight(s, ".") + "%"
-		str += s
 	}
-	return str
+	return strings.Join(parts, "|")
 }
 
 type Monitor struct {

--- a/modules/uptimerobot/widget.go
+++ b/modules/uptimerobot/widget.go
@@ -129,7 +129,7 @@ func formatUptimes(str string) string {
 	parts := make([]string, 0, len(splits))
 	for _, s := range splits {
 		if f, err := strconv.ParseFloat(s, 64); err == nil {
-			parts = append(parts, utils.ColorizeUptimePercent(math.Round(f*10)/10)+"%")
+			parts = append(parts, utils.ColorizeUptimePercent(math.Round(f*100)/100)+"%")
 		} else {
 			s = s[:5]
 			s = strings.TrimRight(s, "0")

--- a/utils/colors.go
+++ b/utils/colors.go
@@ -20,3 +20,23 @@ func ColorizePercent(percent float64) string {
 
 	return fmt.Sprintf("[%s]%v[%s]", color, percent, "white")
 }
+
+// ColorizeUptimePercent colorizes uptime percentages where near-100% is expected.
+func ColorizeUptimePercent(percent float64) string {
+	var color string
+
+	switch {
+	case percent >= 99:
+		color = "green"
+	case percent >= 95:
+		color = "yellow"
+	case percent >= 80:
+		color = "orange"
+	case percent < 0:
+		color = "grey"
+	default:
+		color = "red"
+	}
+
+	return fmt.Sprintf("[%s]%v[%s]", color, percent, "white")
+}

--- a/utils/colors_test.go
+++ b/utils/colors_test.go
@@ -41,3 +41,44 @@ func Test_ColorizePercent(t *testing.T) {
 		})
 	}
 }
+
+func Test_ColorizeUptimePercent(t *testing.T) {
+	tests := []struct {
+		name     string
+		percent  float64
+		expected string
+	}{
+		{
+			name:     "with excellent uptime",
+			percent:  99,
+			expected: "[green]99[white]",
+		},
+		{
+			name:     "with good uptime",
+			percent:  95,
+			expected: "[yellow]95[white]",
+		},
+		{
+			name:     "with acceptable uptime",
+			percent:  80,
+			expected: "[orange]80[white]",
+		},
+		{
+			name:     "with poor uptime",
+			percent:  50,
+			expected: "[red]50[white]",
+		},
+		{
+			name:     "with negative percent",
+			percent:  -1,
+			expected: "[grey]-1[white]",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := ColorizeUptimePercent(tt.percent)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
The problem is that right now UptimeRobot shows uptime percentages in gray, which actually show up as black
when I have a dark background, making it tough to read.

I figured we might as well color-code the percentages, just as it's done for the `Charge` field
of the Power module, which makes the text readable on light and dark background.