### PR TITLE
Add explicit permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -6,6 +6,10 @@ on:
       - trunk
   pull_request:
 
+permissions:
+  contents: read
+  security-events: write
+
 jobs:
   analyze:
     runs-on: ubuntu-24.04

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - trunk
   pull_request:
+
+permissions:
+  contents: read
+
 jobs:
   golangci:
     name: lint

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - '*'
 
+permissions:
+  contents: write
+
 jobs:
   goreleaser:
     runs-on: ubuntu-24.04

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - trunk
 
+permissions:
+  contents: read
+
 jobs:
   goreleaser:
     runs-on: ubuntu-24.04

--- a/.github/workflows/staticcheck.yml
+++ b/.github/workflows/staticcheck.yml
@@ -1,6 +1,10 @@
 name: static check
 on: pull_request
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   imports:
     name: Imports


### PR DESCRIPTION
## Summary

Adds least-privilege `permissions` declarations to all workflow files to resolve CodeQL code scanning alerts #52–#59.

## Changes

| Workflow | Permissions | Rationale |
|----------|------------|-----------|
| `staticcheck.yml` | `contents: read`, `pull-requests: write` | Checks out code; action posts PR comments via `GITHUB_TOKEN` |
| `golangci-lint.yml` | `contents: read` | Only checks out and lints code |
| `codeql-analysis.yml` | `contents: read`, `security-events: write` | Checks out code; uploads SARIF results |
| `goreleaser.yml` | `contents: write` | Uploads release assets (uses PAT but safe fallback) |
| `pr-checks.yml` | `contents: read` | Only checks out code and runs snapshot build |

## Testing

- The PR-triggered workflows (`staticcheck`, `golangci-lint`, `codeql-analysis`, `pr-checks`) will run on this PR — if permissions are too restrictive, jobs will fail with 403 errors.
- `goreleaser.yml` only triggers on tags and can be validated separately.