### PR TITLE
Add [39m as a possible color reset code.

### DIFF
--- a/wtf/colors.go
+++ b/wtf/colors.go
@@ -270,7 +270,7 @@ var colorMap = map[int]string{
 func ASCIItoTviewColors(text string) string {
 	boldRegExp := regexp.MustCompile(`\033\[1m`)
 	fgColorRegExp := regexp.MustCompile(`\033\[38;5;(?P<color>\d+);*\d*m`)
-	resColorRegExp := regexp.MustCompile(`\033\[0m`)
+	resColorRegExp := regexp.MustCompile(`\033\[(0|39)m`)
 
 	return resColorRegExp.ReplaceAllString(
 		boldRegExp.ReplaceAllString(


### PR DESCRIPTION
For a while now I've had an issue with the lunar phase module that the ANSI escape code `[39m` would show up between every character in the output. The colors worked fine, but the code was still there. Nothing in the module code seemed particularly problematic to me so I just added the this code to the possible matches in the `resColorRegExp`.