### PR TITLE
URLcheck: redact password in UI

### DIFF
--- a/modules/urlcheck/urlResult.go
+++ b/modules/urlcheck/urlResult.go
@@ -14,6 +14,22 @@ type urlResult struct {
 	IsValid       bool
 }
 
+// DisplayURL returns the URL with any Basic Auth password redacted.
+func (ur urlResult) DisplayURL() string {
+	u, err := url.Parse(ur.Url)
+	if err != nil || u.User == nil {
+		return ur.Url
+	}
+
+	username := u.User.Username()
+	if _, hasPassword := u.User.Password(); !hasPassword {
+		return ur.Url
+	}
+
+	u.User = url.UserPassword(username, "xxxxx")
+	return u.String()
+}
+
 // Create a UrlResult instance from an urls occurence in the settings
 func newUrlResult(urlString string) *urlResult {
 

--- a/modules/urlcheck/urlResult.go
+++ b/modules/urlcheck/urlResult.go
@@ -14,8 +14,8 @@ type urlResult struct {
 	IsValid       bool
 }
 
-// DisplayURL returns the URL with any Basic Auth password redacted.
-func (ur urlResult) DisplayURL() string {
+// DisplayUrl returns the URL with any Basic Auth password redacted.
+func (ur urlResult) DisplayUrl() string {
 	u, err := url.Parse(ur.Url)
 	if err != nil || u.User == nil {
 		return ur.Url

--- a/modules/urlcheck/urlResult_test.go
+++ b/modules/urlcheck/urlResult_test.go
@@ -44,3 +44,51 @@ func Test_newUrlResult(t *testing.T) {
 		})
 	}
 }
+
+func Test_urlResult_DisplayURL(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		want string
+	}{
+		{
+			name: "no_auth",
+			url:  "https://example.com/path?var=1",
+			want: "https://example.com/path?var=1",
+		},
+		{
+			name: "username_only",
+			url:  "https://user@example.com/path",
+			want: "https://user@example.com/path",
+		},
+		{
+			name: "username_and_password",
+			url:  "https://user:secret@example.com/path",
+			want: "https://user:xxxxx@example.com/path",
+		},
+		{
+			name: "username_and_empty_password",
+			url:  "https://user:@example.com/path",
+			want: "https://user:xxxxx@example.com/path",
+		},
+		{
+			name: "encoded_credentials",
+			url:  "https://user%40example.com:s%40cret@example.com/path",
+			want: "https://user%40example.com:xxxxx@example.com/path",
+		},
+		{
+			name: "invalid_url",
+			url:  "http://not\nurl.com?var=1",
+			want: "http://not\nurl.com?var=1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := urlResult{Url: tt.url}
+
+			assert.Equal(t, tt.want, got.DisplayURL())
+			assert.Equal(t, tt.url, got.Url)
+		})
+	}
+}

--- a/modules/urlcheck/urlResult_test.go
+++ b/modules/urlcheck/urlResult_test.go
@@ -45,7 +45,7 @@ func Test_newUrlResult(t *testing.T) {
 	}
 }
 
-func Test_urlResult_DisplayURL(t *testing.T) {
+func Test_urlResult_DisplayUrl(t *testing.T) {
 	tests := []struct {
 		name string
 		url  string
@@ -87,7 +87,7 @@ func Test_urlResult_DisplayURL(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := urlResult{Url: tt.url}
 
-			assert.Equal(t, tt.want, got.DisplayURL())
+			assert.Equal(t, tt.want, got.DisplayUrl())
 			assert.Equal(t, tt.url, got.Url)
 		})
 	}

--- a/modules/urlcheck/view.go
+++ b/modules/urlcheck/view.go
@@ -16,7 +16,7 @@ func (widget *Widget) PrepareTemplate() {
 	widget.templateString = "{{range .}} " +
 		"{{. | getResultColor}}" +
 		"[{{if eq .ResultCode 999}}---{{else}}{{.ResultCode}}{{end}}]" +
-		textColor + "{{.DisplayURL}}" +
+		textColor + "{{.DisplayUrl}}" +
 		labelColor + "{{.ResultMessage}}" +
 		"\n{{end}}"
 

--- a/modules/urlcheck/view.go
+++ b/modules/urlcheck/view.go
@@ -16,7 +16,7 @@ func (widget *Widget) PrepareTemplate() {
 	widget.templateString = "{{range .}} " +
 		"{{. | getResultColor}}" +
 		"[{{if eq .ResultCode 999}}---{{else}}{{.ResultCode}}{{end}}]" +
-		textColor + "{{.Url}}" +
+		textColor + "{{.DisplayURL}}" +
 		labelColor + "{{.ResultMessage}}" +
 		"\n{{end}}"
 


### PR DESCRIPTION
Sometimes URLs need a password for basic authentication; in these cases, we want to redact the password in the UI