### PR TITLE
Add amd64v3 build support for linux binaries

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,6 +13,12 @@ builds:
   - arm64
   goarm:
   - 7
+  goamd64:
+  - v1
+  - v3
+  ignore:
+  - goos: darwin
+    goamd64: v3
 - id: wtf
   binary: wtfutil
   goos:
@@ -22,6 +28,12 @@ builds:
   - amd64
   - arm
   - arm64
+  goamd64:
+  - v1
+  - v3
+  ignore:
+  - goos: darwin
+    goamd64: v3
 
 archives:
 - id: tessera


### PR DESCRIPTION
Closes #1888 by adding amd64v3 microarchitecture builds via GoReleaser's built-in goamd64 support.

Changes:
- .goreleaser.yml: added goamd64: [v1, v3] to both the tessera and wtf build entries.
- Added an ignore rule (goos: darwin + goamd64: v3) so v3 builds are Linux-only.
- No archive name_template or CI changes needed.

Validation: goreleaser check passed; goreleaser build --snapshot --clean produced linux_amd64_v3 binaries for both tessera and wtfutil with no darwin_amd64_v3; archive naming confirmed correct.