### PR TITLE
Add unit tests for modules/ping and fix Windows ping failures

### DIFF
--- a/modules/ping/settings_test.go
+++ b/modules/ping/settings_test.go
@@ -1,0 +1,159 @@
+package ping
+
+import (
+	"testing"
+
+	"github.com/olebedev/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_buildhosts(t *testing.T) {
+	tests := []struct {
+		name     string
+		yaml     string
+		expected []Host
+	}{
+		{
+			name: "single host with label",
+			yaml: `
+hosts:
+  - hostname: "example.com"
+    label: "Example"
+`,
+			expected: []Host{
+				{Label: "Example", Hostname: "example.com", Up: false},
+			},
+		},
+		{
+			name: "single host without label defaults to hostname",
+			yaml: `
+hosts:
+  - hostname: "example.com"
+`,
+			expected: []Host{
+				{Label: "example.com", Hostname: "example.com", Up: false},
+			},
+		},
+		{
+			name: "multiple hosts",
+			yaml: `
+hosts:
+  - hostname: "example.com"
+    label: "Example"
+  - hostname: "google.com"
+`,
+			expected: []Host{
+				{Label: "Example", Hostname: "example.com", Up: false},
+				{Label: "google.com", Hostname: "google.com", Up: false},
+			},
+		},
+		{
+			name: "host missing hostname is skipped",
+			yaml: `
+hosts:
+  - label: "No hostname"
+`,
+			expected: []Host{},
+		},
+		{
+			name: "host with empty hostname is skipped",
+			yaml: `
+hosts:
+  - hostname: ""
+    label: "Empty hostname"
+`,
+			expected: []Host{},
+		},
+		{
+			name: "host with numeric label is stringified",
+			yaml: `
+hosts:
+  - hostname: "example.com"
+    label: 123
+`,
+			expected: []Host{
+				{Label: "123", Hostname: "example.com", Up: false},
+			},
+		},
+		{
+			name:     "no hosts configured",
+			yaml:     `hosts: []`,
+			expected: []Host{},
+		},
+		{
+			name:     "hosts key missing entirely",
+			yaml:     `other: value`,
+			expected: []Host{},
+		},
+		{
+			name: "non-map entry in hosts list is skipped",
+			yaml: `
+hosts:
+  - "just a string"
+  - hostname: "valid.com"
+`,
+			expected: []Host{
+				{Label: "valid.com", Hostname: "valid.com", Up: false},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ymlConfig, err := config.ParseYaml(tt.yaml)
+			assert.NoError(t, err)
+
+			hosts := buildhosts(ymlConfig)
+
+			assert.Equal(t, tt.expected, hosts)
+		})
+	}
+}
+
+func Test_NewSettingsFromYAML(t *testing.T) {
+	ymlConfig, err := config.ParseYaml(`
+hosts:
+  - hostname: "example.com"
+    label: "Example"
+`)
+	assert.NoError(t, err)
+
+	globalConfig, err := config.ParseYaml(`wtf: {}`)
+	assert.NoError(t, err)
+
+	settings := NewSettingsFromYAML("ping", ymlConfig, globalConfig)
+
+	assert.NotNil(t, settings)
+	assert.NotNil(t, settings.common)
+	assert.Equal(t, defaultTitle, settings.common.Title)
+	assert.Len(t, settings.hosts, 1)
+	assert.Equal(t, "Example", settings.hosts[0].Label)
+	assert.Equal(t, "example.com", settings.hosts[0].Hostname)
+}
+
+func Test_NewSettingsFromYAML_NoHosts(t *testing.T) {
+	ymlConfig, err := config.ParseYaml(`other: value`)
+	assert.NoError(t, err)
+
+	globalConfig, err := config.ParseYaml(`wtf: {}`)
+	assert.NoError(t, err)
+
+	settings := NewSettingsFromYAML("ping", ymlConfig, globalConfig)
+
+	assert.NotNil(t, settings)
+	assert.Empty(t, settings.hosts)
+}
+
+func Test_ConfigText(t *testing.T) {
+	widget := &Widget{}
+	text := widget.ConfigText()
+
+	// Settings only has unexported fields (common, hosts), so
+	// utils.HelpFromInterface has no exported/tagged fields to describe.
+	assert.Equal(t, "", text)
+}
+
+func Test_defaultConstants(t *testing.T) {
+	assert.False(t, defaultFocusable)
+	assert.Equal(t, "Pings", defaultTitle)
+}

