### PR TITLE
Replace devto-api-go with inline HTTP client and add tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	code.cloudfoundry.org/bytefmt v0.78.0
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/PagerDuty/go-pagerduty v1.8.0
-	github.com/VictorAvelar/devto-api-go v1.0.0
 	github.com/adlio/trello v1.12.0
 	github.com/alecthomas/chroma v0.10.0
 	github.com/andygrunwald/go-gerrit v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -33,8 +33,6 @@ github.com/PagerDuty/go-pagerduty v1.8.0 h1:MTFqTffIcAervB83U7Bx6HERzLbyaSPL/+ox
 github.com/PagerDuty/go-pagerduty v1.8.0/go.mod h1:nzIeAqyFSJAFkjWKvMzug0JtwDg+V+UoCWjFrfFH5mI=
 github.com/PuerkitoBio/goquery v1.8.0 h1:PJTF7AmFCFKk1N6V6jmKfrNH9tV5pNE6lZMkG0gta/U=
 github.com/PuerkitoBio/goquery v1.8.0/go.mod h1:ypIiRMtY7COPGk+I/YbZLbxsxn9g5ejnI2HSMtkjZvI=
-github.com/VictorAvelar/devto-api-go v1.0.0 h1:oXmzye3xYvlgBX18vX4+v6LVbjoihgIokpeOpzeJzqU=
-github.com/VictorAvelar/devto-api-go v1.0.0/go.mod h1:gX13cqzMdpo49qP8VtBR2uCnzW7d76LFrAVSX2eLifY=
 github.com/adlio/trello v1.12.0 h1:JqOE2GFHQ9YtEviRRRSnicSxPbt4WFOxhqXzjMOw8lw=
 github.com/adlio/trello v1.12.0/go.mod h1:I4Lti4jf2KxjTNgTqs5W3lLuE78QZZdYbbPnQQGwjOo=
 github.com/alecthomas/chroma v0.10.0 h1:7XDcGkCQopCNKjZHfYrNLraA+M7e0fMiJ/Mfikbfjek=

--- a/modules/devto/client.go
+++ b/modules/devto/client.go
@@ -1,0 +1,83 @@
+package devto
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+const defaultBaseURL = "https://dev.to/api/articles"
+
+// Article represents a DEV.to article from the public API.
+type Article struct {
+	Title string `json:"title"`
+	URL   string `json:"url"`
+	User  struct {
+		Username string `json:"username"`
+	} `json:"user"`
+}
+
+// Client fetches articles from the DEV.to API.
+type Client struct {
+	httpClient *http.Client
+	baseURL    string
+}
+
+// NewClient creates a Client. Pass nil for httpClient to use http.DefaultClient.
+// baseURL overrides the API endpoint (useful for testing); pass "" for the default.
+func NewClient(httpClient *http.Client, baseURL string) *Client {
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	if baseURL == "" {
+		baseURL = defaultBaseURL
+	}
+	return &Client{httpClient: httpClient, baseURL: baseURL}
+}
+
+// FetchArticles retrieves articles matching the given filters.
+func (c *Client) FetchArticles(ctx context.Context, tag, username, state string, perPage int) ([]Article, error) {
+	u, err := url.Parse(c.baseURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid base URL: %w", err)
+	}
+
+	q := u.Query()
+	if tag != "" {
+		q.Set("tag", tag)
+	}
+	if username != "" {
+		q.Set("username", username)
+	}
+	if state != "" {
+		q.Set("state", state)
+	}
+	if perPage > 0 {
+		q.Set("per_page", fmt.Sprintf("%d", perPage))
+	}
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("executing request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status %d from DEV.to API", resp.StatusCode)
+	}
+
+	var articles []Article
+	if err := json.NewDecoder(resp.Body).Decode(&articles); err != nil {
+		return nil, fmt.Errorf("decoding response: %w", err)
+	}
+
+	return articles, nil
+}

