### PR TITLE
Replace pkg/errors with fmt.Errorf from stdlib

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/olebedev/config v0.0.0-20190528211619-364964f3a8e4
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/piquette/finance-go v1.1.0
-	github.com/pkg/errors v0.9.1
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pkg/profile v1.7.0
 	github.com/radovskyb/watcher v1.0.7
 	github.com/rivo/tview v0.42.0

--- a/modules/azuredevops/client.go
+++ b/modules/azuredevops/client.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	azrBuild "github.com/microsoft/azure-devops-go-api/azuredevops/build"
-	"github.com/pkg/errors"
 )
 
 func (widget *Widget) getBuildStats() string {
@@ -14,7 +13,7 @@ func (widget *Widget) getBuildStats() string {
 	top := widget.settings.maxRows
 	builds, err := widget.cli.GetBuilds(widget.ctx, azrBuild.GetBuildsArgs{Project: &projName, StatusFilter: &statusFilter, Top: &top})
 	if err != nil {
-		return errors.Wrap(err, "could not get builds").Error()
+		return fmt.Errorf("could not get builds: %w", err).Error()
 	}
 
 	result := ""

--- a/modules/azuredevops/widget.go
+++ b/modules/azuredevops/widget.go
@@ -6,7 +6,6 @@ import (
 
 	azr "github.com/microsoft/azure-devops-go-api/azuredevops"
 	azrBuild "github.com/microsoft/azure-devops-go-api/azuredevops/build"
-	"github.com/pkg/errors"
 	"github.com/rivo/tview"
 	"github.com/wtfutil/wtf/view"
 )
@@ -31,7 +30,7 @@ func NewWidget(tviewApp *tview.Application, redrawChan chan bool, pages *tview.P
 
 	cli, err := azrBuild.NewClient(ctx, connection)
 	if err != nil {
-		widget.displayBuffer = errors.Wrap(err, "could not create client 2").Error()
+		widget.displayBuffer = fmt.Errorf("could not create client: %w", err).Error()
 	} else {
 		widget.cli = cli
 		widget.ctx = ctx

--- a/modules/docker/client.go
+++ b/modules/docker/client.go
@@ -9,18 +9,17 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/dustin/go-humanize"
-	"github.com/pkg/errors"
 )
 
 func (widget *Widget) getSystemInfo() string {
 	info, err := widget.cli.Info(context.Background())
 	if err != nil {
-		return errors.Wrap(err, "could not get docker system info").Error()
+		return fmt.Errorf("could not get docker system info: %w", err).Error()
 	}
 
 	diskUsage, err := widget.cli.DiskUsage(context.Background(), types.DiskUsageOptions{})
 	if err != nil {
-		return errors.Wrap(err, "could not get disk usage").Error()
+		return fmt.Errorf("could not get disk usage: %w", err).Error()
 	}
 
 	var duContainer int64
@@ -111,7 +110,7 @@ func (widget *Widget) getSystemInfo() string {
 func (widget *Widget) getContainerStates() string {
 	cntrs, err := widget.cli.ContainerList(context.Background(), container.ListOptions{All: true})
 	if err != nil {
-		return errors.Wrapf(err, " could not get container list").Error()
+		return fmt.Errorf("could not get container list: %w", err).Error()
 	}
 
 	if len(cntrs) == 0 {

--- a/modules/docker/widget.go
+++ b/modules/docker/widget.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/docker/docker/client"
-	"github.com/pkg/errors"
 	"github.com/rivo/tview"
 	"github.com/wtfutil/wtf/view"
 )
@@ -26,7 +25,7 @@ func NewWidget(tviewApp *tview.Application, redrawChan chan bool, pages *tview.P
 
 	cli, err := client.NewClientWithOpts(client.FromEnv)
 	if err != nil {
-		widget.displayBuffer = errors.Wrap(err, "could not create client").Error()
+		widget.displayBuffer = fmt.Errorf("could not create client: %w", err).Error()
 	} else {
 		widget.cli = cli
 	}


### PR DESCRIPTION
## Summary

Remove direct dependency on the archived `github.com/pkg/errors` package by replacing `errors.Wrap`/`errors.Wrapf` calls with `fmt.Errorf` using the `%w` verb (available since Go 1.13).

## Changes

- `modules/docker/client.go` — replaced 3 `errors.Wrap`/`errors.Wrapf` calls
- `modules/docker/widget.go` — replaced 1 `errors.Wrap` call
- `modules/azuredevops/client.go` — replaced 1 `errors.Wrap` call
- `modules/azuredevops/widget.go` — replaced 1 `errors.Wrap` call

All `"github.com/pkg/errors"` imports removed from these files. `go mod tidy` run to clean up.

## Note on indirect dependency

`pkg/errors` remains as an `// indirect` dependency in `go.mod` because two upstream libraries still use it:

- **`bitbucket.org/mikehouston/asana-go`** (used by `modules/asana`) — the fork at `github.com/kothar/asana-go` also has this issue
- **`github.com/adlio/trello`** (used by `modules/todo_plus`) — `pkg/errors` has been removed on `main` but no release has been tagged after v1.12.0

Once these upstream dependencies release versions without `pkg/errors`, updating them in `go.mod` will fully eliminate the indirect dependency.

Fixes #1734