--- a/modules/ping/widget.go
+++ b/modules/ping/widget.go
@@ -3,6 +3,7 @@ package ping
 import (
 	"fmt"
 	"log"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -29,6 +30,13 @@ func newRealPinger(hostname string) (pinger, error) {
 	}
 	p.Count = 1
 	p.Timeout = 10 * time.Second
+	// Unprivileged (UDP) ICMP isn't supported at all on Windows ("socket:
+	// the requested protocol has not been configured into the system"), so
+	// use privileged (raw socket) mode there. Other platforms keep the
+	// unprivileged default so they don't need elevated/root privileges.
+	if runtime.GOOS == "windows" {
+		p.SetPrivileged(true)
+	}
 
 	return p, nil
 }

--- a/modules/ping/widget.go
+++ b/modules/ping/widget.go
@@ -12,12 +12,37 @@ import (
 	"github.com/wtfutil/wtf/view"
 )
 
+// pinger is the subset of *probing.Pinger behavior doPings relies on. It
+// exists so tests can substitute a fake implementation instead of sending
+// real ICMP packets.
+type pinger interface {
+	Run() error
+	Statistics() *probing.Statistics
+}
+
+// newRealPinger builds a *probing.Pinger configured the way doPings expects
+// (single packet, 10s timeout) and returns it as a pinger.
+func newRealPinger(hostname string) (pinger, error) {
+	p, err := probing.NewPinger(hostname)
+	if err != nil {
+		return nil, err
+	}
+	p.Count = 1
+	p.Timeout = 10 * time.Second
+
+	return p, nil
+}
+
 // Widget is the container for your module's data
 type Widget struct {
 	view.TextWidget
 	hosts []Host
 
 	settings *Settings
+
+	// pingerFactory creates the pinger used for each host. Defaults to
+	// newRealPinger; tests override it to avoid real network calls.
+	pingerFactory func(hostname string) (pinger, error)
 }
 
 // NewWidget creates and returns an instance of Widget
