### PR TITLE
Add unit tests for modules/git

### DIFF
--- a/modules/git/display_test.go
+++ b/modules/git/display_test.go
@@ -1,0 +1,188 @@
+package git
+
+import (
+	"testing"
+
+	"github.com/rivo/tview"
+	"github.com/stretchr/testify/assert"
+	"github.com/wtfutil/wtf/cfg"
+	"github.com/wtfutil/wtf/view"
+)
+
+func newTestSettings() *Settings {
+	return &Settings{
+		Common: &cfg.Common{
+			Colors: cfg.ColorTheme{TextTheme: cfg.TextTheme{Subheading: "red"}},
+		},
+	}
+}
+
+func Test_formatChange(t *testing.T) {
+	widget := &Widget{settings: newTestSettings()}
+
+	tests := []struct {
+		name string
+		line string
+		want string
+	}{
+		{"empty line returns empty string", "", ""},
+		{"added file is colorized green", ` A "foo.txt"`, " [green]A[white] foo.txt\n"},
+		{"deleted file is colorized red", ` D "foo.txt"`, " [red]D[white] foo.txt\n"},
+		{"modified file is colorized yellow", ` M "foo.txt"`, " [yellow]M[white] foo.txt\n"},
+		{"renamed file is colorized purple", ` R "foo.txt" -> "bar.txt"`, " [purple]R[white] foo.txt -> bar.txt\n"},
+		{"unrecognized status is left unmodified", ` ? foo.txt`, " ? foo.txt\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, widget.formatChange(tt.line))
+		})
+	}
+}
+
+func Test_formatChanges(t *testing.T) {
+	widget := &Widget{settings: newTestSettings()}
+
+	tests := []struct {
+		name string
+		data []string
+		want string
+	}{
+		{
+			name: "single empty entry renders 'none'",
+			data: []string{""},
+			want: " [red]Changed Files[white]\n [grey]none[white]\n",
+		},
+		{
+			name: "multiple entries are each formatted",
+			data: []string{` M "foo.txt"`, ` A "bar.txt"`, ""},
+			want: " [red]Changed Files[white]\n [yellow]M[white] foo.txt\n [green]A[white] bar.txt\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, widget.formatChanges(tt.data))
+		})
+	}
+}
+
+func Test_formatCommit(t *testing.T) {
+	widget := &Widget{settings: newTestSettings()}
+
+	assert.Equal(t, " abc123 fixed the thing\n", widget.formatCommit(`abc123 "fixed the thing"`))
+	assert.Equal(t, " \n", widget.formatCommit(""))
+}
+
+func Test_formatCommits(t *testing.T) {
+	widget := &Widget{settings: newTestSettings()}
+
+	data := []string{`abc123 "first"`, `def456 "second"`}
+	want := " [red]Recent Commits[white]\n abc123 first\n def456 second\n"
+
+	assert.Equal(t, want, widget.formatCommits(data))
+}
+
+func Test_content(t *testing.T) {
+	tests := []struct {
+		name          string
+		settings      *Settings
+		repos         []*GitRepo
+		idx           int
+		wantTitle     string
+		wantUnavail   bool
+		wantBodyEmpty bool
+	}{
+		{
+			name:        "no repo data is unavailable",
+			settings:    newTestSettings(),
+			repos:       nil,
+			wantTitle:   "",
+			wantUnavail: true,
+		},
+		{
+			name:     "index out of range is unavailable",
+			settings: newTestSettings(),
+			repos: []*GitRepo{
+				{Repository: "/home/user/project", Branch: "main"},
+			},
+			idx:         5,
+			wantUnavail: true,
+		},
+		{
+			name: "full repository path shown when lastFolderTitle disabled",
+			settings: &Settings{
+				Common:   newTestSettings().Common,
+				sections: []interface{}{},
+			},
+			repos: []*GitRepo{
+				{Repository: "/home/user/project", Branch: "main", ChangedFiles: []string{""}, Commits: []string{}},
+			},
+			wantTitle: "/home/user/project[white]",
+		},
+		{
+			name: "last folder shown when lastFolderTitle enabled",
+			settings: &Settings{
+				Common:          newTestSettings().Common,
+				sections:        []interface{}{},
+				lastFolderTitle: true,
+			},
+			repos: []*GitRepo{
+				{Repository: "/home/user/project", Branch: "main", ChangedFiles: []string{""}, Commits: []string{}},
+			},
+			wantTitle: "project[white]",
+		},
+		{
+			name: "branch is appended to title when branchInTitle enabled",
+			settings: &Settings{
+				Common:        newTestSettings().Common,
+				sections:      []interface{}{},
+				branchInTitle: true,
+			},
+			repos: []*GitRepo{
+				{Repository: "/home/user/project", Branch: "main", ChangedFiles: []string{""}, Commits: []string{}},
+			},
+			wantTitle: "/home/user/project <main>[white]",
+		},
+		{
+			name: "module name is prefixed when showModuleName enabled",
+			settings: &Settings{
+				Common: &cfg.Common{
+					Colors: cfg.ColorTheme{TextTheme: cfg.TextTheme{Subheading: "red"}},
+					Title:  "Git",
+				},
+				sections:       []interface{}{},
+				showModuleName: true,
+			},
+			repos: []*GitRepo{
+				{Repository: "/home/user/project", Branch: "main", ChangedFiles: []string{""}, Commits: []string{}},
+			},
+			wantTitle: "Git - /home/user/project[white]",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			widget := &Widget{
+				settings: tt.settings,
+				GitRepos: tt.repos,
+			}
+			widget.Idx = tt.idx
+			widget.TextWidget = view.TextWidget{
+				Base: view.NewBase(nil, nil, nil, tt.settings.Common),
+				View: tview.NewTextView(),
+			}
+
+			title, body, wrap := widget.content()
+
+			assert.Equal(t, tt.wantTitle, title)
+			assert.False(t, wrap)
+
+			if tt.wantUnavail {
+				assert.Equal(t, " Git repo data is unavailable ", body)
+			} else {
+				assert.NotEmpty(t, body)
+			}
+		})
+	}
+}

