### PR TITLE
feat: support WTF_CONFIG_DIR env var for hermetic test builds

### DIFF
--- a/cfg/config_files.go
+++ b/cfg/config_files.go
@@ -71,8 +71,15 @@ func Initialize(hasCustom bool) {
 	}
 }
 
-// WtfConfigDir returns the absolute path to the configuration directory
+// WtfConfigDir returns the absolute path to the configuration directory.
+// It checks WTF_CONFIG_DIR first (useful for testing in hermetic environments),
+// then XDG_CONFIG_HOME, then falls back to ~/.config/wtf/.
 func WtfConfigDir() (string, error) {
+	// WTF_CONFIG_DIR takes highest priority, enabling hermetic test environments
+	if configDir := os.Getenv("WTF_CONFIG_DIR"); configDir != "" {
+		return configDir, nil
+	}
+
 	configDir := os.Getenv("XDG_CONFIG_HOME")
 	if configDir == "" {
 		configDir = WtfConfigDirV2

--- a/cfg/config_files_test.go
+++ b/cfg/config_files_test.go
@@ -1,0 +1,28 @@
+package cfg
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_WtfConfigDir_EnvOverride(t *testing.T) {
+	t.Run("WTF_CONFIG_DIR takes priority", func(t *testing.T) {
+		customDir := t.TempDir()
+		t.Setenv("WTF_CONFIG_DIR", customDir)
+		t.Setenv("XDG_CONFIG_HOME", "/should/not/use/this")
+
+		dir, err := WtfConfigDir()
+		assert.NoError(t, err)
+		assert.Equal(t, customDir, dir)
+	})
+
+	t.Run("falls back to XDG_CONFIG_HOME when WTF_CONFIG_DIR unset", func(t *testing.T) {
+		t.Setenv("WTF_CONFIG_DIR", "")
+		t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+		dir, err := WtfConfigDir()
+		assert.NoError(t, err)
+		assert.Contains(t, dir, "wtf")
+	})
+}

--- a/logger/log.go
+++ b/logger/log.go
@@ -28,6 +28,11 @@ func LogFileMissing() bool {
 }
 
 func LogFilePath() string {
+	// Check WTF_CONFIG_DIR first for hermetic test environments
+	if configDir := os.Getenv("WTF_CONFIG_DIR"); configDir != "" {
+		return filepath.Join(configDir, "log.txt")
+	}
+
 	dir, err := os.UserHomeDir()
 	if err != nil {
 		return ""

--- a/utils/homedir_test.go
+++ b/utils/homedir_test.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,29 +11,25 @@ func Test_ExpandHomeDir(t *testing.T) {
 	tests := []struct {
 		name             string
 		path             string
-		expectedStart    string
 		expectedContains string
 		expectedError    error
 	}{
 		{
 			name:             "with empty path",
 			path:             "",
-			expectedStart:    "",
 			expectedContains: "",
 			expectedError:    nil,
 		},
 		{
 			name:             "with relative path",
 			path:             "~/test",
-			expectedStart:    "/",
-			expectedContains: "/test",
+			expectedContains: "test",
 			expectedError:    nil,
 		},
 		{
 			name:             "with absolute path",
 			path:             "/Users/test",
-			expectedStart:    "/",
-			expectedContains: "/test",
+			expectedContains: "test",
 			expectedError:    nil,
 		},
 	}
@@ -41,8 +38,9 @@ func Test_ExpandHomeDir(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			actual, err := ExpandHomeDir(tt.path)
 
-			if len(tt.path) > 0 {
-				assert.Equal(t, tt.expectedStart, string(actual[0]))
+			if len(tt.path) > 0 && tt.path[0] == '~' {
+				// Tilde-expanded paths should be absolute
+				assert.True(t, filepath.IsAbs(actual), "expected absolute path, got: %s", actual)
 			}
 
 			assert.Contains(t, actual, tt.expectedContains)


### PR DESCRIPTION
## Summary
Adds a `WTF_CONFIG_DIR` environment variable that allows overriding the WTF configuration directory path. This enables hermetic build systems (Bazel, Nix) to run tests without needing filesystem access outside the project.

Closes #1612

## Changes
- `cfg/config_files.go`: `WtfConfigDir()` now checks `WTF_CONFIG_DIR` first (highest priority), then `XDG_CONFIG_HOME`, then the default `~/.config/wtf/`.
- `logger/log.go`: `LogFilePath()` respects `WTF_CONFIG_DIR` for the log file location.
- `utils/homedir_test.go`: Assertions are now cross-platform compatible.
- `cfg/config_files_test.go`: New tests for the env var override.

## Usage
```bash
export WTF_CONFIG_DIR=$(mktemp -d)
go test ./...
```