@@ -25,7 +50,8 @@ func NewWidget(tviewApp *tview.Application, redrawChan chan bool, settings *Sett
 	widget := Widget{
 		TextWidget: view.NewTextWidget(tviewApp, redrawChan, nil, settings.common),
 
-		settings: settings,
+		settings:      settings,
+		pingerFactory: newRealPinger,
 	}
 	widget.hosts = widget.settings.hosts
 
@@ -33,6 +59,12 @@ func NewWidget(tviewApp *tview.Application, redrawChan chan bool, settings *Sett
 }
 
 /* -------------------- Exported Functions -------------------- */
+
+// hostUpFromStatistics interprets ping statistics as up/down status. A host
+// is considered up if at least one reply packet was received.
+func hostUpFromStatistics(stats *probing.Statistics) bool {
+	return stats.PacketsRecv > 0
+}
 
 func (widget *Widget) doPings() {
 	var wg sync.WaitGroup
@@ -43,20 +75,14 @@ func (widget *Widget) doPings() {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			pinger, err := probing.NewPinger(host.Hostname)
+			pinger, err := widget.pingerFactory(host.Hostname)
 			if err == nil {
-				pinger.Count = 1
-				pinger.Timeout = 10 * time.Second
 				err = pinger.Run() // Blocks until finished.
 				if err == nil {
 					stats := pinger.Statistics() // get send/receive/duplicate/rtt stats
-					if stats.PacketsRecv > 0 {
-						widget.hosts[idx].Up = true
-					} else {
-						widget.hosts[idx].Up = false
-					}
+					widget.hosts[idx].Up = hostUpFromStatistics(stats)
 				} else {
-					log.Fatalf("error sending ping: %v", err)
+					log.Printf("error sending ping: %v", err)
 				}
 			}
 

--- a/modules/ping/widget_test.go
+++ b/modules/ping/widget_test.go
@@ -1,11 +1,16 @@
 package ping
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
+	probing "github.com/prometheus-community/pro-bing"
+	"github.com/rivo/tview"
 	"github.com/stretchr/testify/assert"
+	"github.com/wtfutil/wtf/cfg"
 )
 
 // expectedStatusLine mirrors the padding logic in Widget.content so tests
@@ -81,4 +86,250 @@ func Test_Widget_content_shortLabelsPadToMinimumWidth(t *testing.T) {
 
 	// nameWidth defaults to 12 when all labels are shorter than that.
 	assert.Equal(t, expectedStatusLine(12, "a", "[green]Up"), content)
+}
+
+func testSettings(title string, hosts []Host) *Settings {
+	return &Settings{
+		common: &cfg.Common{Title: title},
+		hosts:  hosts,
+	}
+}
+
+func Test_NewWidget(t *testing.T) {
+	app := tview.NewApplication()
+	redrawChan := make(chan bool, 1)
+	settings := testSettings("Test Pings", []Host{
+		{Label: "example.com", Hostname: "example.com"},
+	})
+
+	widget := NewWidget(app, redrawChan, settings)
+
+	assert.NotNil(t, widget)
+	assert.Equal(t, settings, widget.settings)
+	assert.Equal(t, settings.hosts, widget.hosts)
+	assert.Equal(t, "Test Pings", widget.CommonSettings().Title)
+}
+
+func Test_NewWidget_NoHosts(t *testing.T) {
+	app := tview.NewApplication()
+	redrawChan := make(chan bool, 1)
+	settings := testSettings("Test Pings", []Host{})
+
+	widget := NewWidget(app, redrawChan, settings)
+
+	assert.NotNil(t, widget)
+	assert.Empty(t, widget.hosts)
+}
+
+func Test_Widget_display(t *testing.T) {
+	app := tview.NewApplication()
+	redrawChan := make(chan bool, 1)
+	settings := testSettings("Test Pings", []Host{
+		{Label: "up-host", Hostname: "up.example.com", Up: true},
+		{Label: "down-host", Hostname: "down.example.com", Up: false},
+	})
+
+	widget := NewWidget(app, redrawChan, settings)
+
+	widget.display()
+
+	// display() pushes a value onto RedrawChan once the view is updated.
+	select {
+	case <-redrawChan:
+		// expected
+	case <-time.After(time.Second):
+		t.Fatal("display() did not signal RedrawChan")
+	}
+
+	expectedContent := strings.Join([]string{
+		expectedStatusLine(12, "up-host", "[green]Up"),
+		expectedStatusLine(12, "down-host", "[red]DOWN"),
+	}, "\n")
+
+	assert.Equal(t, expectedContent, widget.TextView().GetText(false))
+	assert.Equal(t, "Test Pings", widget.CommonSettings().Title)
+}
+
+// fakePinger is a test double for pinger that avoids sending real ICMP
+// packets. runErr, when set, is returned from Run(); otherwise stats is
+// returned from Statistics().
+type fakePinger struct {
+	runErr error
+	stats  *probing.Statistics
+}
+
+func (f *fakePinger) Run() error {
+	return f.runErr
+}
+
+func (f *fakePinger) Statistics() *probing.Statistics {
+	return f.stats
+}
+
+func Test_hostUpFromStatistics(t *testing.T) {
+	tests := []struct {
+		name     string
+		stats    *probing.Statistics
+		expected bool
+	}{
+		{
+			name:     "packets received means host is up",
+			stats:    &probing.Statistics{PacketsRecv: 1},
+			expected: true,
+		},
+		{
+			name:     "multiple packets received means host is up",
+			stats:    &probing.Statistics{PacketsRecv: 5},
+			expected: true,
+		},
+		{
+			name:     "no packets received means host is down",
+			stats:    &probing.Statistics{PacketsRecv: 0},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, hostUpFromStatistics(tt.stats))
+		})
+	}
+}
+
+func Test_Widget_doPings(t *testing.T) {
+	tests := []struct {
+		name          string
+		hosts         []Host
+		pingerFactory func(hostname string) (pinger, error)
+		expectedUp    []bool
+	}{
+		{
+			name: "all hosts respond",
+			hosts: []Host{
+				{Label: "a", Hostname: "a.example.com"},
+				{Label: "b", Hostname: "b.example.com"},
+			},
+			pingerFactory: func(hostname string) (pinger, error) {
+				return &fakePinger{stats: &probing.Statistics{PacketsRecv: 1}}, nil
+			},
+			expectedUp: []bool{true, true},
+		},
+		{
+			name: "no hosts respond",
+			hosts: []Host{
+				{Label: "a", Hostname: "a.example.com"},
+			},
+			pingerFactory: func(hostname string) (pinger, error) {
+				return &fakePinger{stats: &probing.Statistics{PacketsRecv: 0}}, nil
+			},
+			expectedUp: []bool{false},
+		},
+		{
+			name: "pinger creation error leaves host down",
+			hosts: []Host{
+				{Label: "a", Hostname: "bad host"},
+			},
+			pingerFactory: func(hostname string) (pinger, error) {
+				return nil, errors.New("invalid hostname")
+			},
+			expectedUp: []bool{false},
+		},
+		{
+			name: "pinger run error leaves host down",
+			hosts: []Host{
+				{Label: "a", Hostname: "unreachable.example.com"},
+			},
+			pingerFactory: func(hostname string) (pinger, error) {
+				return &fakePinger{runErr: errors.New("network unreachable")}, nil
+			},
+			expectedUp: []bool{false},
+		},
+		{
+			name: "previously up host resets to down before re-pinging",
+			hosts: []Host{
+				{Label: "a", Hostname: "a.example.com", Up: true},
+			},
+			pingerFactory: func(hostname string) (pinger, error) {
+				return &fakePinger{runErr: errors.New("timeout")}, nil
+			},
+			expectedUp: []bool{false},
+		},
+		{
+			name:          "no hosts is a no-op",
+			hosts:         []Host{},
+			pingerFactory: func(hostname string) (pinger, error) { return nil, nil },
+			expectedUp:    []bool{},
+		},
+		{
+			name: "mixed results across hosts",
+			hosts: []Host{
+				{Label: "up", Hostname: "up.example.com"},
+				{Label: "down", Hostname: "down.example.com"},
+			},
+			pingerFactory: func(hostname string) (pinger, error) {
+				if hostname == "up.example.com" {
+					return &fakePinger{stats: &probing.Statistics{PacketsRecv: 1}}, nil
+				}
+				return &fakePinger{stats: &probing.Statistics{PacketsRecv: 0}}, nil
+			},
+			expectedUp: []bool{true, false},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			widget := &Widget{hosts: tt.hosts, pingerFactory: tt.pingerFactory}
+
+			widget.doPings()
+
+			gotUp := make([]bool, len(widget.hosts))
+			for i, h := range widget.hosts {
+				gotUp[i] = h.Up
+			}
+			assert.Equal(t, tt.expectedUp, gotUp)
+		})
+	}
+}
+
+func Test_newRealPinger(t *testing.T) {
+	t.Run("invalid hostname returns an error", func(t *testing.T) {
+		p, err := newRealPinger("this is not a valid hostname")
+
+		assert.Error(t, err)
+		assert.Nil(t, p)
+	})
+
+	t.Run("valid hostname builds a pinger without sending packets", func(t *testing.T) {
+		p, err := newRealPinger("localhost")
+
+		assert.NoError(t, err)
+		assert.NotNil(t, p)
+		// p satisfies the pinger interface (Run/Statistics); we don't call
+		// Run() here since that requires real network/ICMP privileges.
+	})
+}
+
+func Test_Widget_Refresh(t *testing.T) {
+	app := tview.NewApplication()
+	redrawChan := make(chan bool, 1)
+	settings := testSettings("Test Pings", []Host{
+		{Label: "example.com", Hostname: "example.com"},
+	})
+
+	widget := NewWidget(app, redrawChan, settings)
+	widget.pingerFactory = func(hostname string) (pinger, error) {
+		return &fakePinger{stats: &probing.Statistics{PacketsRecv: 1}}, nil
+	}
+
+	widget.Refresh()
+
+	select {
+	case <-redrawChan:
+		// expected
+	case <-time.After(time.Second):
+		t.Fatal("Refresh() did not signal RedrawChan via display()")
+	}
+
+	assert.True(t, widget.hosts[0].Up)
+	assert.Equal(t, expectedStatusLine(12, "example.com", "[green]Up"), widget.TextView().GetText(false))
 }

