### PR TITLE
Add comprehensive unit tests for modules/hibp

### DIFF
--- a/modules/hibp/client.go
+++ b/modules/hibp/client.go
@@ -10,10 +10,13 @@ import (
 )
 
 const (
-	apiURL            = "https://haveibeenpwned.com/api/v3/breachedaccount/"
 	clientTimeoutSecs = 2
 	userAgent         = "WTFUtil"
 )
+
+// apiURL is the base URL for the HIBP breachedaccount API. It's a variable
+// (rather than a constant) so that tests can point it at an httptest server.
+var apiURL = "https://haveibeenpwned.com/api/v3/breachedaccount/"
 
 type hibpError struct {
 	StatusCode int    `json:"statusCode"`
@@ -50,12 +53,13 @@ func (widget *Widget) fetchForAccount(account string, since string) (*Status, er
 
 	response, getErr := hibpClient.Do(request)
 	if getErr != nil {
-		return nil, err
+		return nil, getErr
 	}
+	defer response.Body.Close()
 
 	body, readErr := io.ReadAll(response.Body)
 	if readErr != nil {
-		return nil, err
+		return nil, readErr
 	}
 
 	hibpErr := widget.validateHTTPResponse(response.StatusCode, body)

--- a/modules/hibp/client_test.go
+++ b/modules/hibp/client_test.go
@@ -1,0 +1,320 @@
+package hibp
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func newTestWidget(since, apiKey string) *Widget {
+	return &Widget{
+		settings: newTestSettings(since, apiKey, nil),
+	}
+}
+
+func TestFullURL(t *testing.T) {
+	widget := newTestWidget("", "")
+
+	tests := []struct {
+		name      string
+		account   string
+		truncated bool
+		expected  string
+	}{
+		{"truncated", "test@example.com", true, apiURL + "test@example.com?truncateResponse=true"},
+		{"not truncated", "test@example.com", false, apiURL + "test@example.com?truncateResponse=false"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, widget.fullURL(tt.account, tt.truncated))
+		})
+	}
+}
+
+func TestValidateHTTPResponse(t *testing.T) {
+	widget := newTestWidget("", "")
+
+	tests := []struct {
+		name       string
+		statusCode int
+		body       []byte
+		expectNil  bool
+		expectMsg  string
+	}{
+		{
+			name:       "ok status",
+			statusCode: http.StatusOK,
+			body:       []byte(`[]`),
+			expectNil:  true,
+		},
+		{
+			name:       "not found status",
+			statusCode: http.StatusNotFound,
+			body:       []byte(``),
+			expectNil:  true,
+		},
+		{
+			name:       "unauthorized with valid json",
+			statusCode: http.StatusUnauthorized,
+			body:       []byte(`{"statusCode":401,"message":"Access denied, invalid API key"}`),
+			expectNil:  false,
+			expectMsg:  "Access denied, invalid API key",
+		},
+		{
+			name:       "payment required with valid json",
+			statusCode: http.StatusPaymentRequired,
+			body:       []byte(`{"statusCode":402,"message":"payment required"}`),
+			expectNil:  false,
+			expectMsg:  "payment required",
+		},
+		{
+			name:       "unauthorized with bad json",
+			statusCode: http.StatusUnauthorized,
+			body:       []byte(`not-json`),
+			expectNil:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := widget.validateHTTPResponse(tt.statusCode, tt.body)
+
+			if tt.expectNil {
+				assert.Nil(t, result)
+			} else {
+				assert.NotNil(t, result)
+				assert.Equal(t, tt.expectMsg, result.Message)
+			}
+		})
+	}
+}
+
+func TestParseResponseBody(t *testing.T) {
+	tests := []struct {
+		name          string
+		body          []byte
+		since         string
+		expectError   bool
+		expectedCount int
+	}{
+		{
+			name:          "empty body means no breaches",
+			body:          []byte(``),
+			expectedCount: 0,
+		},
+		{
+			name:          "valid json with breaches",
+			body:          []byte(`[{"Name":"Adobe","BreachDate":"2013-10-04"},{"Name":"LinkedIn","BreachDate":"2012-05-05"}]`),
+			expectedCount: 2,
+		},
+		{
+			name:        "malformed json",
+			body:        []byte(`not-json`),
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			widget := newTestWidget(tt.since, "")
+
+			stat, err := widget.parseResponseBody("test@example.com", tt.body)
+
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, "test@example.com", stat.Account)
+				assert.Len(t, stat.Breaches, tt.expectedCount)
+			}
+		})
+	}
+}
+
+func TestFilterBreaches(t *testing.T) {
+	breaches := []Breach{
+		{Name: "Old Breach", Date: "2010-01-01"},
+		{Name: "New Breach", Date: "2020-01-01"},
+		{Name: "Malformed Date", Date: "not-a-date"},
+	}
+
+	tests := []struct {
+		name     string
+		since    string
+		expected []string
+	}{
+		{
+			name:     "no since filters nothing",
+			since:    "",
+			expected: []string{"Old Breach", "New Breach", "Malformed Date"},
+		},
+		{
+			name:     "since filters older breaches, keeps malformed",
+			since:    "2015-01-01",
+			expected: []string{"New Breach", "Malformed Date"},
+		},
+		{
+			name:     "invalid since filters nothing",
+			since:    "not-a-date",
+			expected: []string{"Old Breach", "New Breach", "Malformed Date"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			widget := newTestWidget(tt.since, "")
+
+			result := widget.filterBreaches(breaches)
+
+			names := make([]string, 0, len(result))
+			for _, b := range result {
+				names = append(names, b.Name)
+			}
+
+			assert.Equal(t, tt.expected, names)
+		})
+	}
+}
+
+func TestFetchForAccount(t *testing.T) {
+	origURL := apiURL
+	defer func() { apiURL = origURL }()
+
+	t.Run("empty account short circuits", func(t *testing.T) {
+		widget := newTestWidget("", "")
+
+		stat, err := widget.fetchForAccount("", "")
+
+		assert.NoError(t, err)
+		assert.Nil(t, stat)
+	})
+
+	t.Run("successful response with breaches", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "WTFUtil", r.Header.Get("User-Agent"))
+			assert.Equal(t, "test-key", r.Header.Get("hibp-api-key"))
+
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[{"Name":"Adobe","BreachDate":"2013-10-04"}]`))
+		}))
+		defer server.Close()
+
+		apiURL = server.URL + "/"
+
+		widget := newTestWidget("", "test-key")
+
+		stat, err := widget.fetchForAccount("test@example.com", "")
+
+		assert.NoError(t, err)
+		assert.NotNil(t, stat)
+		assert.Equal(t, "test@example.com", stat.Account)
+		assert.True(t, stat.HasBeenCompromised())
+	})
+
+	t.Run("no breaches found returns 404", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		defer server.Close()
+
+		apiURL = server.URL + "/"
+
+		widget := newTestWidget("", "")
+
+		stat, err := widget.fetchForAccount("safe@example.com", "")
+
+		assert.NoError(t, err)
+		assert.NotNil(t, stat)
+		assert.False(t, stat.HasBeenCompromised())
+	})
+
+	t.Run("rate limited response", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusTooManyRequests)
+		}))
+		defer server.Close()
+
+		apiURL = server.URL + "/"
+
+		widget := newTestWidget("", "")
+
+		stat, err := widget.fetchForAccount("test@example.com", "")
+
+		// The current validateHTTPResponse implementation only special-cases 401/402,
+		// so a 429 falls through to the default case and is treated like a normal response.
+		assert.NoError(t, err)
+		assert.NotNil(t, stat)
+	})
+
+	t.Run("unauthorized response returns error", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"statusCode":401,"message":"Access denied, invalid API key"}`))
+		}))
+		defer server.Close()
+
+		apiURL = server.URL + "/"
+
+		widget := newTestWidget("", "bad-key")
+
+		stat, err := widget.fetchForAccount("test@example.com", "")
+
+		assert.Error(t, err)
+		assert.Nil(t, stat)
+		assert.Equal(t, "Access denied, invalid API key", err.Error())
+	})
+
+	t.Run("malformed json response returns error", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`not-json`))
+		}))
+		defer server.Close()
+
+		apiURL = server.URL + "/"
+
+		widget := newTestWidget("", "")
+
+		stat, err := widget.fetchForAccount("test@example.com", "")
+
+		assert.Error(t, err)
+		assert.Nil(t, stat)
+	})
+
+	t.Run("network error returns error", func(t *testing.T) {
+		// Point at a server that's been closed so the connection is refused.
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+		server.Close()
+
+		apiURL = server.URL + "/"
+
+		widget := newTestWidget("", "")
+
+		stat, err := widget.fetchForAccount("test@example.com", "")
+
+		assert.Error(t, err)
+		assert.Nil(t, stat)
+	})
+
+	t.Run("breaches filtered by since date", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[{"Name":"Old","BreachDate":"2010-01-01"},{"Name":"New","BreachDate":"2022-01-01"}]`))
+		}))
+		defer server.Close()
+
+		apiURL = server.URL + "/"
+
+		widget := newTestWidget("2015-01-01", "")
+
+		stat, err := widget.fetchForAccount("test@example.com", "2015-01-01")
+
+		assert.NoError(t, err)
+		assert.NotNil(t, stat)
+		assert.Len(t, stat.Breaches, 1)
+		assert.Equal(t, "New", stat.Breaches[0].Name)
+	})
+}

--- a/modules/hibp/hibp_breach_test.go
+++ b/modules/hibp/hibp_breach_test.go
@@ -1,0 +1,59 @@
+package hibp
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBreach_BreachDate(t *testing.T) {
+	tests := []struct {
+		name        string
+		date        string
+		expectError bool
+		expected    time.Time
+	}{
+		{
+			name:        "valid date",
+			date:        "2013-10-04",
+			expectError: false,
+			expected:    time.Date(2013, 10, 4, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name:        "another valid date",
+			date:        "2019-06-22",
+			expectError: false,
+			expected:    time.Date(2019, 6, 22, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name:        "empty date",
+			date:        "",
+			expectError: true,
+		},
+		{
+			name:        "malformed date",
+			date:        "not-a-date",
+			expectError: true,
+		},
+		{
+			name:        "wrong format",
+			date:        "10/04/2013",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			br := &Breach{Date: tt.date}
+			dt, err := br.BreachDate()
+
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.True(t, tt.expected.Equal(dt))
+			}
+		})
+	}
+}

--- a/modules/hibp/hibp_status_test.go
+++ b/modules/hibp/hibp_status_test.go
@@ -1,0 +1,57 @@
+package hibp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewStatus(t *testing.T) {
+	breaches := []Breach{{Name: "Adobe", Date: "2013-10-04"}}
+
+	stat := NewStatus("user@example.com", breaches)
+
+	assert.NotNil(t, stat)
+	assert.Equal(t, "user@example.com", stat.Account)
+	assert.Equal(t, breaches, stat.Breaches)
+}
+
+func TestStatus_HasBeenCompromised(t *testing.T) {
+	tests := []struct {
+		name     string
+		stat     *Status
+		expected bool
+	}{
+		{"nil status", nil, false},
+		{"no breaches", NewStatus("acct", []Breach{}), false},
+		{"nil breaches slice", NewStatus("acct", nil), false},
+		{"one breach", NewStatus("acct", []Breach{{Name: "Adobe"}}), true},
+		{"multiple breaches", NewStatus("acct", []Breach{{Name: "Adobe"}, {Name: "LinkedIn"}}), true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.stat.HasBeenCompromised())
+		})
+	}
+}
+
+func TestStatus_Len(t *testing.T) {
+	tests := []struct {
+		name     string
+		stat     *Status
+		expected int
+	}{
+		{"nil status", nil, 0},
+		{"nil breaches", NewStatus("acct", nil), 0},
+		{"empty breaches", NewStatus("acct", []Breach{}), 0},
+		{"single breach", NewStatus("acct", []Breach{{Name: "Adobe"}}), 1},
+		{"two breaches", NewStatus("acct", []Breach{{Name: "Adobe"}, {Name: "LinkedIn"}}), 2},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.stat.Len())
+		})
+	}
+}

--- a/modules/hibp/settings_test.go
+++ b/modules/hibp/settings_test.go
@@ -1,0 +1,171 @@
+package hibp
+
+import (
+	"testing"
+	"time"
+
+	"github.com/olebedev/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/wtfutil/wtf/cfg"
+)
+
+func newTestSettings(since, apiKey string, accounts []string) *Settings {
+	return &Settings{
+		Common: &cfg.Common{
+			Title: "HIBP",
+		},
+		apiKey:   apiKey,
+		accounts: accounts,
+		since:    since,
+	}
+}
+
+func TestSettings_HasSince(t *testing.T) {
+	tests := []struct {
+		name     string
+		since    string
+		expected bool
+	}{
+		{"empty since", "", false},
+		{"valid since", "2019-06-22", true},
+		{"malformed since", "not-a-date", false},
+		{"partial date", "2019-06", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			settings := newTestSettings(tt.since, "", nil)
+			assert.Equal(t, tt.expected, settings.HasSince())
+		})
+	}
+}
+
+func TestSettings_SinceDate(t *testing.T) {
+	tests := []struct {
+		name        string
+		since       string
+		expectError bool
+		expected    time.Time
+	}{
+		{
+			name:        "valid date",
+			since:       "2019-06-22",
+			expectError: false,
+			expected:    time.Date(2019, 6, 22, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name:        "empty date",
+			since:       "",
+			expectError: true,
+		},
+		{
+			name:        "malformed date",
+			since:       "banana",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			settings := newTestSettings(tt.since, "", nil)
+			dt, err := settings.SinceDate()
+
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.True(t, tt.expected.Equal(dt))
+			}
+		})
+	}
+}
+
+func TestNewSettingsFromYAML(t *testing.T) {
+	tests := []struct {
+		name                string
+		yaml                string
+		expectedAccounts    []string
+		expectedSince       string
+		expectedOkColor     string
+		expectedPwnedColor  string
+		expectMinRefreshMet bool
+	}{
+		{
+			name: "defaults applied when not configured",
+			yaml: `
+accounts:
+  - test@example.com
+`,
+			expectedAccounts:    []string{"test@example.com"},
+			expectedSince:       "",
+			expectedOkColor:     "white",
+			expectedPwnedColor:  "red",
+			expectMinRefreshMet: true,
+		},
+		{
+			name: "custom colors and since",
+			yaml: `
+accounts:
+  - one@example.com
+  - two@example.com
+since: 2019-06-22
+colors:
+  ok: green
+  pwned: orange
+`,
+			expectedAccounts:    []string{"one@example.com", "two@example.com"},
+			expectedSince:       "2019-06-22",
+			expectedOkColor:     "green",
+			expectedPwnedColor:  "orange",
+			expectMinRefreshMet: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ymlConfig, err := config.ParseYaml(tt.yaml)
+			assert.NoError(t, err)
+
+			globalConfig, err := config.ParseYaml(`global: {}`)
+			assert.NoError(t, err)
+
+			settings := NewSettingsFromYAML("hibp", ymlConfig, globalConfig)
+
+			assert.NotNil(t, settings)
+			assert.NotNil(t, settings.Common)
+			assert.Equal(t, tt.expectedAccounts, settings.accounts)
+			assert.Equal(t, tt.expectedSince, settings.since)
+			assert.Equal(t, tt.expectedOkColor, settings.ok)
+			assert.Equal(t, tt.expectedPwnedColor, settings.pwned)
+
+			if tt.expectMinRefreshMet {
+				assert.GreaterOrEqual(t, settings.RefreshInterval, minRefreshInterval)
+			}
+		})
+	}
+}
+
+func TestNewSettingsFromYAML_RefreshIntervalFloor(t *testing.T) {
+	// A configured refresh interval below the HIBP-enforced minimum should be
+	// bumped up to the minimum so we don't hammer the API.
+	ymlConfig, err := config.ParseYaml(`
+accounts:
+  - test@example.com
+refreshInterval: 5
+`)
+	assert.NoError(t, err)
+
+	globalConfig, err := config.ParseYaml(`global: {}`)
+	assert.NoError(t, err)
+
+	settings := NewSettingsFromYAML("hibp", ymlConfig, globalConfig)
+
+	assert.Equal(t, minRefreshInterval, settings.RefreshInterval)
+}
+
+func TestConfigText(t *testing.T) {
+	widget := &Widget{}
+	text := widget.ConfigText()
+
+	assert.NotEmpty(t, text)
+}

--- a/modules/hibp/widget_test.go
+++ b/modules/hibp/widget_test.go
@@ -1,0 +1,153 @@
+package hibp
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/rivo/tview"
+	"github.com/stretchr/testify/assert"
+	"github.com/wtfutil/wtf/cfg"
+)
+
+func newTestWidgetWithColors(since, ok, pwned string) *Widget {
+	app := tview.NewApplication()
+	redrawChan := make(chan bool, 1)
+
+	settings := &Settings{
+		Common: &cfg.Common{Title: "HIBP"},
+		since:  since,
+	}
+	settings.ok = ok
+	settings.pwned = pwned
+
+	return NewWidget(app, redrawChan, settings)
+}
+
+func TestSinceDateForTitle(t *testing.T) {
+	tests := []struct {
+		name     string
+		since    string
+		expected string
+	}{
+		{"no since", "", ""},
+		{"valid since", "2019-06-22", " since Jun 22, 2019"},
+		{"malformed since falls back to raw string", "not-a-date", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			widget := newTestWidgetWithColors(tt.since, "white", "red")
+			assert.Equal(t, tt.expected, widget.sinceDateForTitle())
+		})
+	}
+}
+
+func TestWidget_Content(t *testing.T) {
+	t.Run("error state shows error message", func(t *testing.T) {
+		widget := newTestWidgetWithColors("", "white", "red")
+		widget.err = errors.New("boom")
+
+		title, content, isErr := widget.content()
+
+		assert.Equal(t, "HIBP", title)
+		assert.Equal(t, "boom", content)
+		assert.True(t, isErr)
+	})
+
+	t.Run("no breaches uses ok color", func(t *testing.T) {
+		widget := newTestWidgetWithColors("", "white", "red")
+		widget.statuses = []*Status{
+			NewStatus("safe@example.com", []Breach{}),
+		}
+
+		title, content, isErr := widget.content()
+
+		assert.Equal(t, "HIBP", title)
+		assert.False(t, isErr)
+		assert.Contains(t, content, "[white]safe@example.com[white]")
+	})
+
+	t.Run("breaches use pwned color", func(t *testing.T) {
+		widget := newTestWidgetWithColors("", "white", "red")
+		widget.statuses = []*Status{
+			NewStatus("pwned@example.com", []Breach{{Name: "Adobe", Date: "2013-10-04"}}),
+		}
+
+		title, content, isErr := widget.content()
+
+		assert.Equal(t, "HIBP", title)
+		assert.False(t, isErr)
+		assert.Contains(t, content, "[red]pwned@example.com[white]")
+	})
+
+	t.Run("title includes since date", func(t *testing.T) {
+		widget := newTestWidgetWithColors("2019-06-22", "white", "red")
+		widget.statuses = []*Status{}
+
+		title, content, isErr := widget.content()
+
+		assert.Equal(t, "HIBP since Jun 22, 2019", title)
+		assert.Equal(t, "", content)
+		assert.False(t, isErr)
+	})
+
+	t.Run("mixed statuses render each account", func(t *testing.T) {
+		widget := newTestWidgetWithColors("", "white", "red")
+		widget.statuses = []*Status{
+			NewStatus("safe@example.com", nil),
+			NewStatus("pwned@example.com", []Breach{{Name: "Adobe"}}),
+		}
+
+		_, content, isErr := widget.content()
+
+		assert.False(t, isErr)
+		assert.Contains(t, content, "[white]safe@example.com[white]")
+		assert.Contains(t, content, "[red]pwned@example.com[white]")
+	})
+}
+
+func TestNewWidget(t *testing.T) {
+	app := tview.NewApplication()
+	redrawChan := make(chan bool, 1)
+
+	settings := &Settings{
+		Common: &cfg.Common{Title: "HIBP"},
+	}
+
+	widget := NewWidget(app, redrawChan, settings)
+
+	assert.NotNil(t, widget)
+	assert.Equal(t, settings, widget.settings)
+}
+
+func TestWidget_Fetch(t *testing.T) {
+	t.Run("empty accounts list returns empty statuses", func(t *testing.T) {
+		widget := newTestWidgetWithColors("", "white", "red")
+
+		statuses, err := widget.Fetch([]string{})
+
+		assert.NoError(t, err)
+		assert.Empty(t, statuses)
+	})
+
+	t.Run("accounts containing an empty string yield a nil status entry", func(t *testing.T) {
+		widget := newTestWidgetWithColors("", "white", "red")
+
+		statuses, err := widget.Fetch([]string{""})
+
+		assert.NoError(t, err)
+		assert.Len(t, statuses, 1)
+		assert.Nil(t, statuses[0])
+	})
+}
+
+func TestWidget_Refresh(t *testing.T) {
+	widget := newTestWidgetWithColors("", "white", "red")
+
+	// With no accounts configured, Refresh should complete without error and
+	// leave the widget in a clean, non-error state.
+	widget.Refresh()
+
+	assert.Nil(t, widget.err)
+	assert.Empty(t, widget.statuses)
+}


### PR DESCRIPTION
## Summary
Adds unit tests for the modules/hibp (Have I Been Pwned) package, which previously had 0% test coverage.

Coverage: 0% -> 94.2%

## What's tested
- Status/Breach: NewStatus, HasBeenCompromised, Len, BreachDate (table-driven, including malformed dates)
- Settings: HasSince, SinceDate, NewSettingsFromYAML (colors, since, refresh-interval floor), ConfigText
- Widget: sinceDateForTitle, content() (color/status logic, error state, since-date title), Fetch, Refresh, NewWidget
- Client (mocked with net/http/httptest): fullURL, validateHTTPResponse, parseResponseBody, filterBreaches, and fetchForAccount covering success, 404/no-breach, rate-limit (429), 401/402 API errors, malformed JSON, and simulated network errors

## Notable changes
- Made apiURL a package variable (was a const) so tests can redirect requests to an httptest server.
- Fixed a real bug found while testing error paths: fetchForAccount was swallowing network/read errors - it checked getErr/readErr but returned the already-nil outer err, so network failures silently returned (nil, nil) instead of an error. Also added a missing response.Body.Close().

## Validation
- go build ./... passes
- go test ./modules/hibp/... -cover passes (94.2% coverage)
- golangci-lint run ./modules/hibp/... reports no real issues; only gofmt warnings remain, which are pre-existing CRLF line-ending artifacts reproducible on unrelated, untouched modules (e.g. modules/clocks) - out of scope for this change.