--- a/modules/devto/client_test.go
+++ b/modules/devto/client_test.go
@@ -1,0 +1,113 @@
+package devto
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestFetchArticles_Success(t *testing.T) {
+	articles := []Article{
+		{Title: "First Post", URL: "https://dev.to/first"},
+		{Title: "Second Post", URL: "https://dev.to/second"},
+	}
+	articles[0].User.Username = "alice"
+	articles[1].User.Username = "bob"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("tag") != "go" {
+			t.Errorf("expected tag=go, got %s", r.URL.Query().Get("tag"))
+		}
+		if r.URL.Query().Get("username") != "alice" {
+			t.Errorf("expected username=alice, got %s", r.URL.Query().Get("username"))
+		}
+		if r.URL.Query().Get("state") != "rising" {
+			t.Errorf("expected state=rising, got %s", r.URL.Query().Get("state"))
+		}
+		if r.URL.Query().Get("per_page") != "5" {
+			t.Errorf("expected per_page=5, got %s", r.URL.Query().Get("per_page"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(articles)
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.Client(), srv.URL)
+	result, err := c.FetchArticles(context.Background(), "go", "alice", "rising", 5)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result) != 2 {
+		t.Fatalf("expected 2 articles, got %d", len(result))
+	}
+	if result[0].Title != "First Post" {
+		t.Errorf("expected title 'First Post', got %q", result[0].Title)
+	}
+	if result[0].User.Username != "alice" {
+		t.Errorf("expected username 'alice', got %q", result[0].User.Username)
+	}
+	if result[1].URL != "https://dev.to/second" {
+		t.Errorf("expected URL 'https://dev.to/second', got %q", result[1].URL)
+	}
+}
+
+func TestFetchArticles_EmptyParams(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.RawQuery != "" {
+			t.Errorf("expected no query params, got %s", r.URL.RawQuery)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("[]"))
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.Client(), srv.URL)
+	result, err := c.FetchArticles(context.Background(), "", "", "", 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result) != 0 {
+		t.Fatalf("expected 0 articles, got %d", len(result))
+	}
+}
+
+func TestFetchArticles_Non200Status(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.Client(), srv.URL)
+	_, err := c.FetchArticles(context.Background(), "", "", "", 0)
+	if err == nil {
+		t.Fatal("expected error for non-200 status")
+	}
+	expected := "unexpected status 500 from DEV.to API"
+	if err.Error() != expected {
+		t.Errorf("expected error %q, got %q", expected, err.Error())
+	}
+}
+
+func TestFetchArticles_InvalidJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("not json"))
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.Client(), srv.URL)
+	_, err := c.FetchArticles(context.Background(), "", "", "", 0)
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+}
+
+func TestFetchArticles_RequestError(t *testing.T) {
+	c := NewClient(nil, "http://127.0.0.1:1") // port 1 should refuse
+	_, err := c.FetchArticles(context.Background(), "", "", "", 0)
+	if err == nil {
+		t.Fatal("expected error for connection refused")
+	}
+}

