### PR TITLE
Fix Past() to properly calculate for all-day events

### DIFF
--- a/modules/gcal/cal_event.go
+++ b/modules/gcal/cal_event.go
@@ -49,8 +49,13 @@ func (calEvent *CalEvent) Now() bool {
 
 func (calEvent *CalEvent) Past() bool {
 	if calEvent.AllDay() {
-		// FIXME: This should calculate properly
-		return false
+		now := time.Now().Local()
+		todayMidnight := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+
+		// All-day event end dates are exclusive (Google Calendar convention: a
+		// single-day event starting on the 3rd has an end date of the 4th), so
+		// the event is past once its end date's midnight is today or earlier.
+		return !calEvent.End().After(todayMidnight)
 	}
 
 	return !calEvent.Now() && calEvent.Start().Before(time.Now())

--- a/modules/gcal/cal_event_test.go
+++ b/modules/gcal/cal_event_test.go
@@ -1,0 +1,72 @@
+package gcal
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/api/calendar/v3"
+)
+
+func allDayEvent(startDate, endDate string) *CalEvent {
+	event := &calendar.Event{
+		Start: &calendar.EventDateTime{Date: startDate},
+		End:   &calendar.EventDateTime{Date: endDate},
+	}
+	return NewCalEvent(event)
+}
+
+func Test_Past_AllDayEvent(t *testing.T) {
+	yesterday := time.Now().AddDate(0, 0, -1)
+	today := time.Now()
+	tomorrow := time.Now().AddDate(0, 0, 1)
+
+	dateOnly := func(d time.Time) string {
+		return d.Format("2006-01-02")
+	}
+
+	testCases := []struct {
+		name       string
+		startDate  string
+		endDate    string
+		pastWanted bool
+	}{
+		{
+			name:       "single-day all-day event yesterday is past",
+			startDate:  dateOnly(yesterday),
+			endDate:    dateOnly(today),
+			pastWanted: true,
+		},
+		{
+			name:       "single-day all-day event today is not past",
+			startDate:  dateOnly(today),
+			endDate:    dateOnly(tomorrow),
+			pastWanted: false,
+		},
+		{
+			name:       "single-day all-day event tomorrow is not past",
+			startDate:  dateOnly(tomorrow),
+			endDate:    dateOnly(tomorrow.AddDate(0, 0, 1)),
+			pastWanted: false,
+		},
+		{
+			name:       "multi-day all-day event ending yesterday is past",
+			startDate:  dateOnly(yesterday.AddDate(0, 0, -2)),
+			endDate:    dateOnly(yesterday),
+			pastWanted: true,
+		},
+		{
+			name:       "multi-day all-day event spanning today is not past",
+			startDate:  dateOnly(yesterday),
+			endDate:    dateOnly(tomorrow),
+			pastWanted: false,
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			event := allDayEvent(tt.startDate, tt.endDate)
+			assert.Equal(t, tt.pastWanted, event.Past())
+		})
+	}
+}


### PR DESCRIPTION
\`Past()\` unconditionally returned \`false\` for all-day events (per the existing \`FIXME\` comment), so an all-day event that had already happened was never reported as past.

Google Calendar's all-day event end dates are exclusive (a single-day event starting on the 3rd has an end date of the 4th), so an event is past once its end date's midnight is today or earlier. This adds that date-only comparison for the all-day case, plus tests covering single-day and multi-day events before, during, and after "today".

Verified with \`go build\`, \`go vet\`, \`gofmt\`, and \`go test\` on \`modules/gcal\`.