### PR TITLE
Replace zorkian/go-datadog-api with official DataDog SDK v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/alecthomas/chroma v0.10.0
 	github.com/andygrunwald/go-gerrit v1.1.1
 	github.com/briandowns/openweathermap v0.21.1
-	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
 	github.com/chzyer/readline v1.5.1
 	github.com/creack/pty v1.1.24
 	github.com/digitalocean/godo v1.197.0
@@ -45,7 +44,6 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/wtfutil/spotigopher v0.0.0-20191127141047-7d8168fe103a
 	github.com/zmb3/spotify v1.3.0
-	github.com/zorkian/go-datadog-api v2.30.0+incompatible
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sync v0.21.0
 	golang.org/x/sys v0.46.0 // indirect
@@ -64,6 +62,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.22.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.14.0
 	github.com/Azure/azure-sdk-for-go/sdk/monitor/azquery v1.2.0
+	github.com/DataDog/datadog-api-client-go/v2 v2.62.0
 	github.com/charmbracelet/bubbles v0.21.1
 	github.com/gdamore/tcell/v2 v2.13.10
 	github.com/gopherlibs/todoist v0.1.0
@@ -81,6 +80,7 @@ require (
 	cloud.google.com/go/compute/metadata v0.9.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.7.2 // indirect
+	github.com/DataDog/zstd v1.5.2 // indirect
 	github.com/PuerkitoBio/goquery v1.8.0 // indirect
 	github.com/andybalholm/cascadia v1.3.1 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
@@ -112,6 +112,7 @@ require (
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect
+	github.com/goccy/go-json v0.10.2 // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
 	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/google/gnostic-models v0.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -25,6 +25,10 @@ github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1 h1:WJ
 github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1/go.mod h1:tCcJZ0uHAmvjsVYzEFivsRTN00oz5BEsRgQHu5JZ9WE=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.7.2 h1:RHK7bS+HQMslb1sZpAokUt+zTVmue0hKSs2C791hhzU=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.7.2/go.mod h1:HKpQxkWaGLJ+D/5H8QRpyQXA1eKjxkFlOMwck5+33Jk=
+github.com/DataDog/datadog-api-client-go/v2 v2.62.0 h1:AIe01Tyl5Y+kHCJskB4Vkw6ANjHcD45bfbi//ICmAaU=
+github.com/DataDog/datadog-api-client-go/v2 v2.62.0/go.mod h1:d3tOEgUd2kfsr9uuHQdY+nXrWp4uikgTgVCPdKNK30U=
+github.com/DataDog/zstd v1.5.2 h1:vUG4lAyuPCXO0TLbXvPv7EB7cNK1QV/luu55UHLrrn8=
+github.com/DataDog/zstd v1.5.2/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
 github.com/Masterminds/semver/v3 v3.5.0 h1:kQceYJfbupGfZOKZQg0kou0DgAKhzDg2NZPAwZ/2OOE=
 github.com/Masterminds/semver/v3 v3.5.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
@@ -47,8 +51,6 @@ github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiE
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/briandowns/openweathermap v0.21.1 h1:TPbuixuF+aGJP1mpgTNny6eUkdbvj7gqODGXkwhss48=
 github.com/briandowns/openweathermap v0.21.1/go.mod h1:0GLnknqicWxXnGi1IqoOaZIw+kIe5hkt+YM5WY3j8+0=
-github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
-github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
@@ -156,6 +158,8 @@ github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZ
 github.com/gobwas/httphead v0.1.0/go.mod h1:O/RXo79gxV8G+RqlR/otEwx4Q36zl9rqC5u12GKvMCM=
 github.com/gobwas/pool v0.2.1/go.mod h1:q8bcK0KcYlCgd9e7WYLm9LpyS+YeLd8JVDW6WezmKEw=
 github.com/gobwas/ws v1.2.1/go.mod h1:hRKAFb8wOxFROYNsT1bqfWnhX+b5MFeJM9r2ZSwg/KY=
+github.com/goccy/go-json v0.10.2 h1:CrxCmQqYDkv1z7lO7Wbh2HN93uovUHgrECaO5ZrCXAU=
+github.com/goccy/go-json v0.10.2/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/godbus/dbus v4.1.0+incompatible h1:WqqLRTsQic3apZUK9qC5sGNfXthmPXzUZ7nQPrNITa4=
 github.com/godbus/dbus v4.1.0+incompatible/go.mod h1:/YcGZj5zSblfDWMMoOzV4fas9FZnQYTkDnsGvmh2Grw=
 github.com/golang-jwt/jwt/v4 v4.5.2 h1:YtQM7lnr8iZ+j5q71MGKkNw9Mn7AjHM68uc9g5fXeUI=
@@ -367,8 +371,6 @@ github.com/yusufpapurcu/wmi v1.2.2 h1:KBNDSne4vP5mbSWnJbO+51IMOXJB67QiYCSBrubbPR
 github.com/yusufpapurcu/wmi v1.2.2/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 github.com/zmb3/spotify v1.3.0 h1:6Z2F1IMx0Hviq/dpf8nFwvKPppFEMXn8yfReSBVi16k=
 github.com/zmb3/spotify v1.3.0/go.mod h1:GD7AAEMUJVYc2Z7p2a2S0E3/5f/KxM/vOnErNr4j+Tw=
-github.com/zorkian/go-datadog-api v2.30.0+incompatible h1:R4ryGocppDqZZbnNc5EDR8xGWF/z/MxzWnqTUijDQes=
-github.com/zorkian/go-datadog-api v2.30.0+incompatible/go.mod h1:PkXwHX9CUQa/FpB9ZwAD45N1uhCW4MT/Wj7m36PbKss=
 gitlab.com/gitlab-org/api/client-go v0.160.1 h1:7kEgo1yQ3ZMRps/2JbXzqbRb4Rs8n2ECkAv+6MadJw8=
 gitlab.com/gitlab-org/api/client-go v0.160.1/go.mod h1:YqKcnxyV9OPAL5U99mpwBVEgBPz1PK/3qwqq/3h6bao=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=

--- a/modules/datadog/client.go
+++ b/modules/datadog/client.go
@@ -1,20 +1,34 @@
 package datadog
 
 import (
+	"context"
+	"strings"
+
+	ddapi "github.com/DataDog/datadog-api-client-go/v2/api/datadog"
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV1"
 	"github.com/wtfutil/wtf/utils"
-	datadog "github.com/zorkian/go-datadog-api"
 )
 
 // Monitors returns a list of Datadog monitors
-func (widget *Widget) Monitors() ([]datadog.Monitor, error) {
-	client := datadog.NewClient(
-		widget.settings.apiKey,
-		widget.settings.applicationKey,
-	)
+func (widget *Widget) Monitors() ([]datadogV1.Monitor, error) {
+	ctx := context.WithValue(context.Background(), ddapi.ContextAPIKeys, map[string]ddapi.APIKey{
+		"apiKeyAuth": {Key: widget.settings.apiKey},
+		"appKeyAuth": {Key: widget.settings.applicationKey},
+	})
+
+	config := ddapi.NewConfiguration()
+	client := ddapi.NewAPIClient(config)
 
 	tags := utils.ToStrs(widget.settings.tags)
 
-	monitors, err := client.GetMonitorsByTags(tags)
+	optionalParams := datadogV1.NewListMonitorsOptionalParameters()
+	if len(tags) > 0 {
+		tagFilter := strings.Join(tags, ",")
+		optionalParams = optionalParams.WithMonitorTags(tagFilter)
+	}
+
+	monitorsApi := datadogV1.NewMonitorsApi(client)
+	monitors, _, err := monitorsApi.ListMonitors(ctx, *optionalParams)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/datadog/widget.go
+++ b/modules/datadog/widget.go
@@ -3,16 +3,16 @@ package datadog
 import (
 	"fmt"
 
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV1"
 	"github.com/rivo/tview"
 	"github.com/wtfutil/wtf/utils"
 	"github.com/wtfutil/wtf/view"
-	datadog "github.com/zorkian/go-datadog-api"
 )
 
 type Widget struct {
 	view.ScrollableWidget
 
-	monitors []datadog.Monitor
+	monitors []datadogV1.Monitor
 	settings *Settings
 	err      error
 }
@@ -43,11 +43,11 @@ func (widget *Widget) Refresh() {
 		widget.Redraw(func() (string, string, bool) { return widget.CommonSettings().Title, monitorErr.Error(), true })
 		return
 	}
-	triggeredMonitors := []datadog.Monitor{}
+	triggeredMonitors := []datadogV1.Monitor{}
 
 	for _, monitor := range monitors {
-		state := *monitor.OverallState
-		if state == "Alert" {
+		state := monitor.GetOverallState()
+		if state == datadogV1.MONITOROVERALLSTATES_ALERT {
 			triggeredMonitors = append(triggeredMonitors, monitor)
 		}
 	}
@@ -82,12 +82,13 @@ func (widget *Widget) content() (string, string, bool) {
 			),
 		)
 		for idx, triggeredMonitor := range triggeredMonitors {
+			name := triggeredMonitor.GetName()
 			row := fmt.Sprintf(`[%s][red] %s[%s]`,
 				widget.RowColor(idx),
-				*triggeredMonitor.Name,
+				name,
 				widget.RowColor(idx),
 			)
-			str += utils.HighlightableHelper(widget.View, row, idx, len(*triggeredMonitor.Name))
+			str += utils.HighlightableHelper(widget.View, row, idx, len(name))
 		}
 	} else {
 		str += fmt.Sprintf(
@@ -104,6 +105,6 @@ func (widget *Widget) openItem() {
 	sel := widget.GetSelected()
 	if sel >= 0 && widget.monitors != nil && sel < len(widget.monitors) {
 		item := &widget.monitors[sel]
-		utils.OpenFile(fmt.Sprintf("https://app.datadoghq.com/monitors/%d?q=*", *item.Id))
+		utils.OpenFile(fmt.Sprintf("https://app.datadoghq.com/monitors/%d?q=*", item.GetId()))
 	}
 }


### PR DESCRIPTION
Replace the unmaintained `github.com/zorkian/go-datadog-api` (last updated May 2021) with the official `github.com/DataDog/datadog-api-client-go/v2`.

Behavior is unchanged: fetch monitors by tags, filter for Alert state, display name and link.

**Note:** No integration test was performed against a live Datadog account. The SDK wiring (auth key names, API method signatures, monitor field accessors) has been verified against the SDK source, and the project builds cleanly.