--- a/modules/devto/settings_test.go
+++ b/modules/devto/settings_test.go
@@ -1,0 +1,93 @@
+package devto
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/olebedev/config"
+)
+
+func TestNewSettingsFromYAML(t *testing.T) {
+	yamlStr := `
+numberOfArticles: 5
+contentTag: "golang"
+contentUsername: "testuser"
+contentState: "fresh"
+enabled: true
+position:
+  top: 0
+  left: 0
+  height: 1
+  width: 1
+refreshInterval: 300
+`
+	globalStr := `
+wtf:
+  colors:
+    border:
+      focusable: "darkslateblue"
+      focused: "orange"
+      normal: "gray"
+`
+
+	yamlConfig, err := config.ParseYaml(yamlStr)
+	if err != nil {
+		t.Fatalf("failed to parse yaml: %v", err)
+	}
+
+	globalConfig, err := config.ParseYaml(globalStr)
+	if err != nil {
+		t.Fatalf("failed to parse global yaml: %v", err)
+	}
+
+	settings := NewSettingsFromYAML("devto", yamlConfig, globalConfig)
+
+	if settings.numberOfArticles != 5 {
+		t.Errorf("expected numberOfArticles=5, got %d", settings.numberOfArticles)
+	}
+	if settings.contentTag != "golang" {
+		t.Errorf("expected contentTag='golang', got %q", settings.contentTag)
+	}
+	if settings.contentUsername != "testuser" {
+		t.Errorf("expected contentUsername='testuser', got %q", settings.contentUsername)
+	}
+	if settings.contentState != "fresh" {
+		t.Errorf("expected contentState='fresh', got %q", settings.contentState)
+	}
+}
+
+func TestNewSettingsFromYAML_Defaults(t *testing.T) {
+	yamlStr := `
+position:
+  top: 0
+  left: 0
+  height: 1
+  width: 1
+`
+	globalStr := `
+wtf:
+  colors:
+    border:
+      focusable: "darkslateblue"
+      focused: "orange"
+      normal: "gray"
+`
+
+	yamlConfig, _ := config.ParseYaml(yamlStr)
+	globalConfig, _ := config.ParseYaml(globalStr)
+
+	settings := NewSettingsFromYAML("devto", yamlConfig, globalConfig)
+
+	if settings.numberOfArticles != 10 {
+		t.Errorf("expected default numberOfArticles=10, got %d", settings.numberOfArticles)
+	}
+	if settings.contentTag != "" {
+		t.Errorf("expected empty default contentTag, got %q", settings.contentTag)
+	}
+	if settings.contentState != "" {
+		t.Errorf("expected empty default contentState, got %q", settings.contentState)
+	}
+	if !strings.Contains(settings.Title, "dev.to") {
+		t.Errorf("expected title to contain 'dev.to', got %q", settings.Title)
+	}
+}

--- a/modules/devto/widget.go
+++ b/modules/devto/widget.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/VictorAvelar/devto-api-go/devto"
 	"github.com/rivo/tview"
 
 	"github.com/wtfutil/wtf/utils"