--- a/modules/git/git_repo.go
+++ b/modules/git/git_repo.go
@@ -50,11 +50,7 @@ func (repo *GitRepo) changedFiles() []string {
 }
 
 func (repo *GitRepo) commits(commitCount int, commitFormat, dateFormat string) []string {
-	dateStr := fmt.Sprintf("--date=format:\"%s\"", dateFormat)
-	numStr := fmt.Sprintf("-n %d", commitCount)
-	commitStr := fmt.Sprintf("--pretty=format:\"%s\"", commitFormat)
-
-	arg := []string{repo.gitDir(), repo.workTree(), "log", dateStr, numStr, commitStr}
+	arg := append([]string{repo.gitDir(), repo.workTree()}, commitLogArgs(commitCount, commitFormat, dateFormat)...)
 
 	cmd := exec.Command(__go_cmd, arg...)
 	str := utils.ExecuteCommand(cmd)
@@ -62,6 +58,17 @@ func (repo *GitRepo) commits(commitCount int, commitFormat, dateFormat string) [
 	data := strings.Split(str, "\n")
 
 	return data
+}
+
+// commitLogArgs builds the `git log` arguments used to retrieve recent commits in the
+// requested count, message format, and date format. Extracted as a pure function so the
+// argument formatting can be unit tested without shelling out to git.
+func commitLogArgs(commitCount int, commitFormat, dateFormat string) []string {
+	dateStr := fmt.Sprintf("--date=format:\"%s\"", dateFormat)
+	numStr := fmt.Sprintf("-n %d", commitCount)
+	commitStr := fmt.Sprintf("--pretty=format:\"%s\"", commitFormat)
+
+	return []string{"log", dateStr, numStr, commitStr}
 }
 
 func (repo *GitRepo) repository() string {

--- a/modules/git/git_repo_test.go
+++ b/modules/git/git_repo_test.go
@@ -1,0 +1,127 @@
+package git
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_gitDir(t *testing.T) {
+	repo := &GitRepo{Path: "/home/user/project"}
+	assert.Equal(t, "--git-dir=/home/user/project/.git", repo.gitDir())
+}
+
+func Test_workTree(t *testing.T) {
+	repo := &GitRepo{Path: "/home/user/project"}
+	assert.Equal(t, "--work-tree=/home/user/project", repo.workTree())
+}
+
+func Test_commitLogArgs(t *testing.T) {
+	tests := []struct {
+		name         string
+		commitCount  int
+		commitFormat string
+		dateFormat   string
+		want         []string
+	}{
+		{
+			name:         "basic formatting",
+			commitCount:  5,
+			commitFormat: "%h %s",
+			dateFormat:   "%b %d, %Y",
+			want:         []string{"log", `--date=format:"%b %d, %Y"`, "-n 5", `--pretty=format:"%h %s"`},
+		},
+		{
+			name:         "zero commit count",
+			commitCount:  0,
+			commitFormat: "%h",
+			dateFormat:   "%Y",
+			want:         []string{"log", `--date=format:"%Y"`, "-n 0", `--pretty=format:"%h"`},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, commitLogArgs(tt.commitCount, tt.commitFormat, tt.dateFormat))
+		})
+	}
+}
+
+// initTestRepo creates a temporary git repository with a single commit and returns its path.
+func initTestRepo(t *testing.T) string {
+	t.Helper()
+
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git binary not available")
+	}
+
+	dir := t.TempDir()
+
+	run := func(args ...string) {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=Test", "GIT_AUTHOR_EMAIL=test@example.com",
+			"GIT_COMMITTER_NAME=Test", "GIT_COMMITTER_EMAIL=test@example.com",
+		)
+		out, err := cmd.CombinedOutput()
+		require.NoErrorf(t, err, "git %v failed: %s", args, out)
+	}
+
+	run("init", "-b", "main")
+	run("config", "user.email", "test@example.com")
+	run("config", "user.name", "Test")
+
+	readme := filepath.Join(dir, "README.md")
+	require.NoError(t, os.WriteFile(readme, []byte("hello\n"), 0o644))
+
+	run("add", "README.md")
+	run("commit", "-m", "Initial commit")
+
+	return dir
+}
+
+func Test_NewGitRepo(t *testing.T) {
+	dir := initTestRepo(t)
+
+	repo := NewGitRepo(dir, 5, "%s", "%Y-%m-%d")
+
+	assert.Equal(t, "main\n", repo.Branch)
+	assert.Contains(t, filepath.ToSlash(repo.Repository), filepath.ToSlash(dir))
+	require.Len(t, repo.Commits, 1)
+	assert.Contains(t, repo.Commits[0], "Initial commit")
+	// A clean repo reports only the trailing empty line from `git status --porcelain`.
+	assert.Equal(t, []string{""}, repo.ChangedFiles)
+}
+
+func Test_GitRepo_changedFiles(t *testing.T) {
+	dir := initTestRepo(t)
+
+	untracked := filepath.Join(dir, "untracked.txt")
+	require.NoError(t, os.WriteFile(untracked, []byte("new\n"), 0o644))
+
+	repo := &GitRepo{Path: dir}
+	files := repo.changedFiles()
+
+	require.Len(t, files, 2)
+	assert.Contains(t, files[0], "untracked.txt")
+	assert.True(t, strings.HasPrefix(strings.TrimSpace(files[0]), "??"))
+}
+
+func Test_GitRepo_checkout(t *testing.T) {
+	dir := initTestRepo(t)
+
+	cmd := exec.Command("git", "branch", "feature")
+	cmd.Dir = dir
+	require.NoError(t, cmd.Run())
+
+	repo := &GitRepo{Path: dir}
+	repo.checkout("feature")
+
+	assert.Equal(t, "feature\n", repo.branch())
+}

