### PR TITLE
nbascore: Switch to ESPN API, add tests, improve UX

### DIFF
--- a/modules/nbascore/widget.go
+++ b/modules/nbascore/widget.go
@@ -15,7 +15,7 @@ import (
 
 var (
 	offset     = 0
-	nbaBaseURL = "http://data.nba.net/10s/prod/v1"
+	nbaBaseURL = "https://site.api.espn.com/apis/site/v2/sports/basketball/nba/scoreboard"
 )
 
 // A Widget represents an NBA Score  widget
@@ -45,18 +45,52 @@ func (widget *Widget) Refresh() {
 	widget.Redraw(widget.nbascore)
 }
 
+// ESPN API response structures
+type espnResponse struct {
+	Events []espnEvent `json:"events"`
+}
+
+type espnEvent struct {
+	Competitions []espnCompetition `json:"competitions"`
+	Status       espnStatus        `json:"status"`
+}
+
+type espnCompetition struct {
+	Competitors []espnCompetitor `json:"competitors"`
+}
+
+type espnCompetitor struct {
+	HomeAway string   `json:"homeAway"`
+	Team     espnTeam `json:"team"`
+	Score    string   `json:"score"`
+}
+
+type espnTeam struct {
+	Abbreviation string `json:"abbreviation"`
+}
+
+type espnStatus struct {
+	Period int            `json:"period"`
+	Type   espnStatusType `json:"type"`
+}
+
+type espnStatusType struct {
+	State string `json:"state"`
+}
+
 func (widget *Widget) nbascore() (string, string, bool) {
 	title := widget.CommonSettings().Title
-	cur := time.Now().AddDate(0, 0, offset) // Go back/forward offset days
-	curString := cur.Format("20060102")     // Need 20060102 format to feed to api
-	client := &http.Client{}
-	req, err := http.NewRequest("GET", nbaBaseURL+"/"+curString+"/scoreboard.json", http.NoBody)
+	cur := time.Now().AddDate(0, 0, offset)
+	dateStr := cur.Format("20060102")
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	req, err := http.NewRequest("GET", nbaBaseURL+"?dates="+dateStr, http.NoBody)
 	if err != nil {
 		return title, err.Error(), true
 	}
 
 	req.Header.Set("Accept-Language", widget.language)
-	req.Header.Set("User-Agent", "curl")
+	req.Header.Set("User-Agent", "WTFUtil (+https://wtfutil.com)")
 	response, err := client.Do(req)
 	if err != nil {
 		return title, err.Error(), true
@@ -64,13 +98,14 @@ func (widget *Widget) nbascore() (string, string, bool) {
 	defer func() { _ = response.Body.Close() }()
 	if response.StatusCode != 200 {
 		return title, fmt.Sprintf("unexpected status code: %d", response.StatusCode), true
-	} // Get data from data.nba.net and check if successful
+	}
 
 	contents, err := io.ReadAll(response.Body)
 	if err != nil {
 		return title, err.Error(), true
 	}
-	result := map[string]interface{}{}
+
+	var result espnResponse
 	err = json.Unmarshal(contents, &result)
 	if err != nil {
 		return title, err.Error(), true
@@ -78,49 +113,36 @@ func (widget *Widget) nbascore() (string, string, bool) {
 
 	allGame := fmt.Sprintf(" [%s]", widget.settings.Colors.Subheading) + (cur.Format(utils.FriendlyDateFormat) + "\n\n") + "[white]"
 
-	for _, game := range result["games"].([]interface{}) {
-		vTeam, hTeam, vScore, hScore := "", "", "", ""
-		quarter := 0.
-		activate := false
-		for keyGame, team := range game.(map[string]interface{}) { // assertion
-			switch keyGame {
-			case "vTeam", "hTeam":
-				for keyTeam, stat := range team.(map[string]interface{}) {
-					switch keyTeam {
-					case "triCode":
-						if keyGame == "vTeam" {
-							vTeam = stat.(string)
-						} else {
-							hTeam = stat.(string)
-						}
-					case "score":
-						if keyGame == "vTeam" {
-							vScore = stat.(string)
-						} else {
-							hScore = stat.(string)
-						}
-					}
-				}
-			case "period":
-				for keyTeam, stat := range team.(map[string]interface{}) {
-					if keyTeam == "current" {
-						quarter = stat.(float64)
-					}
-				}
-			case "isGameActivated":
-				activate = team.(bool)
+	for _, event := range result.Events {
+		if len(event.Competitions) == 0 {
+			continue
+		}
+		comp := event.Competitions[0]
+
+		var vTeam, hTeam, vScore, hScore string
+		for _, c := range comp.Competitors {
+			if c.HomeAway == "home" {
+				hTeam = c.Team.Abbreviation
+				hScore = c.Score
+			} else {
+				vTeam = c.Team.Abbreviation
+				vScore = c.Score
 			}
 		}
+
+		quarter := event.Status.Period
+		// state: "pre" = not started, "in" = active, "post" = final
+		active := event.Status.Type.State == "in"
+
 		vNum, _ := strconv.Atoi(vScore)
 		hNum, _ := strconv.Atoi(hScore)
 		hColor := ""
-		if quarter != 0 { // Compare the score
+		if quarter != 0 {
 			switch {
 			case vNum > hNum:
 				vTeam = "[orange]" + vTeam
 			case hNum > vNum:
-				// hScore = "[orange]" + hScore
-				hColor = "[orange]" // For correct padding
+				hColor = "[orange]"
 				hTeam += "[white]"
 			default:
 				vTeam = "[orange]" + vTeam
@@ -129,10 +151,10 @@ func (widget *Widget) nbascore() (string, string, bool) {
 			}
 		}
 		qColor := "[white]"
-		if activate {
+		if active {
 			qColor = "[sandybrown]"
 		}
-		allGame += fmt.Sprintf("%s%5s%v[white] %s %3s [white]vs %s%-3s %s\n", qColor, "Q", quarter, vTeam, vScore, hColor, hScore, hTeam) // Format the score and store in allgame
+		allGame += fmt.Sprintf("%s%5s%v[white] %s %3s [white]vs %s%-3s %s\n", qColor, "Q", quarter, vTeam, vScore, hColor, hScore, hTeam)
 	}
 	return title, allGame, false
 }

--- a/modules/nbascore/widget.go
+++ b/modules/nbascore/widget.go
@@ -47,7 +47,12 @@ func (widget *Widget) Refresh() {
 
 // ESPN API response structures
 type espnResponse struct {
+	Day    espnDay     `json:"day"`
 	Events []espnEvent `json:"events"`
+}
+
+type espnDay struct {
+	Date string `json:"date"`
 }
 
 type espnEvent struct {
@@ -112,6 +117,17 @@ func (widget *Widget) nbascore() (string, string, bool) {
 	}
 
 	allGame := fmt.Sprintf(" [%s]", widget.settings.Colors.Subheading) + (cur.Format(utils.FriendlyDateFormat) + "\n\n") + "[white]"
+
+	if len(result.Events) == 0 {
+		msg := " No games scheduled"
+		if result.Day.Date != "" {
+			if nextDate, err := time.Parse("2006-01-02", result.Day.Date); err == nil {
+				msg += "\n Next game: " + nextDate.Format(utils.FriendlyDateFormat)
+			}
+		}
+		allGame += msg
+		return title, allGame, false
+	}
 
 	for _, event := range result.Events {
 		if len(event.Competitions) == 0 {

--- a/modules/nbascore/widget.go
+++ b/modules/nbascore/widget.go
@@ -13,7 +13,10 @@ import (
 	"github.com/wtfutil/wtf/view"
 )
 
-var offset = 0
+var (
+	offset     = 0
+	nbaBaseURL = "http://data.nba.net/10s/prod/v1"
+)
 
 // A Widget represents an NBA Score  widget
 type Widget struct {
@@ -47,7 +50,7 @@ func (widget *Widget) nbascore() (string, string, bool) {
 	cur := time.Now().AddDate(0, 0, offset) // Go back/forward offset days
 	curString := cur.Format("20060102")     // Need 20060102 format to feed to api
 	client := &http.Client{}
-	req, err := http.NewRequest("GET", "http://data.nba.net/10s/prod/v1/"+curString+"/scoreboard.json", http.NoBody)
+	req, err := http.NewRequest("GET", nbaBaseURL+"/"+curString+"/scoreboard.json", http.NoBody)
 	if err != nil {
 		return title, err.Error(), true
 	}
@@ -60,7 +63,7 @@ func (widget *Widget) nbascore() (string, string, bool) {
 	}
 	defer func() { _ = response.Body.Close() }()
 	if response.StatusCode != 200 {
-		return title, err.Error(), true
+		return title, fmt.Sprintf("unexpected status code: %d", response.StatusCode), true
 	} // Get data from data.nba.net and check if successful
 
 	contents, err := io.ReadAll(response.Body)

--- a/modules/nbascore/widget_test.go
+++ b/modules/nbascore/widget_test.go
@@ -63,6 +63,16 @@ func buildESPNResponse(events []espnEvent) []byte {
 	return b
 }
 
+// buildESPNResponseWithDay builds an ESPN response with a day.date field.
+func buildESPNResponseWithDay(events []espnEvent, dayDate string) []byte {
+	data := espnResponse{
+		Day:    espnDay{Date: dayDate},
+		Events: events,
+	}
+	b, _ := json.Marshal(data)
+	return b
+}
+
 func makeEvent(awayAbbr, homeAbbr, awayScore, homeScore string, period int, state string) espnEvent {
 	return espnEvent{
 		Competitions: []espnCompetition{
@@ -114,7 +124,7 @@ func TestNbascore_SuccessfulResponse(t *testing.T) {
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write(buildESPNResponse(events))
+		_, _ = w.Write(buildESPNResponse(events))
 	}))
 	defer ts.Close()
 
@@ -152,7 +162,7 @@ func TestNbascore_SuccessfulResponse(t *testing.T) {
 func TestNbascore_EmptyGames(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write(buildESPNResponse([]espnEvent{}))
+		_, _ = w.Write(buildESPNResponseWithDay([]espnEvent{}, "2026-10-05"))
 	}))
 	defer ts.Close()
 
@@ -174,12 +184,47 @@ func TestNbascore_EmptyGames(t *testing.T) {
 	if !strings.Contains(content, today) {
 		t.Errorf("expected content to contain date %q", today)
 	}
+	if !strings.Contains(content, "No games scheduled") {
+		t.Errorf("expected 'No games scheduled' message, got %q", content)
+	}
+	if !strings.Contains(content, "Next game:") {
+		t.Errorf("expected 'Next game:' message, got %q", content)
+	}
+}
+
+func TestNbascore_EmptyGamesNoNextDate(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(buildESPNResponse([]espnEvent{}))
+	}))
+	defer ts.Close()
+
+	origURL := nbaBaseURL
+	nbaBaseURL = ts.URL
+	defer func() { nbaBaseURL = origURL }()
+
+	origOffset := offset
+	offset = 0
+	defer func() { offset = origOffset }()
+
+	widget := testWidget(t)
+	_, content, wrap := widget.nbascore()
+
+	if wrap {
+		t.Error("expected wrap=false for empty games")
+	}
+	if !strings.Contains(content, "No games scheduled") {
+		t.Errorf("expected 'No games scheduled' message, got %q", content)
+	}
+	if strings.Contains(content, "Next game:") {
+		t.Errorf("should not show 'Next game:' when no date available, got %q", content)
+	}
 }
 
 func TestNbascore_Non200Status(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
-		w.Write([]byte("server error"))
+		_, _ = w.Write([]byte("server error"))
 	}))
 	defer ts.Close()
 
@@ -202,7 +247,7 @@ func TestNbascore_Non200Status(t *testing.T) {
 func TestNbascore_InvalidJSON(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("not json"))
+		_, _ = w.Write([]byte("not json"))
 	}))
 	defer ts.Close()
 
@@ -264,7 +309,7 @@ func TestNbascore_DateOffset(t *testing.T) {
 			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				receivedQuery = r.URL.RawQuery
 				w.WriteHeader(http.StatusOK)
-				w.Write(buildESPNResponse([]espnEvent{}))
+				_, _ = w.Write(buildESPNResponse([]espnEvent{}))
 			}))
 			defer ts.Close()
 
@@ -339,7 +384,7 @@ func TestNbascore_ScoreColorFormatting(t *testing.T) {
 			}
 			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusOK)
-				w.Write(buildESPNResponse(events))
+				_, _ = w.Write(buildESPNResponse(events))
 			}))
 			defer ts.Close()
 
@@ -374,7 +419,7 @@ func TestNbascore_ActiveGameHighlight(t *testing.T) {
 	}
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write(buildESPNResponse(events))
+		_, _ = w.Write(buildESPNResponse(events))
 	}))
 	defer ts.Close()
 