@@ -14,16 +13,20 @@ import (
 type Widget struct {
 	view.ScrollableWidget
 
-	articles []devto.ListedArticle
+	articles []Article
+	client   *Client
 	settings *Settings
 	err      error
+	openURL  func(string)
 }
 
 func NewWidget(tviewApp *tview.Application, redrawChan chan bool, pages *tview.Pages, settings *Settings) *Widget {
 	widget := &Widget{
 		ScrollableWidget: view.NewScrollableWidget(tviewApp, redrawChan, pages, settings.Common),
 
+		client:   NewClient(nil, ""),
 		settings: settings,
+		openURL:  utils.OpenFile,
 	}
 
 	widget.SetRenderFunction(widget.Render)
@@ -39,37 +42,25 @@ func (widget *Widget) Refresh() {
 	}
 
 	ctx := context.Background()
-	wCfg, _ := devto.NewConfig(false, "")
 
-	c, _ := devto.NewClient(ctx, wCfg, nil, devto.BaseURL)
-
-	options := devto.ArticleListOptions{
-		Tags:     widget.settings.contentTag,
-		Username: widget.settings.contentUsername,
-		State:    widget.settings.contentState,
-	}
-
-	articles, err := c.Articles.List(ctx, options)
+	articles, err := widget.client.FetchArticles(
+		ctx,
+		widget.settings.contentTag,
+		widget.settings.contentUsername,
+		widget.settings.contentState,
+		widget.settings.numberOfArticles,
+	)
 	if err != nil {
 		widget.err = err
 		widget.articles = nil
 		widget.SetItemCount(0)
 	} else {
-		var displayArticles []devto.ListedArticle
-		var l int
-		if len(articles) < widget.settings.numberOfArticles {
-			l = len(articles)
-		} else {
-			l = widget.settings.numberOfArticles - 1
+		limit := widget.settings.numberOfArticles
+		if len(articles) < limit {
+			limit = len(articles)
 		}
-		for i, art := range articles {
-			if i > l {
-				break
-			}
-			displayArticles = append(displayArticles, art)
-		}
-		widget.articles = displayArticles
-		widget.SetItemCount(len(displayArticles))
+		widget.articles = articles[:limit]
+		widget.SetItemCount(len(widget.articles))
 	}
 
 	widget.Render()
@@ -96,14 +87,7 @@ func (widget *Widget) content() (string, string, bool) {
 
 	var str string
 	for idx, article := range articles {
-		row := fmt.Sprintf(
-			`[%s]%2d. %s [lightblue](%s)[white]`,
-			widget.RowColor(idx),
-			idx+1,
-			article.Title,
-			article.User.Username,
-		)
-
+		row := formatArticleRow(idx, article.Title, article.User.Username, widget.RowColor(idx))
 		str += utils.HighlightableHelper(widget.View, row, idx, len(article.Title))
 	}
 
@@ -114,6 +98,17 @@ func (widget *Widget) openStory() {
 	sel := widget.GetSelected()
 	if sel >= 0 && widget.articles != nil && sel < len(widget.articles) {
 		article := &widget.articles[sel]
-		utils.OpenFile(article.URL.String())
+		widget.openURL(article.URL)
 	}
+}
+
+// formatArticleRow formats a single article row for display.
+func formatArticleRow(idx int, title, username, rowColor string) string {
+	return fmt.Sprintf(
+		`[%s]%2d. %s [lightblue](%s)[white]`,
+		rowColor,
+		idx+1,
+		title,
+		username,
+	)
 }

--- a/modules/devto/widget_test.go
+++ b/modules/devto/widget_test.go
@@ -1,0 +1,341 @@
+package devto
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/rivo/tview"
+	"github.com/wtfutil/wtf/cfg"
+)
+
+// helper to create a test widget with an httptest server
+func createTestWidgetWithServer(handler http.HandlerFunc) (*Widget, *httptest.Server) {
+	srv := httptest.NewServer(handler)
+
+	app := tview.NewApplication()
+	redrawChan := make(chan bool, 1)
+
+	settings := &Settings{
+		Common: &cfg.Common{
+			Title:   "dev.to",
+			Enabled: true,
+		},
+		numberOfArticles: 10,
+		contentTag:       "go",
+		contentUsername:  "",
+		contentState:     "rising",
+	}
+
+	widget := NewWidget(app, redrawChan, nil, settings)
+	widget.client = NewClient(srv.Client(), srv.URL)
+
+	return widget, srv
+}
+
+func TestWidget_Refresh_Disabled(t *testing.T) {
+	widget, srv := createTestWidgetWithServer(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("server should not be called when widget is disabled")
+	})
+	defer srv.Close()
+
+	widget.Disable()
+	widget.Refresh()
+
+	if widget.articles != nil {
+		t.Error("expected nil articles when disabled")
+	}
+}
+
+func TestNewWidget_Initialization(t *testing.T) {
+	app := tview.NewApplication()
+	redrawChan := make(chan bool, 1)
+
+	settings := &Settings{
+		Common: &cfg.Common{
+			Title: "Test DEV.to",
+		},
+		numberOfArticles: 5,
+	}
+
+	widget := NewWidget(app, redrawChan, nil, settings)
+
+	if widget == nil {
+		t.Fatal("expected non-nil widget")
+	}
+	if widget.client == nil {
+		t.Error("expected client to be initialized")
+	}
+	if widget.settings != settings {
+		t.Error("expected settings to match")
+	}
+	if widget.openURL == nil {
+		t.Error("expected openURL to be set")
+	}
+}
+
+func TestWidget_Refresh_Success(t *testing.T) {
+	articles := []Article{
+		{Title: "Article 1", URL: "https://dev.to/1"},
+		{Title: "Article 2", URL: "https://dev.to/2"},
+		{Title: "Article 3", URL: "https://dev.to/3"},
+	}
+	articles[0].User.Username = "alice"
+	articles[1].User.Username = "bob"
+	articles[2].User.Username = "carol"
+
+	widget, srv := createTestWidgetWithServer(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(articles)
+	})
+	defer srv.Close()
+
+	widget.settings.numberOfArticles = 2
+	widget.Refresh()
+
+	if widget.err != nil {
+		t.Fatalf("unexpected error: %v", widget.err)
+	}
+	if len(widget.articles) != 2 {
+		t.Errorf("expected 2 articles, got %d", len(widget.articles))
+	}
+}
+
+func TestWidget_Refresh_FewerThanRequested(t *testing.T) {
+	articles := []Article{
+		{Title: "Only One", URL: "https://dev.to/only"},
+	}
+	articles[0].User.Username = "solo"
+
+	widget, srv := createTestWidgetWithServer(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(articles)
+	})
+	defer srv.Close()
+
+	widget.settings.numberOfArticles = 10
+	widget.Refresh()
+
+	if widget.err != nil {
+		t.Fatalf("unexpected error: %v", widget.err)
+	}
+	if len(widget.articles) != 1 {
+		t.Errorf("expected 1 article, got %d", len(widget.articles))
+	}
+}
+
+func TestWidget_Refresh_Error(t *testing.T) {
+	widget, srv := createTestWidgetWithServer(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	})
+	defer srv.Close()
+
+	widget.Refresh()
+
+	if widget.err == nil {
+		t.Fatal("expected error")
+	}
+	if widget.articles != nil {
+		t.Error("expected nil articles on error")
+	}
+}
+
+func TestWidget_Content_NoArticles(t *testing.T) {
+	widget, srv := createTestWidgetWithServer(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("[]"))
+	})
+	defer srv.Close()
+
+	widget.Refresh()
+
+	title, body, _ := widget.content()
+	if title == "" {
+		t.Error("expected non-empty title")
+	}
+	if body != "No stories to display" {
+		t.Errorf("expected 'No stories to display', got %q", body)
+	}
+}
+
+func TestWidget_Content_WithError(t *testing.T) {
+	widget, srv := createTestWidgetWithServer(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	defer srv.Close()
+
+	widget.Refresh()
+
+	_, body, wrap := widget.content()
+	if body == "" {
+		t.Error("expected error message in body")
+	}
+	if !wrap {
+		t.Error("expected wrap=true for error content")
+	}
+}
+
+func TestWidget_Content_WithArticles(t *testing.T) {
+	articles := []Article{
+		{Title: "Go Testing", URL: "https://dev.to/go-testing"},
+	}
+	articles[0].User.Username = "gopher"
+
+	widget, srv := createTestWidgetWithServer(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(articles)
+	})
+	defer srv.Close()
+
+	widget.Refresh()
+
+	_, body, wrap := widget.content()
+	if wrap {
+		t.Error("expected wrap=false for normal content")
+	}
+	if body == "" || body == "No stories to display" {
+		t.Error("expected article content in body")
+	}
+}
+
+func TestWidget_OpenStory_ValidSelection(t *testing.T) {
+	var openedURL string
+	widget, srv := createTestWidgetWithServer(func(w http.ResponseWriter, r *http.Request) {
+		articles := []Article{{Title: "Test", URL: "https://dev.to/test"}}
+		articles[0].User.Username = "user"
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(articles)
+	})
+	defer srv.Close()
+
+	widget.openURL = func(url string) { openedURL = url }
+	widget.Refresh()
+	widget.Selected = 0
+
+	widget.openStory()
+
+	if openedURL != "https://dev.to/test" {
+		t.Errorf("expected URL 'https://dev.to/test', got %q", openedURL)
+	}
+}
+
+func TestWidget_OpenStory_EmptyList(t *testing.T) {
+	widget, srv := createTestWidgetWithServer(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("[]"))
+	})
+	defer srv.Close()
+
+	called := false
+	widget.openURL = func(url string) { called = true }
+	widget.Refresh()
+
+	widget.openStory()
+
+	if called {
+		t.Error("openURL should not be called with empty article list")
+	}
+}
+
+func TestWidget_OpenStory_NegativeSelection(t *testing.T) {
+	widget, srv := createTestWidgetWithServer(func(w http.ResponseWriter, r *http.Request) {
+		articles := []Article{{Title: "Test", URL: "https://dev.to/test"}}
+		articles[0].User.Username = "user"
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(articles)
+	})
+	defer srv.Close()
+
+	called := false
+	widget.openURL = func(url string) { called = true }
+	widget.Refresh()
+	widget.Selected = -1
+
+	widget.openStory()
+
+	if called {
+		t.Error("openURL should not be called with negative selection")
+	}
+}
+
+func TestFormatArticleRow(t *testing.T) {
+	tests := []struct {
+		name     string
+		idx      int
+		title    string
+		username string
+		color    string
+		want     string
+	}{
+		{
+			name:     "basic formatting",
+			idx:      0,
+			title:    "Hello World",
+			username: "alice",
+			color:    "white",
+			want:     `[white] 1. Hello World [lightblue](alice)[white]`,
+		},
+		{
+			name:     "double digit index",
+			idx:      9,
+			title:    "Tenth Post",
+			username: "bob",
+			color:    "green",
+			want:     `[green]10. Tenth Post [lightblue](bob)[white]`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatArticleRow(tt.idx, tt.title, tt.username, tt.color)
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewClient_Defaults(t *testing.T) {
+	c := NewClient(nil, "")
+	if c.httpClient != http.DefaultClient {
+		t.Error("expected http.DefaultClient when nil passed")
+	}
+	if c.baseURL != defaultBaseURL {
+		t.Errorf("expected default base URL %q, got %q", defaultBaseURL, c.baseURL)
+	}
+}
+
+func TestNewClient_Custom(t *testing.T) {
+	custom := &http.Client{}
+	c := NewClient(custom, "http://example.com/api")
+	if c.httpClient != custom {
+		t.Error("expected custom http client")
+	}
+	if c.baseURL != "http://example.com/api" {
+		t.Errorf("expected custom base URL, got %q", c.baseURL)
+	}
+}
+
+func TestFetchArticles_InvalidBaseURL(t *testing.T) {
+	c := NewClient(nil, "://bad-url")
+	_, err := c.FetchArticles(context.Background(), "", "", "", 0)
+	if err == nil {
+		t.Fatal("expected error for invalid base URL")
+	}
+}
+
+func TestConfigText(t *testing.T) {
+	app := tview.NewApplication()
+	redrawChan := make(chan bool, 1)
+	settings := &Settings{
+		Common: &cfg.Common{Title: "Test"},
+	}
+	widget := NewWidget(app, redrawChan, nil, settings)
+
+	text := widget.ConfigText()
+	if text == "" {
+		t.Error("expected non-empty config text")
+	}
+}


### PR DESCRIPTION
Remove the archived `github.com/VictorAvelar/devto-api-go` dependency by inlining the DEV.to API calls using `net/http` + `encoding/json`.

## Changes

- **`modules/devto/client.go`** — New `Client` struct with injectable `*http.Client` and base URL. `FetchArticles()` makes a GET to the DEV.to public API with tag/username/state/per_page query params.
- **`modules/devto/widget.go`** — Switched from the external library to the internal client. Extracted `formatArticleRow()` as a pure function. Made URL opener injectable for testability.
- **`modules/devto/client_test.go`** — Tests fetch/parse, empty params, non-200 status, invalid JSON, connection errors.
- **`modules/devto/widget_test.go`** — Tests Refresh (success, error, disabled, truncation), content rendering, openStory edge cases, formatting.
- **`modules/devto/settings_test.go`** — Tests YAML config parsing with custom values and defaults.
- **`go.mod`/`go.sum`** — Removed `VictorAvelar/devto-api-go` via `go mod tidy`.

## Coverage

| Before | After |
|--------|-------|
| 32.2%  | 98.7% |