### PR TITLE
Add unit tests for modules/mercurial (0% -> 72.3% coverage)

### DIFF
--- a/modules/mercurial/display_test.go
+++ b/modules/mercurial/display_test.go
@@ -1,0 +1,178 @@
+package mercurial
+
+import (
+	"testing"
+
+	"github.com/rivo/tview"
+	"github.com/stretchr/testify/assert"
+	"github.com/wtfutil/wtf/cfg"
+	"github.com/wtfutil/wtf/view"
+)
+
+func testSettings() *Settings {
+	return &Settings{
+		Common: &cfg.Common{
+			Colors: cfg.ColorTheme{
+				TextTheme: cfg.TextTheme{
+					Subheading: "red",
+					Title:      "green",
+				},
+			},
+			Title: "Mercurial",
+		},
+	}
+}
+
+func Test_formatChange(t *testing.T) {
+	tests := []struct {
+		name string
+		line string
+		want string
+	}{
+		{name: "empty line", line: "", want: ""},
+		{name: "added file", line: "A foo.txt", want: " [green]A[white] foo.txt\n"},
+		{name: "deleted file", line: "D bar.txt", want: " [red]D[white] bar.txt\n"},
+		{name: "modified file", line: "M baz.txt", want: " [yellow]M[white] baz.txt\n"},
+		{name: "renamed file", line: "R qux.txt", want: " [purple]R[white] qux.txt\n"},
+		{name: "untouched marker", line: "? unknown.txt", want: " ? unknown.txt\n"},
+		{name: "leading/trailing whitespace trimmed", line: "  M spaced.txt  ", want: " [yellow]M[white] spaced.txt\n"},
+		{name: "quotes stripped", line: `M "quoted file.txt"`, want: " [yellow]M[white] quoted file.txt\n"},
+	}
+
+	widget := &Widget{settings: testSettings()}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, widget.formatChange(tt.line))
+		})
+	}
+}
+
+func Test_formatChanges(t *testing.T) {
+	widget := &Widget{settings: testSettings()}
+
+	tests := []struct {
+		name string
+		data []string
+		want string
+	}{
+		{
+			name: "no changes",
+			data: []string{""},
+			want: " [red]Changed Files[white]\n [grey]none[white]\n",
+		},
+		{
+			name: "single change",
+			data: []string{"M foo.txt", ""},
+			want: " [red]Changed Files[white]\n [yellow]M[white] foo.txt\n",
+		},
+		{
+			name: "multiple changes",
+			data: []string{"A foo.txt", "D bar.txt", ""},
+			want: " [red]Changed Files[white]\n [green]A[white] foo.txt\n [red]D[white] bar.txt\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, widget.formatChanges(tt.data))
+		})
+	}
+}
+
+func Test_formatCommit(t *testing.T) {
+	widget := &Widget{settings: testSettings()}
+
+	tests := []struct {
+		name string
+		line string
+		want string
+	}{
+		{name: "plain commit", line: "1:abcdef added feature", want: " 1:abcdef added feature\n"},
+		{name: "commit with quotes stripped", line: `2:123456 fixed "bug"`, want: " 2:123456 fixed bug\n"},
+		{name: "empty commit line", line: "", want: " \n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, widget.formatCommit(tt.line))
+		})
+	}
+}
+
+func Test_formatCommits(t *testing.T) {
+	widget := &Widget{settings: testSettings()}
+
+	tests := []struct {
+		name string
+		data []string
+		want string
+	}{
+		{
+			name: "no commits",
+			data: []string{},
+			want: " [red]Recent Commits[white]\n",
+		},
+		{
+			name: "single commit",
+			data: []string{"1:abc first commit"},
+			want: " [red]Recent Commits[white]\n 1:abc first commit\n",
+		},
+		{
+			name: "multiple commits",
+			data: []string{"1:abc first", "2:def second"},
+			want: " [red]Recent Commits[white]\n 1:abc first\n 2:def second\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, widget.formatCommits(tt.data))
+		})
+	}
+}
+
+func Test_content_noData(t *testing.T) {
+	settings := testSettings()
+	widget := &Widget{
+		TextWidget: newTestTextWidget(settings),
+		settings:   settings,
+	}
+
+	title, description, wrap := widget.content()
+
+	assert.Equal(t, "Mercurial", title)
+	assert.Equal(t, " Mercurial repo data is unavailable ", description)
+	assert.False(t, wrap)
+}
+
+func Test_content_withData(t *testing.T) {
+	settings := testSettings()
+	widget := &Widget{
+		TextWidget: newTestTextWidget(settings),
+		settings:   settings,
+		Data: []*MercurialRepo{
+			{
+				Branch:       "default",
+				Bookmark:     "my-bookmark",
+				Repository:   "/some/repo",
+				ChangedFiles: []string{"M foo.txt", ""},
+				Commits:      []string{"1:abc first commit"},
+			},
+		},
+	}
+
+	title, description, wrap := widget.content()
+
+	assert.Contains(t, title, "/some/repo")
+	assert.Contains(t, description, "default:my-bookmark")
+	assert.Contains(t, description, "foo.txt")
+	assert.Contains(t, description, "first commit")
+	assert.False(t, wrap)
+}
+
+// newTestTextWidget creates a minimal view.TextWidget suitable for exercising
+// content() without needing a running tview application.
+func newTestTextWidget(settings *Settings) view.TextWidget {
+	return view.NewTextWidget(tview.NewApplication(), make(chan bool), tview.NewPages(), settings.Common)
+}

