### PR TITLE
fix: Ctrl+C now exits cleanly via os.Exit(0)

### DIFF
--- a/app/wtf_app.go
+++ b/app/wtf_app.go
@@ -155,9 +155,7 @@ func (wtfApp *WtfApp) keyboardIntercept(event *tcell.EventKey) *tcell.EventKey {
 	// These keys are global keys used by the app. Widgets should not implement these keys
 	switch event.Key() {
 	case tcell.KeyCtrlC:
-		wtfApp.Stop()
-		wtfApp.TViewApp.Stop()
-		wtfApp.DisplayExitMessage()
+		wtfApp.Exit()
 	case tcell.KeyCtrlR:
 		wtfApp.refreshAllWidgets()
 		return nil


### PR DESCRIPTION
## Problem

Pressing Ctrl+C to exit the app would stop the tview event loop but leave the process hanging. Background goroutines (widget refresh schedules, config file watcher, HTTP calls) kept the process alive indefinitely.

## Fix

Replace the inline stop logic in the Ctrl+C handler with a call to `wtfApp.Exit()`, which calls `os.Exit(0)` after cleanup — matching the behavior of the `q` quit key.