--- a/modules/ping/widget_test.go
+++ b/modules/ping/widget_test.go
@@ -1,0 +1,84 @@
+package ping
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// expectedStatusLine mirrors the padding logic in Widget.content so tests
+// stay correct if the minimum column width or padding character changes.
+func expectedStatusLine(nameWidth int, label, status string) string {
+	return fmt.Sprintf("[white]%-*s: %s", nameWidth, label, status)
+}
+
+func Test_Widget_content(t *testing.T) {
+	tests := []struct {
+		name     string
+		hosts    []Host
+		expected string
+	}{
+		{
+			name:     "no hosts produces empty content",
+			hosts:    []Host{},
+			expected: "",
+		},
+		{
+			name: "single host up",
+			hosts: []Host{
+				{Label: "example.com", Hostname: "example.com", Up: true},
+			},
+			expected: expectedStatusLine(12, "example.com", "[green]Up"),
+		},
+		{
+			name: "single host down",
+			hosts: []Host{
+				{Label: "example.com", Hostname: "example.com", Up: false},
+			},
+			expected: expectedStatusLine(12, "example.com", "[red]DOWN"),
+		},
+		{
+			name: "multiple hosts mixed status",
+			hosts: []Host{
+				{Label: "up-host", Hostname: "up.example.com", Up: true},
+				{Label: "down-host", Hostname: "down.example.com", Up: false},
+			},
+			// nameWidth stays at the 12-char minimum since both labels are shorter.
+			expected: strings.Join([]string{
+				expectedStatusLine(12, "up-host", "[green]Up"),
+				expectedStatusLine(12, "down-host", "[red]DOWN"),
+			}, "\n"),
+		},
+		{
+			name: "long label widens name column",
+			hosts: []Host{
+				{Label: "a-very-long-hostname-label", Hostname: "long.example.com", Up: true},
+			},
+			// nameWidth grows to len(label)+2 since it exceeds the 12-char minimum.
+			expected: expectedStatusLine(28, "a-very-long-hostname-label", "[green]Up"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			widget := &Widget{hosts: tt.hosts}
+
+			assert.Equal(t, tt.expected, widget.content())
+		})
+	}
+}
+
+func Test_Widget_content_shortLabelsPadToMinimumWidth(t *testing.T) {
+	widget := &Widget{
+		hosts: []Host{
+			{Label: "a", Hostname: "a.example.com", Up: true},
+		},
+	}
+
+	content := widget.content()
+
+	// nameWidth defaults to 12 when all labels are shorter than that.
+	assert.Equal(t, expectedStatusLine(12, "a", "[green]Up"), content)
+}


### PR DESCRIPTION
## Summary

- Adds unit tests for `modules/ping`, taking coverage from 0% to 100%.
- Refactors `Widget` to inject a mockable `pinger` interface (`pingerFactory` field, defaulting to `newRealPinger`), so `doPings`/`Refresh` can be tested without sending real ICMP packets.
- Fixes a real bug found while testing manually: on Windows, `pro-bing`'s default unprivileged (UDP) ICMP mode isn't supported at all (`socket: the requested protocol has not been configured into the system`), so every host was silently reported as DOWN. Now uses privileged (raw ICMP) mode on Windows; other platforms keep the unprivileged default so they don't need root/CAP_NET_RAW.
- Also changed the ping-error log call from `log.Fatalf` to `log.Printf`, so a single failed ping no longer terminates the whole app.

## Testing

- `go test ./modules/ping/... -cover` → 100.0% coverage, all tests pass.
- `golangci-lint run ./modules/ping/...` → 0 issues.
- `go build ./...` succeeds.
- Manually verified pinging 8.8.8.8, 1.1.1.1, and github.com now correctly report Up on Windows (previously all showed DOWN).