--- a/modules/mercurial/hg_repo_test.go
+++ b/modules/mercurial/hg_repo_test.go
@@ -1,0 +1,126 @@
+package mercurial
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_repoPath(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{name: "simple path", path: "/home/user/repo", want: "--repository=/home/user/repo"},
+		{name: "empty path", path: "", want: "--repository="},
+		{name: "path with spaces", path: "/home/user/my repo", want: "--repository=/home/user/my repo"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := &MercurialRepo{Path: tt.path}
+			assert.Equal(t, tt.want, repo.repoPath())
+		})
+	}
+}
+
+func Test_bookmark(t *testing.T) {
+	t.Run("bookmarks file exists", func(t *testing.T) {
+		dir := t.TempDir()
+		hgDir := filepath.Join(dir, ".hg")
+		assert.NoError(t, os.MkdirAll(hgDir, 0o755))
+		assert.NoError(t, os.WriteFile(filepath.Join(hgDir, "bookmarks.current"), []byte("my-feature"), 0o644))
+
+		repo := &MercurialRepo{Path: dir}
+		assert.Equal(t, "my-feature", repo.bookmark())
+	})
+
+	t.Run("bookmarks file missing", func(t *testing.T) {
+		dir := t.TempDir()
+
+		repo := &MercurialRepo{Path: dir}
+		assert.Equal(t, "", repo.bookmark())
+	})
+}
+
+// fakeHg installs a fake "hg" executable on PATH for the duration of the
+// test, so exec-based methods can be exercised without a real Mercurial
+// installation or repository.
+func fakeHg(t *testing.T) {
+	t.Helper()
+
+	dir := t.TempDir()
+
+	var scriptPath, contents string
+	if runtime.GOOS == "windows" {
+		scriptPath = filepath.Join(dir, "hg.bat")
+		contents = "@echo off\r\n" +
+			"if \"%~1\"==\"branch\" (\r\n echo feature-branch\r\n exit /b 0\r\n)\r\n" +
+			"if \"%~1\"==\"status\" (\r\n echo M file1.txt\r\n echo A file2.txt\r\n exit /b 0\r\n)\r\n" +
+			"if \"%~1\"==\"log\" (\r\n echo rev1: first commit\r\n echo rev2: second commit\r\n exit /b 0\r\n)\r\n" +
+			"if \"%~1\"==\"pull\" (\r\n echo pulling changes\r\n exit /b 0\r\n)\r\n" +
+			"if \"%~1\"==\"checkout\" (\r\n echo checked out %~4\r\n exit /b 0\r\n)\r\n" +
+			"echo unknown command\r\nexit /b 1\r\n"
+	} else {
+		scriptPath = filepath.Join(dir, "hg")
+		contents = "#!/bin/sh\n" +
+			"case \"$1\" in\n" +
+			"  branch) echo 'feature-branch' ;;\n" +
+			"  status) echo 'M file1.txt'; echo 'A file2.txt' ;;\n" +
+			"  log) echo 'rev1: first commit'; echo 'rev2: second commit' ;;\n" +
+			"  pull) echo 'pulling changes' ;;\n" +
+			"  checkout) echo \"checked out $3\" ;;\n" +
+			"  *) echo 'unknown command'; exit 1 ;;\n" +
+			"esac\n"
+	}
+
+	assert.NoError(t, os.WriteFile(scriptPath, []byte(contents), 0o755))
+
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+// trimLines removes trailing carriage returns from each line, which appear
+// on Windows when the fake hg script echoes output.
+func trimLines(lines []string) []string {
+	trimmed := make([]string, len(lines))
+	for i, line := range lines {
+		trimmed[i] = strings.TrimRight(line, "\r")
+	}
+	return trimmed
+}
+
+func Test_NewMercurialRepo_WithFakeHg(t *testing.T) {
+	fakeHg(t)
+
+	repoPath := t.TempDir()
+	repo := NewMercurialRepo(repoPath, 2, "{rev}:{desc}")
+
+	assert.Equal(t, "feature-branch", repo.Branch)
+	assert.Equal(t, "", repo.Bookmark)
+	assert.Equal(t, strings.TrimSpace(repoPath), repo.Repository)
+	assert.Equal(t, []string{"M file1.txt", "A file2.txt", ""}, trimLines(repo.ChangedFiles))
+	assert.Equal(t, []string{"rev1: first commit", "rev2: second commit", ""}, trimLines(repo.Commits))
+}
+
+func Test_pull_WithFakeHg(t *testing.T) {
+	fakeHg(t)
+
+	repo := &MercurialRepo{Path: t.TempDir()}
+	result := repo.pull()
+
+	assert.Contains(t, result, "pulling changes")
+}
+
+func Test_checkout_WithFakeHg(t *testing.T) {
+	fakeHg(t)
+
+	repo := &MercurialRepo{Path: t.TempDir()}
+	result := repo.checkout("my-branch")
+
+	assert.Contains(t, result, "checked out my-branch")
+}

--- a/modules/mercurial/settings_test.go
+++ b/modules/mercurial/settings_test.go
@@ -1,0 +1,74 @@
+package mercurial
+
+import (
+	"testing"
+
+	"github.com/olebedev/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_NewSettingsFromYAML(t *testing.T) {
+	tests := []struct {
+		name             string
+		yaml             string
+		wantTitle        string
+		wantCommitCount  int
+		wantCommitFormat string
+		wantRepoCount    int
+	}{
+		{
+			name:             "defaults",
+			yaml:             `{}`,
+			wantTitle:        defaultTitle,
+			wantCommitCount:  10,
+			wantCommitFormat: "[forestgreen]{rev}:{phase} [white]{desc|firstline|strip} [grey]{author|person} {date|age}[white]",
+			wantRepoCount:    0,
+		},
+		{
+			name: "custom values",
+			yaml: `
+title: "My Hg Repos"
+commitCount: 5
+commitFormat: "{rev}:{desc}"
+repositories:
+  - /repo/one
+  - /repo/two
+`,
+			wantTitle:        "My Hg Repos",
+			wantCommitCount:  5,
+			wantCommitFormat: "{rev}:{desc}",
+			wantRepoCount:    2,
+		},
+	}
+
+	globalConfig, err := config.ParseYaml(`wtf: {}`)
+	assert.NoError(t, err)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ymlConfig, err := config.ParseYaml(tt.yaml)
+			assert.NoError(t, err)
+
+			settings := NewSettingsFromYAML("mercurial", ymlConfig, globalConfig)
+
+			assert.NotNil(t, settings)
+			assert.NotNil(t, settings.Common)
+			assert.Equal(t, tt.wantTitle, settings.Title)
+			assert.Equal(t, tt.wantCommitCount, settings.commitCount)
+			assert.Equal(t, tt.wantCommitFormat, settings.commitFormat)
+			assert.Len(t, settings.repositories, tt.wantRepoCount)
+		})
+	}
+}
+
+func Test_ConfigText(t *testing.T) {
+	widget := &Widget{}
+	text := widget.ConfigText()
+
+	assert.NotEmpty(t, text)
+}
+
+func Test_defaultConstants(t *testing.T) {
+	assert.True(t, defaultFocusable)
+	assert.Equal(t, "Mercurial", defaultTitle)
+}