--- a/modules/git/settings_test.go
+++ b/modules/git/settings_test.go
@@ -1,0 +1,114 @@
+package git
+
+import (
+	"testing"
+
+	"github.com/olebedev/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func parseYAML(t *testing.T, yml string) *config.Config {
+	t.Helper()
+
+	cfg, err := config.ParseYaml(yml)
+	require.NoError(t, err)
+
+	return cfg
+}
+
+func Test_NewSettingsFromYAML(t *testing.T) {
+	globalConfig := parseYAML(t, "wtf:\n  colors: {}\n")
+
+	tests := []struct {
+		name                 string
+		yml                  string
+		wantCommitCount      int
+		wantSections         []interface{}
+		wantShowModuleName   bool
+		wantBranchInTitle    bool
+		wantShowFilesIfEmpty bool
+		wantLastFolderTitle  bool
+		wantCommitFormat     string
+		wantDateFormat       string
+		wantRepositories     []interface{}
+	}{
+		{
+			name:                 "defaults when no config provided",
+			yml:                  "{}",
+			wantCommitCount:      10,
+			wantSections:         []interface{}{"branch", "files", "commits"},
+			wantShowModuleName:   true,
+			wantBranchInTitle:    false,
+			wantShowFilesIfEmpty: true,
+			wantLastFolderTitle:  false,
+			wantCommitFormat:     "[forestgreen]%h [white]%s [grey]%an on %cd[white]",
+			wantDateFormat:       "%b %d, %Y",
+			wantRepositories:     []interface{}{},
+		},
+		{
+			name: "explicit values override defaults",
+			yml: `
+commitCount: 3
+sections: ["branch", "commits"]
+showModuleName: false
+branchInTitle: true
+showFilesIfEmpty: false
+lastFolderTitle: true
+commitFormat: "%h %s"
+dateFormat: "%Y-%m-%d"
+repositories: ["/home/user/project"]
+`,
+			wantCommitCount:      3,
+			wantSections:         []interface{}{"branch", "commits"},
+			wantShowModuleName:   false,
+			wantBranchInTitle:    true,
+			wantShowFilesIfEmpty: false,
+			wantLastFolderTitle:  true,
+			wantCommitFormat:     "%h %s",
+			wantDateFormat:       "%Y-%m-%d",
+			wantRepositories:     []interface{}{"/home/user/project"},
+		},
+		{
+			name:                 "empty sections list falls back to default sections",
+			yml:                  "sections: []\n",
+			wantCommitCount:      10,
+			wantSections:         []interface{}{"branch", "files", "commits"},
+			wantShowModuleName:   true,
+			wantShowFilesIfEmpty: true,
+			wantCommitFormat:     "[forestgreen]%h [white]%s [grey]%an on %cd[white]",
+			wantDateFormat:       "%b %d, %Y",
+			wantRepositories:     []interface{}{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ymlConfig := parseYAML(t, tt.yml)
+
+			settings := NewSettingsFromYAML("git", ymlConfig, globalConfig)
+
+			require.NotNil(t, settings)
+			require.NotNil(t, settings.Common)
+			assert.Equal(t, tt.wantCommitCount, settings.commitCount)
+			assert.Equal(t, tt.wantSections, settings.sections)
+			assert.Equal(t, tt.wantShowModuleName, settings.showModuleName)
+			assert.Equal(t, tt.wantBranchInTitle, settings.branchInTitle)
+			assert.Equal(t, tt.wantShowFilesIfEmpty, settings.showFilesIfEmpty)
+			assert.Equal(t, tt.wantLastFolderTitle, settings.lastFolderTitle)
+			assert.Equal(t, tt.wantCommitFormat, settings.commitFormat)
+			assert.Equal(t, tt.wantDateFormat, settings.dateFormat)
+			assert.Equal(t, tt.wantRepositories, settings.repositories)
+		})
+	}
+}
+
+func Test_ConfigText(t *testing.T) {
+	widget := &Widget{}
+
+	text := widget.ConfigText()
+
+	assert.NotEmpty(t, text)
+	assert.Contains(t, text, "commitCount")
+	assert.Contains(t, text, "repositories")
+}

