### PR TITLE
fix: prevent UI deadlock in GitHub widget

### DIFF
--- a/modules/github/display.go
+++ b/modules/github/display.go
@@ -12,7 +12,6 @@ func (widget *Widget) display() {
 
 func (widget *Widget) content() (string, string, bool) {
 	repo := widget.currentGithubRepo()
-	username := widget.settings.username
 
 	// Choses the correct place to scroll to when changing sources
 	if len(widget.View.GetHighlights()) > 0 {
@@ -21,14 +20,16 @@ func (widget *Widget) content() (string, string, bool) {
 		widget.View.ScrollToBeginning()
 	}
 
+	if repo == nil {
+		return widget.CommonSettings().Title, " GitHub repo data is unavailable ", false
+	}
+
 	// initial maxItems count
 	widget.Items = make([]int, 0)
-	widget.SetItemCount(len(repo.myReviewRequests((username))))
+	widget.SetItemCount(len(repo.CachedMyReviewRequests))
 
 	title := fmt.Sprintf("%s - %s", widget.CommonSettings().Title, widget.title(repo))
-	if repo == nil {
-		return title, " GitHub repo data is unavailable ", false
-	} else if repo.Err != nil {
+	if repo.Err != nil {
 		return title, repo.Err.Error(), true
 	}
 
@@ -40,22 +41,22 @@ func (widget *Widget) content() (string, string, bool) {
 	}
 	if widget.settings.showOpenReviewRequests {
 		str += fmt.Sprintf("\n [%s]Open Review Requests[white]\n", widget.settings.Colors.Subheading)
-		str += widget.displayMyReviewRequests(repo, username)
+		str += widget.displayMyReviewRequests(repo)
 	}
 	if widget.settings.showMyPullRequests {
 		str += fmt.Sprintf("\n [%s]My Pull Requests[white]\n", widget.settings.Colors.Subheading)
-		str += widget.displayMyPullRequests(repo, username)
+		str += widget.displayMyPullRequests(repo)
 	}
 	for _, customQuery := range widget.settings.customQueries {
 		str += fmt.Sprintf("\n [%s]%s[white]\n", widget.settings.Colors.Subheading, customQuery.title)
-		str += widget.displayCustomQuery(repo, customQuery.filter, customQuery.perPage)
+		str += widget.displayCustomQuery(repo, customQuery.filter)
 	}
 
 	return title, str, false
 }
 
-func (widget *Widget) displayMyPullRequests(repo *Repo, username string) string {
-	prs := repo.myPullRequests(username, widget.settings.enableStatus)
+func (widget *Widget) displayMyPullRequests(repo *Repo) string {
+	prs := repo.CachedMyPullRequests
 
 	prLength := len(prs)
 
@@ -77,8 +78,8 @@ func (widget *Widget) displayMyPullRequests(repo *Repo, username string) string 
 	return str
 }
 
-func (widget *Widget) displayCustomQuery(repo *Repo, filter string, perPage int) string {
-	res := repo.customIssueQuery(filter, perPage)
+func (widget *Widget) displayCustomQuery(repo *Repo, filter string) string {
+	res := repo.CachedCustomQueries[filter]
 
 	if res == nil {
 		return " [grey]Invalid Query[white]\n"
@@ -104,8 +105,8 @@ func (widget *Widget) displayCustomQuery(repo *Repo, filter string, perPage int)
 	return str
 }
 
-func (widget *Widget) displayMyReviewRequests(repo *Repo, username string) string {
-	prs := repo.myReviewRequests(username)
+func (widget *Widget) displayMyReviewRequests(repo *Repo) string {
+	prs := repo.CachedMyReviewRequests
 
 	if len(prs) == 0 {
 		return " [grey]none[white]\n"

--- a/modules/github/github_repo.go
+++ b/modules/github/github_repo.go
@@ -3,10 +3,13 @@ package github
 import (
 	"context"
 	"fmt"
+	"time"
 
 	ghb "github.com/google/go-github/v89/github"
 	"github.com/wtfutil/wtf/utils"
 )
+
+const apiTimeout = 30 * time.Second
 
 const (
 	pullRequestsPath = "/pulls"
@@ -24,6 +27,11 @@ type Repo struct {
 	PullRequests []*ghb.PullRequest
 	RemoteRepo   *ghb.Repository
 	Err          error
+
+	// Cached display data populated during Refresh
+	CachedMyPullRequests   []*ghb.PullRequest
+	CachedMyReviewRequests []*ghb.PullRequest
+	CachedCustomQueries    map[string]*ghb.IssuesSearchResult
 }
 
 // NewGithubRepo returns a new Github Repo with a name, owner, apiKey, baseURL and uploadURL
@@ -55,17 +63,32 @@ func (repo *Repo) OpenIssues() {
 	utils.OpenFile(*repo.RemoteRepo.HTMLURL + issuesPath)
 }
 
-// Refresh reloads the github data via the Github API
-func (repo *Repo) Refresh() {
-	prs, err := repo.loadPullRequests()
+// Refresh reloads the github data via the Github API and caches display data
+func (repo *Repo) Refresh(username string, enableStatus bool, customQueries []customQuery) {
+	ctx, cancel := context.WithTimeout(context.Background(), apiTimeout)
+	defer cancel()
+
+	prs, err := repo.loadPullRequests(ctx)
 	repo.Err = err
 	repo.PullRequests = prs
 	if err != nil {
 		return
 	}
-	remote, err := repo.loadRemoteRepository()
+	remote, err := repo.loadRemoteRepository(ctx)
 	repo.Err = err
 	repo.RemoteRepo = remote
+	if err != nil {
+		return
+	}
+
+	// Pre-compute display data so content() never does HTTP
+	repo.CachedMyReviewRequests = repo.computeMyReviewRequests(username)
+	repo.CachedMyPullRequests = repo.computeMyPullRequests(ctx, username, enableStatus)
+
+	repo.CachedCustomQueries = make(map[string]*ghb.IssuesSearchResult)
+	for _, q := range customQueries {
+		repo.CachedCustomQueries[q.filter] = repo.fetchCustomIssueQuery(ctx, q.filter, q.perPage)
+	}
 }
 
 /* -------------------- Counts -------------------- */
@@ -118,7 +141,7 @@ func (repo *Repo) githubClient() (*ghb.Client, error) {
 }
 
 // myPullRequests returns a list of pull requests created by username on this repo
-func (repo *Repo) myPullRequests(username string, showStatus bool) []*ghb.PullRequest {
+func (repo *Repo) computeMyPullRequests(ctx context.Context, username string, showStatus bool) []*ghb.PullRequest {
 	prs := []*ghb.PullRequest{}
 
 	for _, pr := range repo.PullRequests {
@@ -130,7 +153,7 @@ func (repo *Repo) myPullRequests(username string, showStatus bool) []*ghb.PullRe
 	}
 
 	if showStatus {
-		prs = repo.individualPRs(prs)
+		prs = repo.individualPRs(ctx, prs)
 	}
 
 	return prs
@@ -139,7 +162,7 @@ func (repo *Repo) myPullRequests(username string, showStatus bool) []*ghb.PullRe
 // individualPRs takes a list of pull requests (presumably returned from
 // github.PullRequests.List) and fetches them individually to get more detailed
 // status info on each. see: https://developer.github.com/v3/git/#checking-mergeability-of-pull-requests
-func (repo *Repo) individualPRs(prs []*ghb.PullRequest) []*ghb.PullRequest {
+func (repo *Repo) individualPRs(ctx context.Context, prs []*ghb.PullRequest) []*ghb.PullRequest {
 	github, err := repo.githubClient()
 	if err != nil {
 		return prs
@@ -147,7 +170,7 @@ func (repo *Repo) individualPRs(prs []*ghb.PullRequest) []*ghb.PullRequest {
 
 	var ret []*ghb.PullRequest
 	for i := range prs {
-		pr, _, err := github.PullRequests.Get(context.Background(), repo.Owner, repo.Name, prs[i].GetNumber())
+		pr, _, err := github.PullRequests.Get(ctx, repo.Owner, repo.Name, prs[i].GetNumber())
 		if err != nil {
 			// worst case, just keep the original one
 			ret = append(ret, prs[i])
@@ -160,7 +183,7 @@ func (repo *Repo) individualPRs(prs []*ghb.PullRequest) []*ghb.PullRequest {
 
 // myReviewRequests returns a list of pull requests for which username has been
 // requested to do a code review
-func (repo *Repo) myReviewRequests(username string) []*ghb.PullRequest {
+func (repo *Repo) computeMyReviewRequests(username string) []*ghb.PullRequest {
 	prs := []*ghb.PullRequest{}
 
 	for _, pr := range repo.PullRequests {
@@ -174,7 +197,7 @@ func (repo *Repo) myReviewRequests(username string) []*ghb.PullRequest {
 	return prs
 }
 
-func (repo *Repo) customIssueQuery(filter string, perPage int) *ghb.IssuesSearchResult {
+func (repo *Repo) fetchCustomIssueQuery(ctx context.Context, filter string, perPage int) *ghb.IssuesSearchResult {
 	github, err := repo.githubClient()
 	if err != nil {
 		return nil
@@ -185,11 +208,11 @@ func (repo *Repo) customIssueQuery(filter string, perPage int) *ghb.IssuesSearch
 		opts.PerPage = perPage
 	}
 
-	prs, _, _ := github.Search.Issues(context.Background(), fmt.Sprintf("%s repo:%s/%s", filter, repo.Owner, repo.Name), opts)
+	prs, _, _ := github.Search.Issues(ctx, fmt.Sprintf("%s repo:%s/%s", filter, repo.Owner, repo.Name), opts)
 	return prs
 }
 
-func (repo *Repo) loadPullRequests() ([]*ghb.PullRequest, error) {
+func (repo *Repo) loadPullRequests(ctx context.Context) ([]*ghb.PullRequest, error) {
 	github, err := repo.githubClient()
 	if err != nil {
 		return nil, err
@@ -198,7 +221,7 @@ func (repo *Repo) loadPullRequests() ([]*ghb.PullRequest, error) {
 	opts := &ghb.PullRequestListOptions{}
 	opts.PerPage = 100
 
-	prs, _, err := github.PullRequests.List(context.Background(), repo.Owner, repo.Name, opts)
+	prs, _, err := github.PullRequests.List(ctx, repo.Owner, repo.Name, opts)
 
 	if err != nil {
 		return nil, err
@@ -207,14 +230,14 @@ func (repo *Repo) loadPullRequests() ([]*ghb.PullRequest, error) {
 	return prs, nil
 }
 
-func (repo *Repo) loadRemoteRepository() (*ghb.Repository, error) {
+func (repo *Repo) loadRemoteRepository(ctx context.Context) (*ghb.Repository, error) {
 	github, err := repo.githubClient()
 
 	if err != nil {
 		return nil, err
 	}
 
-	repository, _, err := github.Repositories.Get(context.Background(), repo.Owner, repo.Name)
+	repository, _, err := github.Repositories.Get(ctx, repo.Owner, repo.Name)
 
 	if err != nil {
 		return nil, err

--- a/modules/github/widget.go
+++ b/modules/github/widget.go
@@ -95,7 +95,7 @@ func (widget *Widget) Unselect() {
 // Refresh reloads the github data via the Github API and reruns the display
 func (widget *Widget) Refresh() {
 	for _, repo := range widget.GithubRepos {
-		repo.Refresh()
+		repo.Refresh(widget.settings.username, widget.settings.enableStatus, widget.settings.customQueries)
 	}
 
 	widget.display()

--- a/view/base.go
+++ b/view/base.go
@@ -164,8 +164,11 @@ func (base *Base) ShowHelp() {
 	base.pages.AddPage("help", modal, false, true)
 	base.tviewApp.SetFocus(modal)
 
-	// Tell the app to force redraw the screen
-	base.RedrawChan <- true
+	// Tell the app to force redraw the screen (non-blocking to avoid deadlock)
+	select {
+	case base.RedrawChan <- true:
+	default:
+	}
 }
 
 func (base *Base) Stop() {

--- a/view/text_widget.go
+++ b/view/text_widget.go
@@ -48,7 +48,11 @@ func (widget *TextWidget) Redraw(data func() (string, string, bool)) {
 	widget.View.SetTitle(widget.ContextualTitle(title))
 	widget.View.SetText(strings.TrimRight(content, "\n"))
 
-	widget.RedrawChan <- true
+	// Non-blocking send to avoid deadlock when multiple widgets refresh simultaneously
+	select {
+	case widget.RedrawChan <- true:
+	default:
+	}
 }
 
 /* -------------------- Unexported Functions -------------------- */


### PR DESCRIPTION
## Problem

The GitHub widget can freeze the UI due to HTTP calls happening in the display/rendering path. When keyboard handlers (`h`/`l`/`r`) trigger `content()`, it calls `myPullRequests()` → `individualPRs()` which makes N sequential HTTP requests, blocking the tview event loop. Combined with `context.Background()` (no timeouts) and a blocking `RedrawChan` send, this can lock up the entire UI.

## Fix

- **Move HTTP out of `content()`**: `Repo.Refresh()` now pre-fetches and caches all display data (`CachedMyPullRequests`, `CachedMyReviewRequests`, `CachedCustomQueries`). `content()` reads only cached fields — zero network calls.
- **Add context timeouts**: All API calls use `context.WithTimeout(30s)` instead of `context.Background()`.
- **Non-blocking RedrawChan**: `Redraw()` and `ShowHelp()` use `select`/`default` to avoid goroutine stalls when the channel buffer is full.
- **Fix nil dereference**: `repo == nil` check moved before any method calls on `repo`.

## Testing

Tested with `enableStatus: true` and multiple repositories. Source switching (`h`/`l`) is now instant and manual refresh (`r`) no longer freezes the UI.