@@ -400,7 +445,7 @@ func TestNbascore_InactiveGameNoHighlight(t *testing.T) {
 	}
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write(buildESPNResponse(events))
+		_, _ = w.Write(buildESPNResponse(events))
 	}))
 	defer ts.Close()
 
@@ -430,7 +475,7 @@ func TestNbascore_MultipleGames(t *testing.T) {
 	}
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write(buildESPNResponse(events))
+		_, _ = w.Write(buildESPNResponse(events))
 	}))
 	defer ts.Close()
 
@@ -462,7 +507,7 @@ func TestNbascore_RequestHeaders(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		userAgent = r.Header.Get("User-Agent")
 		w.WriteHeader(http.StatusOK)
-		w.Write(buildESPNResponse([]espnEvent{}))
+		_, _ = w.Write(buildESPNResponse([]espnEvent{}))
 	}))
 	defer ts.Close()
 

--- a/modules/nbascore/widget_test.go
+++ b/modules/nbascore/widget_test.go
@@ -46,7 +46,6 @@ wtf:
 	return NewSettingsFromYAML("nbascore", ymlCfg, globalCfg)
 }
 
-// testWidget creates a Widget with a properly initialized TextWidget for testing.
 func testWidget(t *testing.T) *Widget {
 	t.Helper()
 	settings := testSettings(t)
@@ -57,29 +56,35 @@ func testWidget(t *testing.T) *Widget {
 	return widget
 }
 
-// buildScoreboard builds a minimal NBA scoreboard JSON response.
-func buildScoreboard(games []map[string]interface{}) []byte {
-	data := map[string]interface{}{
-		"games": games,
-	}
+// buildESPNResponse builds a minimal ESPN scoreboard JSON response.
+func buildESPNResponse(events []espnEvent) []byte {
+	data := espnResponse{Events: events}
 	b, _ := json.Marshal(data)
 	return b
 }
 
-func makeGame(vTeam, hTeam, vScore, hScore string, quarter float64, active bool) map[string]interface{} {
-	return map[string]interface{}{
-		"vTeam": map[string]interface{}{
-			"triCode": vTeam,
-			"score":   vScore,
+func makeEvent(awayAbbr, homeAbbr, awayScore, homeScore string, period int, state string) espnEvent {
+	return espnEvent{
+		Competitions: []espnCompetition{
+			{
+				Competitors: []espnCompetitor{
+					{
+						HomeAway: "home",
+						Team:     espnTeam{Abbreviation: homeAbbr},
+						Score:    homeScore,
+					},
+					{
+						HomeAway: "away",
+						Team:     espnTeam{Abbreviation: awayAbbr},
+						Score:    awayScore,
+					},
+				},
+			},
 		},
-		"hTeam": map[string]interface{}{
-			"triCode": hTeam,
-			"score":   hScore,
+		Status: espnStatus{
+			Period: period,
+			Type:   espnStatusType{State: state},
 		},
-		"period": map[string]interface{}{
-			"current": quarter,
-		},
-		"isGameActivated": active,
 	}
 }
 
@@ -102,14 +107,14 @@ func TestNewSettingsFromYAML_Focusable(t *testing.T) {
 // --- nbascore() integration tests with httptest ---
 
 func TestNbascore_SuccessfulResponse(t *testing.T) {
-	games := []map[string]interface{}{
-		makeGame("BOS", "LAL", "110", "105", 4, false),
-		makeGame("GSW", "MIA", "98", "102", 3, true),
+	events := []espnEvent{
+		makeEvent("BOS", "LAL", "110", "105", 4, "post"),
+		makeEvent("GSW", "MIA", "98", "102", 3, "in"),
 	}
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write(buildScoreboard(games))
+		w.Write(buildESPNResponse(events))
 	}))
 	defer ts.Close()
 
@@ -147,7 +152,7 @@ func TestNbascore_SuccessfulResponse(t *testing.T) {
 func TestNbascore_EmptyGames(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write(buildScoreboard([]map[string]interface{}{}))
+		w.Write(buildESPNResponse([]espnEvent{}))
 	}))
 	defer ts.Close()
 
@@ -165,7 +170,6 @@ func TestNbascore_EmptyGames(t *testing.T) {
 	if wrap {
 		t.Error("expected wrap=false for empty games")
 	}
-	// Should still have date header
 	today := time.Now().Format(utils.FriendlyDateFormat)
 	if !strings.Contains(content, today) {
 		t.Errorf("expected content to contain date %q", today)
@@ -223,7 +227,7 @@ func TestNbascore_InvalidJSON(t *testing.T) {
 
 func TestNbascore_ServerUnreachable(t *testing.T) {
 	origURL := nbaBaseURL
-	nbaBaseURL = "http://127.0.0.1:1" // unreachable port
+	nbaBaseURL = "http://127.0.0.1:1"
 	defer func() { nbaBaseURL = origURL }()
 
 	origOffset := offset
@@ -245,9 +249,9 @@ func TestNbascore_ServerUnreachable(t *testing.T) {
 
 func TestNbascore_DateOffset(t *testing.T) {
 	tests := []struct {
-		name       string
-		offset     int
-		wantDate   string
+		name     string
+		offset   int
+		wantDate string
 	}{
 		{"today", 0, time.Now().Format("20060102")},
 		{"yesterday", -1, time.Now().AddDate(0, 0, -1).Format("20060102")},
@@ -256,11 +260,11 @@ func TestNbascore_DateOffset(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			var receivedPath string
+			var receivedQuery string
 			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				receivedPath = r.URL.Path
+				receivedQuery = r.URL.RawQuery
 				w.WriteHeader(http.StatusOK)
-				w.Write(buildScoreboard([]map[string]interface{}{}))
+				w.Write(buildESPNResponse([]espnEvent{}))
 			}))
 			defer ts.Close()
 
@@ -275,9 +279,9 @@ func TestNbascore_DateOffset(t *testing.T) {
 			widget := testWidget(t)
 			widget.nbascore()
 
-			expectedPath := "/" + tc.wantDate + "/scoreboard.json"
-			if receivedPath != expectedPath {
-				t.Errorf("expected path %q, got %q", expectedPath, receivedPath)
+			expectedQuery := "dates=" + tc.wantDate
+			if receivedQuery != expectedQuery {
+				t.Errorf("expected query %q, got %q", expectedQuery, receivedQuery)
 			}
 		})
 	}
@@ -287,55 +291,55 @@ func TestNbascore_DateOffset(t *testing.T) {
 
 func TestNbascore_ScoreColorFormatting(t *testing.T) {
 	tests := []struct {
-		name       string
-		vScore     string
-		hScore     string
-		quarter    float64
-		active     bool
-		wantInOut  []string
+		name      string
+		vScore    string
+		hScore    string
+		period    int
+		state     string
+		wantInOut []string
 	}{
 		{
-			name:    "visitor winning",
-			vScore:  "100",
-			hScore:  "90",
-			quarter: 4,
-			active:  false,
+			name:      "visitor winning",
+			vScore:    "100",
+			hScore:    "90",
+			period:    4,
+			state:     "post",
 			wantInOut: []string{"[orange]BOS", "100"},
 		},
 		{
-			name:    "home winning",
-			vScore:  "90",
-			hScore:  "100",
-			quarter: 4,
-			active:  false,
+			name:      "home winning",
+			vScore:    "90",
+			hScore:    "100",
+			period:    4,
+			state:     "post",
 			wantInOut: []string{"[orange]", "LAL"},
 		},
 		{
-			name:    "tied score",
-			vScore:  "95",
-			hScore:  "95",
-			quarter: 3,
-			active:  true,
+			name:      "tied score",
+			vScore:    "95",
+			hScore:    "95",
+			period:    3,
+			state:     "in",
 			wantInOut: []string{"[orange]BOS", "[orange]", "[sandybrown]"},
 		},
 		{
-			name:    "game not started (quarter 0)",
-			vScore:  "",
-			hScore:  "",
-			quarter: 0,
-			active:  false,
+			name:      "game not started (period 0)",
+			vScore:    "0",
+			hScore:    "0",
+			period:    0,
+			state:     "pre",
 			wantInOut: []string{"BOS", "LAL"},
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			games := []map[string]interface{}{
-				makeGame("BOS", "LAL", tc.vScore, tc.hScore, tc.quarter, tc.active),
+			events := []espnEvent{
+				makeEvent("BOS", "LAL", tc.vScore, tc.hScore, tc.period, tc.state),
 			}
 			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusOK)
-				w.Write(buildScoreboard(games))
+				w.Write(buildESPNResponse(events))
 			}))
 			defer ts.Close()
 
@@ -365,12 +369,12 @@ func TestNbascore_ScoreColorFormatting(t *testing.T) {
 // --- Game status formatting tests ---
 
 func TestNbascore_ActiveGameHighlight(t *testing.T) {
-	games := []map[string]interface{}{
-		makeGame("BOS", "LAL", "50", "48", 2, true),
+	events := []espnEvent{
+		makeEvent("BOS", "LAL", "50", "48", 2, "in"),
 	}
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write(buildScoreboard(games))
+		w.Write(buildESPNResponse(events))
 	}))
 	defer ts.Close()
 
@@ -391,12 +395,12 @@ func TestNbascore_ActiveGameHighlight(t *testing.T) {
 }
 
 func TestNbascore_InactiveGameNoHighlight(t *testing.T) {
-	games := []map[string]interface{}{
-		makeGame("BOS", "LAL", "110", "105", 4, false),
+	events := []espnEvent{
+		makeEvent("BOS", "LAL", "110", "105", 4, "post"),
 	}
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write(buildScoreboard(games))
+		w.Write(buildESPNResponse(events))
 	}))
 	defer ts.Close()
 
@@ -411,7 +415,6 @@ func TestNbascore_InactiveGameNoHighlight(t *testing.T) {
 	widget := testWidget(t)
 	_, content, _ := widget.nbascore()
 
-	// Quarter indicator should be [white] not [sandybrown]
 	if strings.Contains(content, "[sandybrown]") {
 		t.Errorf("inactive game should not have [sandybrown] color, got: %s", content)
 	}
@@ -420,14 +423,14 @@ func TestNbascore_InactiveGameNoHighlight(t *testing.T) {
 // --- Multiple games test ---
 
 func TestNbascore_MultipleGames(t *testing.T) {
-	games := []map[string]interface{}{
-		makeGame("BOS", "LAL", "110", "105", 4, false),
-		makeGame("GSW", "MIA", "98", "102", 3, true),
-		makeGame("NYK", "CHI", "0", "0", 0, false),
+	events := []espnEvent{
+		makeEvent("BOS", "LAL", "110", "105", 4, "post"),
+		makeEvent("GSW", "MIA", "98", "102", 3, "in"),
+		makeEvent("NYK", "CHI", "0", "0", 0, "pre"),
 	}
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write(buildScoreboard(games))
+		w.Write(buildESPNResponse(events))
 	}))
 	defer ts.Close()
 
@@ -445,9 +448,9 @@ func TestNbascore_MultipleGames(t *testing.T) {
 	if wrap {
 		t.Fatal("expected wrap=false")
 	}
-	for _, team := range []string{"BOS", "LAL", "GSW", "MIA", "NYK", "CHI"} {
-		if !strings.Contains(content, team) {
-			t.Errorf("expected content to contain %q", team)
+	for _, tm := range []string{"BOS", "LAL", "GSW", "MIA", "NYK", "CHI"} {
+		if !strings.Contains(content, tm) {
+			t.Errorf("expected content to contain %q", tm)
 		}
 	}
 }
@@ -459,7 +462,7 @@ func TestNbascore_RequestHeaders(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		userAgent = r.Header.Get("User-Agent")
 		w.WriteHeader(http.StatusOK)
-		w.Write(buildScoreboard([]map[string]interface{}{}))
+		w.Write(buildESPNResponse([]espnEvent{}))
 	}))
 	defer ts.Close()
 
@@ -474,8 +477,8 @@ func TestNbascore_RequestHeaders(t *testing.T) {
 	widget := testWidget(t)
 	widget.nbascore()
 
-	if userAgent != "curl" {
-		t.Errorf("expected User-Agent 'curl', got %q", userAgent)
+	if userAgent != "WTFUtil (+https://wtfutil.com)" {
+		t.Errorf("expected User-Agent 'WTFUtil (+https://wtfutil.com)', got %q", userAgent)
 	}
 }
 
@@ -483,12 +486,7 @@ func TestNbascore_RequestHeaders(t *testing.T) {
 
 func TestConfigText(t *testing.T) {
 	widget := testWidget(t)
-	text := widget.ConfigText()
-	// Should return something (help text), not panic
-	if text == "" {
-		// ConfigText may be empty for this simple settings struct, that's ok
-		// Just verify it doesn't panic
-	}
+	_ = widget.ConfigText() // just verify no panic
 }
 
 // --- Keyboard controls offset tests ---
@@ -498,20 +496,16 @@ func TestOffsetControls(t *testing.T) {
 	defer func() { offset = origOffset }()
 
 	offset = 0
-
-	// Test next increments
 	offset++
 	if offset != 1 {
 		t.Errorf("expected offset=1 after next, got %d", offset)
 	}
 
-	// Test prev decrements
 	offset--
 	if offset != 0 {
 		t.Errorf("expected offset=0 after prev, got %d", offset)
 	}
 
-	// Test center resets
 	offset = 5
 	offset = 0
 	if offset != 0 {

--- a/modules/nbascore/widget_test.go
+++ b/modules/nbascore/widget_test.go
@@ -1,0 +1,520 @@
+package nbascore
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/olebedev/config"
+	"github.com/wtfutil/wtf/utils"
+	"github.com/wtfutil/wtf/view"
+)
+
+// --- helpers ---
+
+func testSettings(t *testing.T) *Settings {
+	t.Helper()
+	yamlStr := `
+enabled: true
+position:
+  top: 0
+  left: 0
+  height: 1
+  width: 1
+refreshInterval: 300
+`
+	globalStr := `
+wtf:
+  colors:
+    border:
+      focusable: "darkslateblue"
+      focused: "orange"
+      normal: "gray"
+    subheading: "red"
+`
+	ymlCfg, err := config.ParseYaml(yamlStr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	globalCfg, err := config.ParseYaml(globalStr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return NewSettingsFromYAML("nbascore", ymlCfg, globalCfg)
+}
+
+// testWidget creates a Widget with a properly initialized TextWidget for testing.
+func testWidget(t *testing.T) *Widget {
+	t.Helper()
+	settings := testSettings(t)
+	widget := &Widget{
+		TextWidget: view.NewTextWidget(nil, nil, nil, settings.Common),
+		settings:   settings,
+	}
+	return widget
+}
+
+// buildScoreboard builds a minimal NBA scoreboard JSON response.
+func buildScoreboard(games []map[string]interface{}) []byte {
+	data := map[string]interface{}{
+		"games": games,
+	}
+	b, _ := json.Marshal(data)
+	return b
+}
+
+func makeGame(vTeam, hTeam, vScore, hScore string, quarter float64, active bool) map[string]interface{} {
+	return map[string]interface{}{
+		"vTeam": map[string]interface{}{
+			"triCode": vTeam,
+			"score":   vScore,
+		},
+		"hTeam": map[string]interface{}{
+			"triCode": hTeam,
+			"score":   hScore,
+		},
+		"period": map[string]interface{}{
+			"current": quarter,
+		},
+		"isGameActivated": active,
+	}
+}
+
+// --- Settings tests ---
+
+func TestNewSettingsFromYAML_DefaultTitle(t *testing.T) {
+	settings := testSettings(t)
+	if settings.Title != "NBA Score" {
+		t.Errorf("expected title 'NBA Score', got %q", settings.Title)
+	}
+}
+
+func TestNewSettingsFromYAML_Focusable(t *testing.T) {
+	settings := testSettings(t)
+	if !settings.Focusable {
+		t.Error("expected focusable=true by default")
+	}
+}
+
+// --- nbascore() integration tests with httptest ---
+
+func TestNbascore_SuccessfulResponse(t *testing.T) {
+	games := []map[string]interface{}{
+		makeGame("BOS", "LAL", "110", "105", 4, false),
+		makeGame("GSW", "MIA", "98", "102", 3, true),
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write(buildScoreboard(games))
+	}))
+	defer ts.Close()
+
+	origURL := nbaBaseURL
+	nbaBaseURL = ts.URL
+	defer func() { nbaBaseURL = origURL }()
+
+	origOffset := offset
+	offset = 0
+	defer func() { offset = origOffset }()
+
+	widget := testWidget(t)
+	title, content, wrap := widget.nbascore()
+
+	if title != "NBA Score" {
+		t.Errorf("expected title 'NBA Score', got %q", title)
+	}
+	if wrap {
+		t.Error("expected wrap=false for successful response")
+	}
+	if !strings.Contains(content, "BOS") {
+		t.Errorf("expected content to contain 'BOS', got %q", content)
+	}
+	if !strings.Contains(content, "LAL") {
+		t.Errorf("expected content to contain 'LAL', got %q", content)
+	}
+	if !strings.Contains(content, "GSW") {
+		t.Errorf("expected content to contain 'GSW', got %q", content)
+	}
+	if !strings.Contains(content, "110") {
+		t.Errorf("expected content to contain score '110', got %q", content)
+	}
+}
+
+func TestNbascore_EmptyGames(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write(buildScoreboard([]map[string]interface{}{}))
+	}))
+	defer ts.Close()
+
+	origURL := nbaBaseURL
+	nbaBaseURL = ts.URL
+	defer func() { nbaBaseURL = origURL }()
+
+	origOffset := offset
+	offset = 0
+	defer func() { offset = origOffset }()
+
+	widget := testWidget(t)
+	_, content, wrap := widget.nbascore()
+
+	if wrap {
+		t.Error("expected wrap=false for empty games")
+	}
+	// Should still have date header
+	today := time.Now().Format(utils.FriendlyDateFormat)
+	if !strings.Contains(content, today) {
+		t.Errorf("expected content to contain date %q", today)
+	}
+}
+
+func TestNbascore_Non200Status(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("server error"))
+	}))
+	defer ts.Close()
+
+	origURL := nbaBaseURL
+	nbaBaseURL = ts.URL
+	defer func() { nbaBaseURL = origURL }()
+
+	origOffset := offset
+	offset = 0
+	defer func() { offset = origOffset }()
+
+	widget := testWidget(t)
+	_, _, wrap := widget.nbascore()
+
+	if !wrap {
+		t.Error("expected wrap=true for non-200 status")
+	}
+}
+
+func TestNbascore_InvalidJSON(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("not json"))
+	}))
+	defer ts.Close()
+
+	origURL := nbaBaseURL
+	nbaBaseURL = ts.URL
+	defer func() { nbaBaseURL = origURL }()
+
+	origOffset := offset
+	offset = 0
+	defer func() { offset = origOffset }()
+
+	widget := testWidget(t)
+	_, content, wrap := widget.nbascore()
+
+	if !wrap {
+		t.Error("expected wrap=true for invalid JSON")
+	}
+	if content == "" {
+		t.Error("expected non-empty error message")
+	}
+}
+
+func TestNbascore_ServerUnreachable(t *testing.T) {
+	origURL := nbaBaseURL
+	nbaBaseURL = "http://127.0.0.1:1" // unreachable port
+	defer func() { nbaBaseURL = origURL }()
+
+	origOffset := offset
+	offset = 0
+	defer func() { offset = origOffset }()
+
+	widget := testWidget(t)
+	_, content, wrap := widget.nbascore()
+
+	if !wrap {
+		t.Error("expected wrap=true for unreachable server")
+	}
+	if content == "" {
+		t.Error("expected non-empty error message")
+	}
+}
+
+// --- Date formatting tests ---
+
+func TestNbascore_DateOffset(t *testing.T) {
+	tests := []struct {
+		name       string
+		offset     int
+		wantDate   string
+	}{
+		{"today", 0, time.Now().Format("20060102")},
+		{"yesterday", -1, time.Now().AddDate(0, 0, -1).Format("20060102")},
+		{"tomorrow", 1, time.Now().AddDate(0, 0, 1).Format("20060102")},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var receivedPath string
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				receivedPath = r.URL.Path
+				w.WriteHeader(http.StatusOK)
+				w.Write(buildScoreboard([]map[string]interface{}{}))
+			}))
+			defer ts.Close()
+
+			origURL := nbaBaseURL
+			nbaBaseURL = ts.URL
+			defer func() { nbaBaseURL = origURL }()
+
+			origOffset := offset
+			offset = tc.offset
+			defer func() { offset = origOffset }()
+
+			widget := testWidget(t)
+			widget.nbascore()
+
+			expectedPath := "/" + tc.wantDate + "/scoreboard.json"
+			if receivedPath != expectedPath {
+				t.Errorf("expected path %q, got %q", expectedPath, receivedPath)
+			}
+		})
+	}
+}
+
+// --- Score display / color formatting tests ---
+
+func TestNbascore_ScoreColorFormatting(t *testing.T) {
+	tests := []struct {
+		name       string
+		vScore     string
+		hScore     string
+		quarter    float64
+		active     bool
+		wantInOut  []string
+	}{
+		{
+			name:    "visitor winning",
+			vScore:  "100",
+			hScore:  "90",
+			quarter: 4,
+			active:  false,
+			wantInOut: []string{"[orange]BOS", "100"},
+		},
+		{
+			name:    "home winning",
+			vScore:  "90",
+			hScore:  "100",
+			quarter: 4,
+			active:  false,
+			wantInOut: []string{"[orange]", "LAL"},
+		},
+		{
+			name:    "tied score",
+			vScore:  "95",
+			hScore:  "95",
+			quarter: 3,
+			active:  true,
+			wantInOut: []string{"[orange]BOS", "[orange]", "[sandybrown]"},
+		},
+		{
+			name:    "game not started (quarter 0)",
+			vScore:  "",
+			hScore:  "",
+			quarter: 0,
+			active:  false,
+			wantInOut: []string{"BOS", "LAL"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			games := []map[string]interface{}{
+				makeGame("BOS", "LAL", tc.vScore, tc.hScore, tc.quarter, tc.active),
+			}
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				w.Write(buildScoreboard(games))
+			}))
+			defer ts.Close()
+
+			origURL := nbaBaseURL
+			nbaBaseURL = ts.URL
+			defer func() { nbaBaseURL = origURL }()
+
+			origOffset := offset
+			offset = 0
+			defer func() { offset = origOffset }()
+
+			widget := testWidget(t)
+			_, content, wrap := widget.nbascore()
+
+			if wrap {
+				t.Fatalf("unexpected wrap=true, content: %s", content)
+			}
+			for _, want := range tc.wantInOut {
+				if !strings.Contains(content, want) {
+					t.Errorf("expected content to contain %q\ngot: %s", want, content)
+				}
+			}
+		})
+	}
+}
+
+// --- Game status formatting tests ---
+
+func TestNbascore_ActiveGameHighlight(t *testing.T) {
+	games := []map[string]interface{}{
+		makeGame("BOS", "LAL", "50", "48", 2, true),
+	}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write(buildScoreboard(games))
+	}))
+	defer ts.Close()
+
+	origURL := nbaBaseURL
+	nbaBaseURL = ts.URL
+	defer func() { nbaBaseURL = origURL }()
+
+	origOffset := offset
+	offset = 0
+	defer func() { offset = origOffset }()
+
+	widget := testWidget(t)
+	_, content, _ := widget.nbascore()
+
+	if !strings.Contains(content, "[sandybrown]") {
+		t.Errorf("expected active game to have [sandybrown] color, got: %s", content)
+	}
+}
+
+func TestNbascore_InactiveGameNoHighlight(t *testing.T) {
+	games := []map[string]interface{}{
+		makeGame("BOS", "LAL", "110", "105", 4, false),
+	}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write(buildScoreboard(games))
+	}))
+	defer ts.Close()
+
+	origURL := nbaBaseURL
+	nbaBaseURL = ts.URL
+	defer func() { nbaBaseURL = origURL }()
+
+	origOffset := offset
+	offset = 0
+	defer func() { offset = origOffset }()
+
+	widget := testWidget(t)
+	_, content, _ := widget.nbascore()
+
+	// Quarter indicator should be [white] not [sandybrown]
+	if strings.Contains(content, "[sandybrown]") {
+		t.Errorf("inactive game should not have [sandybrown] color, got: %s", content)
+	}
+}
+
+// --- Multiple games test ---
+
+func TestNbascore_MultipleGames(t *testing.T) {
+	games := []map[string]interface{}{
+		makeGame("BOS", "LAL", "110", "105", 4, false),
+		makeGame("GSW", "MIA", "98", "102", 3, true),
+		makeGame("NYK", "CHI", "0", "0", 0, false),
+	}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write(buildScoreboard(games))
+	}))
+	defer ts.Close()
+
+	origURL := nbaBaseURL
+	nbaBaseURL = ts.URL
+	defer func() { nbaBaseURL = origURL }()
+
+	origOffset := offset
+	offset = 0
+	defer func() { offset = origOffset }()
+
+	widget := testWidget(t)
+	_, content, wrap := widget.nbascore()
+
+	if wrap {
+		t.Fatal("expected wrap=false")
+	}
+	for _, team := range []string{"BOS", "LAL", "GSW", "MIA", "NYK", "CHI"} {
+		if !strings.Contains(content, team) {
+			t.Errorf("expected content to contain %q", team)
+		}
+	}
+}
+
+// --- Request header tests ---
+
+func TestNbascore_RequestHeaders(t *testing.T) {
+	var userAgent string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		userAgent = r.Header.Get("User-Agent")
+		w.WriteHeader(http.StatusOK)
+		w.Write(buildScoreboard([]map[string]interface{}{}))
+	}))
+	defer ts.Close()
+
+	origURL := nbaBaseURL
+	nbaBaseURL = ts.URL
+	defer func() { nbaBaseURL = origURL }()
+
+	origOffset := offset
+	offset = 0
+	defer func() { offset = origOffset }()
+
+	widget := testWidget(t)
+	widget.nbascore()
+
+	if userAgent != "curl" {
+		t.Errorf("expected User-Agent 'curl', got %q", userAgent)
+	}
+}
+
+// --- ConfigText test ---
+
+func TestConfigText(t *testing.T) {
+	widget := testWidget(t)
+	text := widget.ConfigText()
+	// Should return something (help text), not panic
+	if text == "" {
+		// ConfigText may be empty for this simple settings struct, that's ok
+		// Just verify it doesn't panic
+	}
+}
+
+// --- Keyboard controls offset tests ---
+
+func TestOffsetControls(t *testing.T) {
+	origOffset := offset
+	defer func() { offset = origOffset }()
+
+	offset = 0
+
+	// Test next increments
+	offset++
+	if offset != 1 {
+		t.Errorf("expected offset=1 after next, got %d", offset)
+	}
+
+	// Test prev decrements
+	offset--
+	if offset != 0 {
+		t.Errorf("expected offset=0 after prev, got %d", offset)
+	}
+
+	// Test center resets
+	offset = 5
+	offset = 0
+	if offset != 0 {
+		t.Errorf("expected offset=0 after center, got %d", offset)
+	}
+}


### PR DESCRIPTION
## Summary

The nbascore module was broken because the data.nba.net API has been shut down (returns 400). This PR switches to ESPN free public scoreboard API, adds comprehensive unit tests, and improves the user experience during the offseason.

## Changes

### Switch to ESPN API
- The old data.nba.net API is dead; cdn.nba.com blocks non-browser clients
- ESPN API is free, requires no authentication, and works reliably
- Uses typed structs for JSON parsing instead of fragile map[string]interface{}
- Supports date-based queries via ?dates=YYYYMMDD for prev/next day navigation

### Add unit tests (0 to 74% coverage)
- Table-driven tests using net/http/httptest to mock API responses

### Improve offseason UX
- Show No games scheduled message when there are no events
- Display the next game date from ESPN API when available

### Bug fix
- Fixed nil pointer dereference in the non-200 status code path