--- a/modules/git/widget_test.go
+++ b/modules/git/widget_test.go
@@ -1,0 +1,94 @@
+package git
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wtfutil/wtf/cfg"
+)
+
+func Test_currentData(t *testing.T) {
+	repoA := &GitRepo{Repository: "a"}
+	repoB := &GitRepo{Repository: "b"}
+
+	tests := []struct {
+		name  string
+		repos []*GitRepo
+		idx   int
+		want  *GitRepo
+	}{
+		{"no repos returns nil", nil, 0, nil},
+		{"negative index returns nil", []*GitRepo{repoA}, -1, nil},
+		{"index beyond bounds returns nil", []*GitRepo{repoA}, 1, nil},
+		{"valid index returns repo", []*GitRepo{repoA, repoB}, 1, repoB},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			widget := &Widget{GitRepos: tt.repos}
+			widget.Idx = tt.idx
+
+			assert.Equal(t, tt.want, widget.currentData())
+		})
+	}
+}
+
+func Test_gitRepos(t *testing.T) {
+	dir := initTestRepo(t)
+
+	widget := &Widget{
+		settings: &Settings{
+			Common:       &cfg.Common{},
+			commitCount:  1,
+			commitFormat: "%s",
+			dateFormat:   "%Y",
+		},
+	}
+
+	repos := widget.gitRepos([]string{dir})
+
+	require.Len(t, repos, 1)
+	assert.Equal(t, "main\n", repos[0].Branch)
+}
+
+func Test_findGitRepositories(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git binary not available")
+	}
+
+	root := t.TempDir()
+
+	repoOne := filepath.Join(root, "repo-one")
+	repoTwo := filepath.Join(root, "nested", "repo-two")
+	ignored := filepath.Join(root, "vendor", "repo-three")
+
+	for _, path := range []string{repoOne, repoTwo, ignored} {
+		require.NoError(t, os.MkdirAll(path, 0o755))
+		cmd := exec.Command("git", "init", "-b", "main")
+		cmd.Dir = path
+		require.NoError(t, cmd.Run())
+	}
+
+	widget := &Widget{
+		settings: &Settings{
+			Common:       &cfg.Common{},
+			commitCount:  1,
+			commitFormat: "%s",
+			dateFormat:   "%Y",
+		},
+	}
+
+	repos := widget.findGitRepositories(make([]*GitRepo, 0), root)
+
+	require.Len(t, repos, 2)
+
+	var found []string
+	for _, r := range repos {
+		found = append(found, filepath.Base(r.Path))
+	}
+	assert.ElementsMatch(t, []string{"repo-one", "repo-two"}, found)
+}