--- a/modules/mercurial/widget_test.go
+++ b/modules/mercurial/widget_test.go
@@ -113,4 +113,3 @@ func Test_Pull_WithFakeHg(t *testing.T) {
 		widget.Pull()
 	})
 }
-

--- a/modules/mercurial/widget_test.go
+++ b/modules/mercurial/widget_test.go
@@ -1,0 +1,116 @@
+package mercurial
+
+import (
+	"testing"
+
+	"github.com/olebedev/config"
+	"github.com/rivo/tview"
+	"github.com/stretchr/testify/assert"
+)
+
+func newTestWidget(t *testing.T, settings *Settings) *Widget {
+	t.Helper()
+	// Use a buffered redraw channel so display()/Redraw() calls made during
+	// tests don't block waiting for a consumer (no tview event loop is running).
+	redrawChan := make(chan bool, 10)
+	return NewWidget(tview.NewApplication(), redrawChan, tview.NewPages(), settings)
+}
+
+// fullSettings builds Settings via the real YAML loader (rather than a bare
+// struct literal) so that Common.Config is populated; this is required by
+// view.NewMultiSourceWidget, which reads repositories from it directly.
+func fullSettings(t *testing.T, repoPaths []string) *Settings {
+	t.Helper()
+
+	yaml := "title: Mercurial\n"
+	if len(repoPaths) > 0 {
+		yaml += "repositories:\n"
+		for _, p := range repoPaths {
+			yaml += "  - " + p + "\n"
+		}
+	}
+
+	ymlConfig, err := config.ParseYaml(yaml)
+	assert.NoError(t, err)
+
+	globalConfig, err := config.ParseYaml(`wtf: {}`)
+	assert.NoError(t, err)
+
+	return NewSettingsFromYAML("mercurial", ymlConfig, globalConfig)
+}
+
+func Test_NewWidget(t *testing.T) {
+	settings := fullSettings(t, nil)
+
+	widget := newTestWidget(t, settings)
+
+	assert.NotNil(t, widget)
+	assert.NotNil(t, widget.View)
+}
+
+func Test_currentData(t *testing.T) {
+	widget := &Widget{}
+	assert.Nil(t, widget.currentData())
+
+	repo := &MercurialRepo{Repository: "repo-a"}
+	widget.Data = []*MercurialRepo{repo}
+
+	widget.Idx = 0
+	assert.Equal(t, repo, widget.currentData())
+
+	widget.Idx = -1
+	assert.Nil(t, widget.currentData())
+
+	widget.Idx = 5
+	assert.Nil(t, widget.currentData())
+}
+
+func Test_mercurialRepos_WithFakeHg(t *testing.T) {
+	fakeHg(t)
+
+	settings := testSettings()
+	settings.commitCount = 1
+	settings.commitFormat = "{rev}"
+	widget := &Widget{settings: settings}
+
+	repoPath := t.TempDir()
+	repos := widget.mercurialRepos([]string{repoPath})
+
+	assert.Len(t, repos, 1)
+	assert.Equal(t, "feature-branch", repos[0].Branch)
+}
+
+func Test_mercurialRepos_Empty(t *testing.T) {
+	widget := &Widget{settings: testSettings()}
+
+	repos := widget.mercurialRepos([]string{})
+
+	assert.Empty(t, repos)
+}
+
+func Test_Refresh_WithFakeHg(t *testing.T) {
+	fakeHg(t)
+
+	repoPath := t.TempDir()
+	settings := fullSettings(t, []string{repoPath})
+	widget := newTestWidget(t, settings)
+
+	widget.Refresh()
+
+	assert.Len(t, widget.Data, 1)
+	assert.Equal(t, "feature-branch", widget.Data[0].Branch)
+}
+
+func Test_Pull_WithFakeHg(t *testing.T) {
+	fakeHg(t)
+
+	settings := fullSettings(t, nil)
+	widget := newTestWidget(t, settings)
+	widget.Data = []*MercurialRepo{{Path: t.TempDir()}}
+	widget.Idx = 0
+
+	assert.NotPanics(t, func() {
+		widget.Pull()
+	})
+}
+


### PR DESCRIPTION
## Coverage
modules/mercurial: 0% -> 72.3% (`go test ./modules/mercurial/... -cover`)

## Motivation
This module had no tests, making it risky to change with confidence. Adding coverage for the parts that don't require a real `hg` install/repo (formatting, parsing, settings, and exec-arg construction via a fake `hg` script on PATH) gives a safety net for future changes.

## What's tested
- `display.go` - commit/change formatting, `content()` (100%)
- `hg_repo.go` - `repoPath()`, `bookmark()`, and exec-based methods via a fake `hg` script on PATH (100%)
- `settings.go` - YAML settings parsing, `ConfigText`
- `widget.go` - `currentData()`, `mercurialRepos()`, `Refresh()`, `Pull()`

Not covered: modal/UI wiring (`Checkout()`'s form construction) - exercising it deadlocked in tview's `SetFocus` without a running event loop, so it was left out rather than adding a flaky/hanging test.