### PR DESCRIPTION
## Summary
Adds table-driven unit tests for `modules/git`, covering formatting, output parsing, and settings. Coverage went from 0% to 59.6% (`go test ./modules/git/... -cover`).

## What's covered
- **display_test.go**: `formatChange`/`formatChanges`/`formatCommit`/`formatCommits`, and `content()` title logic (branch-in-title, last-folder-title, show-module-name, unavailable states).
- **git_repo_test.go**: `gitDir`/`workTree` (pure), `commitLogArgs` (new pure helper extracted from `commits()` for testability), plus integration tests against real temporary git repos for `NewGitRepo`, `changedFiles`, and `checkout`.
- **settings_test.go**: `NewSettingsFromYAML` defaults/overrides/empty-sections fallback, `ConfigText`.
- **widget_test.go**: `currentData`, `gitRepos`, `findGitRepositories` (real nested repos, including `vendor`/`node_modules` exclusion).

## Refactor
Extracted `commitLogArgs()` out of `GitRepo.commits()` as a small pure function so the `git log` argument formatting can be unit tested without shelling out to git. No behavior change.

## Validation
- `go build ./...` — clean
- `go vet ./modules/git/...` — clean
- `golangci-lint run ./modules/git/...` — clean except pre-existing gofmt CRLF false positives on Windows checkouts (reproducible on unmodified files elsewhere in the repo; not introduced by this change)
- `go test ./modules/git/... -cover` — all tests pass, 59.6% coverage