### PR TITLE
Port the football module to football-data.org API v4

### DIFF
--- a/modules/football/client.go
+++ b/modules/football/client.go
@@ -6,7 +6,7 @@ import (
 )
 
 var (
-	footballAPIUrl = "https://api.football-data.org/v2"
+	footballAPIUrl = "https://api.football-data.org/v4"
 )
 
 type leagueInfo struct {
@@ -30,12 +30,13 @@ func (client *Client) footballRequest(path string, id int) (*http.Response, erro
 
 	url := fmt.Sprintf("%s/competitions/%d/%s", footballAPIUrl, id, path)
 	req, err := http.NewRequest("GET", url, http.NoBody)
-	req.Header.Add("Accept", "application/json")
-	req.Header.Add("Content-Type", "application/json")
-	req.Header.Add("X-Auth-Token", client.apiKey)
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Add("Accept", "application/json")
+	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("X-Auth-Token", client.apiKey)
+
 	httpClient := &http.Client{}
 	resp, err := httpClient.Do(req)
 	if err != nil {

--- a/modules/football/types.go
+++ b/modules/football/types.go
@@ -5,9 +5,17 @@ type Team struct {
 }
 
 type LeagueStandings struct {
-	Standings []struct {
-		Table []Table `json:"table"`
-	} `json:"standings"`
+	Standings []Standing `json:"standings"`
+}
+
+// Standing is one table within a standings response. v4 returns several:
+// for a league competition it returns TOTAL, HOME and AWAY tables, and for
+// a cup it returns one TOTAL table per group.
+type Standing struct {
+	Stage string  `json:"stage"`
+	Type  string  `json:"type"`
+	Group string  `json:"group"`
+	Table []Table `json:"table"`
 }
 
 type Table struct {
@@ -40,7 +48,13 @@ type Score struct {
 	Winner   string      `json:"winner"`
 }
 
+// ScoreByTime holds the goals scored by each side at a point in the match.
+//
+// Two v4 changes are captured here: the sides are keyed "home" and "away"
+// (v2 used "homeTeam" and "awayTeam"), and the values are null until the
+// match produces them, so they are pointers rather than plain ints. A nil
+// value means "no score yet", which is not the same as 0.
 type ScoreByTime struct {
-	AwayTeam int `json:"awayTeam"`
-	HomeTeam int `json:"homeTeam"`
+	Away *int `json:"away"`
+	Home *int `json:"home"`
 }

--- a/modules/football/util.go
+++ b/modules/football/util.go
@@ -3,6 +3,7 @@ package football
 import (
 	"bytes"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -34,4 +35,30 @@ func getDateString(offset int) string {
 	today := time.Now()
 	return today.AddDate(0, 0, offset).Format("2006-01-02")
 
+}
+
+// scoreString renders one side's goal count. v4 leaves scores null until the
+// match produces them, so a missing value is shown as a dash rather than as
+// a misleading 0.
+func scoreString(goals *int) string {
+
+	if goals == nil {
+		return "-"
+	}
+
+	return strconv.Itoa(*goals)
+}
+
+// totalTable returns the overall table from a standings response. v4 returns
+// TOTAL, HOME and AWAY tables for a league competition; taking the first
+// entry unconditionally only picks the overall table by accident of ordering.
+func totalTable(standings []Standing) []Table {
+
+	for _, standing := range standings {
+		if standing.Type == "" || strings.EqualFold(standing.Type, "TOTAL") {
+			return standing.Table
+		}
+	}
+
+	return nil
 }

--- a/modules/football/widget.go
+++ b/modules/football/widget.go
@@ -110,11 +110,12 @@ func (widget *Widget) GetStandings(leagueId int) string {
 		return "Error fetching standings"
 	}
 
-	if len(l.Standings) == 0 {
+	table := totalTable(l.Standings)
+	if len(table) == 0 {
 		return "No standings found for this competition"
 	}
 
-	for _, i := range l.Standings[0].Table {
+	for _, i := range table {
 		if i.Position <= widget.settings.standingCount {
 			row := []string{strconv.Itoa(i.Position), i.Team.Name, strconv.Itoa(i.PlayedGames), strconv.Itoa(i.Won), strconv.Itoa(i.Draw), strconv.Itoa(i.Lost), strconv.Itoa(i.GoalDifference), strconv.Itoa(i.Points)}
 			tStandings.Append(row)
@@ -141,7 +142,9 @@ func (widget *Widget) GetMatches(leagueId int) string {
 	from := getDateString(-widget.settings.matchesFrom)
 	to := getDateString(widget.settings.matchesTo)
 
-	requestPath := fmt.Sprintf("matches?dateFrom=%s&dateTo=%s", from, to)
+	// v4 excludes the dateTo day itself, so ask for one day beyond the
+	// configured window to keep matchesTo inclusive as documented.
+	requestPath := fmt.Sprintf("matches?dateFrom=%s&dateTo=%s", from, getDateString(widget.settings.matchesTo+1))
 	resp, err := widget.footballRequest(requestPath, leagueId)
 	if err != nil {
 		return fmt.Sprintf("Error fetching matches: %s", err.Error())
@@ -165,12 +168,18 @@ func (widget *Widget) GetMatches(leagueId int) string {
 		widget.markFavorite(&m)
 
 		switch m.Status {
-		case "SCHEDULED":
+		case "SCHEDULED", "TIMED":
+			// TIMED is a match whose kick-off time has been confirmed. It
+			// was previously dropped, which hid every imminent fixture.
 			row := []string{m.HomeTeam.Name, "🆚", m.AwayTeam.Name, parseDateString(m.Date)}
 			tScheduled.Append(row)
-		case "FINISHED":
-			row := []string{m.HomeTeam.Name, strconv.Itoa(m.Score.FullTime.HomeTeam), "🆚", m.AwayTeam.Name, strconv.Itoa(m.Score.FullTime.AwayTeam)}
+		case "IN_PLAY", "PAUSED", "FINISHED", "AWARDED":
+			row := []string{m.HomeTeam.Name, scoreString(m.Score.FullTime.Home), "🆚", m.AwayTeam.Name, scoreString(m.Score.FullTime.Away)}
 			tPlayed.Append(row)
+		default:
+			// POSTPONED, SUSPENDED, CANCELLED
+			row := []string{m.HomeTeam.Name, "🆚", m.AwayTeam.Name, fmt.Sprintf("⚠ %s", m.Status)}
+			tScheduled.Append(row)
 		}
 	}
 

--- a/modules/football/widget_test.go
+++ b/modules/football/widget_test.go
@@ -34,6 +34,13 @@ func TestGetStandingsFiltersByStandingCount(t *testing.T) {
 	const standingsJSON = `{
 		"standings": [
 			{
+				"type": "HOME",
+				"table": [
+					{"position": 1, "team": {"name": "Home Only FC"}, "playedGames": 5, "won": 5, "draw": 0, "lost": 0, "goalDifference": 9, "points": 15}
+				]
+			},
+			{
+				"type": "TOTAL",
 				"table": [
 					{"position": 1, "team": {"name": "Team A"}, "playedGames": 10, "won": 8, "draw": 1, "lost": 1, "goalDifference": 15, "points": 25},
 					{"position": 2, "team": {"name": "Team B"}, "playedGames": 10, "won": 6, "draw": 2, "lost": 2, "goalDifference": 10, "points": 20},
@@ -57,6 +64,7 @@ func TestGetStandingsFiltersByStandingCount(t *testing.T) {
 	assert.Assert(t, strings.Contains(content, "Team A"))
 	assert.Assert(t, strings.Contains(content, "Team B"))
 	assert.Assert(t, !strings.Contains(content, "Team C"), "team outside standingCount should be excluded")
+	assert.Assert(t, !strings.Contains(content, "Home Only FC"), "only the TOTAL table should be rendered")
 }
 
 func TestGetStandingsEmptyReturnsError(t *testing.T) {
@@ -75,8 +83,8 @@ func TestGetStandingsEmptyReturnsError(t *testing.T) {
 func TestGetMatchesSplitsScheduledAndFinished(t *testing.T) {
 	const matchesJSON = `{
 		"matches": [
-			{"homeTeam": {"name": "Home FC"}, "awayTeam": {"name": "Away FC"}, "status": "FINISHED", "utcDate": "2024-01-01T15:00:00Z", "score": {"fullTime": {"homeTeam": 2, "awayTeam": 1}}},
-			{"homeTeam": {"name": "Next Home"}, "awayTeam": {"name": "Next Away"}, "status": "SCHEDULED", "utcDate": "2024-01-08T15:00:00Z", "score": {"fullTime": {"homeTeam": 0, "awayTeam": 0}}}
+			{"homeTeam": {"name": "Home FC"}, "awayTeam": {"name": "Away FC"}, "status": "FINISHED", "utcDate": "2024-01-01T15:00:00Z", "score": {"fullTime": {"home": 2, "away": 1}}},
+			{"homeTeam": {"name": "Next Home"}, "awayTeam": {"name": "Next Away"}, "status": "SCHEDULED", "utcDate": "2024-01-08T15:00:00Z", "score": {"fullTime": {"home": null, "away": null}}}
 		]
 	}`
 
@@ -101,7 +109,7 @@ func TestGetMatchesSplitsScheduledAndFinished(t *testing.T) {
 func TestGetMatchesMarksFavoriteTeam(t *testing.T) {
 	const matchesJSON = `{
 		"matches": [
-			{"homeTeam": {"name": "Home FC"}, "awayTeam": {"name": "My Favorite Team"}, "status": "SCHEDULED", "utcDate": "2024-01-08T15:00:00Z", "score": {"fullTime": {"homeTeam": 0, "awayTeam": 0}}}
+			{"homeTeam": {"name": "Home FC"}, "awayTeam": {"name": "My Favorite Team"}, "status": "SCHEDULED", "utcDate": "2024-01-08T15:00:00Z", "score": {"fullTime": {"home": null, "away": null}}}
 		]
 	}`
 
@@ -211,12 +219,12 @@ func TestMarkFavoriteMarksAwayTeam(t *testing.T) {
 func TestContentHappyPath(t *testing.T) {
 	const standingsJSON = `{
 		"standings": [
-			{"table": [{"position": 1, "team": {"name": "Team A"}, "playedGames": 1, "won": 1, "draw": 0, "lost": 0, "goalDifference": 1, "points": 3}]}
+			{"type": "TOTAL", "table": [{"position": 1, "team": {"name": "Team A"}, "playedGames": 1, "won": 1, "draw": 0, "lost": 0, "goalDifference": 1, "points": 3}]}
 		]
 	}`
 	const matchesJSON = `{
 		"matches": [
-			{"homeTeam": {"name": "Home FC"}, "awayTeam": {"name": "Away FC"}, "status": "FINISHED", "utcDate": "2024-01-01T15:00:00Z", "score": {"fullTime": {"homeTeam": 1, "awayTeam": 0}}}
+			{"homeTeam": {"name": "Home FC"}, "awayTeam": {"name": "Away FC"}, "status": "FINISHED", "utcDate": "2024-01-01T15:00:00Z", "score": {"fullTime": {"home": 1, "away": 0}}}
 		]
 	}`
 
@@ -244,4 +252,116 @@ func TestContentHappyPath(t *testing.T) {
 	assert.Assert(t, strings.Contains(content, "Matches Played:"))
 	assert.Assert(t, strings.Contains(content, "Home FC"))
 	assert.Assert(t, !wrap)
+}
+
+// TestGetMatchesIncludesTimedFixtures covers the v4 status workflow: a fixture
+// with a confirmed kick-off time is TIMED, not SCHEDULED. Only handling
+// SCHEDULED silently dropped every imminent fixture from the widget.
+func TestGetMatchesIncludesTimedFixtures(t *testing.T) {
+	const matchesJSON = `{
+		"matches": [
+			{"homeTeam": {"name": "Timed Home"}, "awayTeam": {"name": "Timed Away"}, "status": "TIMED", "utcDate": "2024-01-08T15:00:00Z", "score": {"fullTime": {"home": null, "away": null}}}
+		]
+	}`
+
+	withFakeFootballAPI(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, matchesJSON)
+	})
+
+	widget := newTestWidget(&Settings{matchesFrom: 2, matchesTo: 5})
+
+	content := widget.GetMatches(2021)
+
+	assert.Assert(t, strings.Contains(content, "Upcoming Matches:"))
+	assert.Assert(t, strings.Contains(content, "Timed Home"))
+	assert.Assert(t, strings.Contains(content, "Timed Away"))
+}
+
+// TestGetMatchesLiveMatchShowsRunningScore checks that an in-progress match is
+// rendered with its running score rather than being dropped.
+func TestGetMatchesLiveMatchShowsRunningScore(t *testing.T) {
+	const matchesJSON = `{
+		"matches": [
+			{"homeTeam": {"name": "Live Home"}, "awayTeam": {"name": "Live Away"}, "status": "IN_PLAY", "utcDate": "2024-01-08T15:00:00Z", "score": {"fullTime": {"home": 2, "away": 0}}}
+		]
+	}`
+
+	withFakeFootballAPI(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, matchesJSON)
+	})
+
+	widget := newTestWidget(&Settings{matchesFrom: 2, matchesTo: 5})
+
+	content := widget.GetMatches(2021)
+
+	assert.Assert(t, strings.Contains(content, "Live Home"))
+	assert.Assert(t, strings.Contains(content, "2"))
+}
+
+// TestGetMatchesPostponedIsShown checks that statuses outside the happy path
+// are surfaced instead of vanishing from the widget.
+func TestGetMatchesPostponedIsShown(t *testing.T) {
+	const matchesJSON = `{
+		"matches": [
+			{"homeTeam": {"name": "Off Home"}, "awayTeam": {"name": "Off Away"}, "status": "POSTPONED", "utcDate": "2024-01-08T15:00:00Z", "score": {"fullTime": {"home": null, "away": null}}}
+		]
+	}`
+
+	withFakeFootballAPI(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, matchesJSON)
+	})
+
+	widget := newTestWidget(&Settings{matchesFrom: 2, matchesTo: 5})
+
+	content := widget.GetMatches(2021)
+
+	assert.Assert(t, strings.Contains(content, "Off Home"))
+	assert.Assert(t, strings.Contains(content, "POSTPONED"))
+}
+
+// TestGetMatchesRequestsInclusiveDateRange guards the v4 change that excludes
+// the dateTo day itself from the result set.
+func TestGetMatchesRequestsInclusiveDateRange(t *testing.T) {
+	var gotDateTo string
+
+	withFakeFootballAPI(t, func(w http.ResponseWriter, r *http.Request) {
+		gotDateTo = r.URL.Query().Get("dateTo")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, `{"matches": []}`)
+	})
+
+	widget := newTestWidget(&Settings{matchesFrom: 2, matchesTo: 5})
+
+	widget.GetMatches(2021)
+
+	assert.Equal(t, gotDateTo, getDateString(6))
+}
+
+// TestTotalTableSkipsHomeAndAwayTables covers the v4 standings response, which
+// returns separate TOTAL, HOME and AWAY tables for a league competition.
+func TestTotalTableSkipsHomeAndAwayTables(t *testing.T) {
+	standings := []Standing{
+		{Type: "HOME", Table: []Table{{Position: 1, Team: Team{Name: "Home Table Team"}}}},
+		{Type: "TOTAL", Table: []Table{{Position: 1, Team: Team{Name: "Total Table Team"}}}},
+		{Type: "AWAY", Table: []Table{{Position: 1, Team: Team{Name: "Away Table Team"}}}},
+	}
+
+	table := totalTable(standings)
+
+	assert.Equal(t, len(table), 1)
+	assert.Equal(t, table[0].Team.Name, "Total Table Team")
+}
+
+func TestTotalTableNoStandings(t *testing.T) {
+	assert.Assert(t, totalTable(nil) == nil)
+}
+
+func TestScoreStringNilIsDash(t *testing.T) {
+	assert.Equal(t, scoreString(nil), "-")
+
+	goals := 3
+	assert.Equal(t, scoreString(&goals), "3")
 }


### PR DESCRIPTION
## What's happening

The football module targets football-data.org API v2, which no longer returns
matches for the current season. Comparing the same window on both versions:

```bash
# v2 — empty
curl -s -H "X-Auth-Token: $KEY" \
  "https://api.football-data.org/v2/competitions/PL/matches?dateFrom=2026-08-15&dateTo=2026-08-22" \
  | jq '.matches | length'
# 0

# v4 — six fixtures, all TIMED
curl -s -H "X-Auth-Token: $KEY" \
  "https://api.football-data.org/v4/competitions/PL/matches?dateFrom=2026-08-15&dateTo=2026-08-22" \
  | jq -r '.matches[].status' | sort | uniq -c
# 6 TIMED
```

v2 still answers, and still returns last season's data, it isn't being fed the current season's data. The module shows
an empty widget.

This PR ports the module to v4.

## Changes

**API v4 migration**

- Base URL moved from `/v2` to `/v4`.
- `score.fullTime` is keyed `home`/`away` in v4, where v2 used
  `homeTeam`/`awayTeam`. This is because the old struct tags
  unmarshal against v4 without error and silently produce zero values, so every
  finished match would render `0 - 0` with no error message.
- Scores are nullable in v4, so `ScoreByTime` now holds `*int` and a helper
  renders a missing value as `-` rather than a `0`.
- `dateTo` is exclusive in v4. The request now asks for one day beyond
  `matchesTo` so the configured window stays inclusive, as documented.
- v4 returns separate `TOTAL`, `HOME` and `AWAY` standings tables for a league
  competition. The old code took `Standings[0]`, which was only the overall
  table by accident of ordering; there's now an explicit lookup for the `TOTAL`
  table, falling back to the first block if no type is set.

**Match status handling** (separate commit)

- `TIMED` fixtures are now shown. The switch previously matched only
  `SCHEDULED` and `FINISHED`, so a fixture whose kick-off time had been
  confirmed was dropped without trace. In the sample above, that's all six.
- `IN_PLAY` and `PAUSED` matches render with their running score, and `AWARDED`
  is treated as finished.
- `POSTPONED`, `SUSPENDED` and `CANCELLED` are surfaced with their status
  rather than vanishing.

**Drive-by fix** (separate commit)

- `footballRequest` used the request object before checking the error from
  `http.NewRequest`, which would panic rather than return the error.

## Testing

`go test ./modules/football/` passes. Existing tests were updated to v4 payload
shapes, and new ones cover the `TIMED` case, a live match, a non-played status,
the inclusive date range, and `TOTAL` table selection.

## Documentation

Per CONTRIBUTING.md, the `matchesTo` change affects a documented configuration
parameter: the same YAML value now produces a different window. I'm happy to
open a companion PR against wtfdocs once the direction here is agreed.

## Open questions

- The status-handling commit is a behaviour change that v4 exposed rather than
  caused. If you'd rather keep this PR to the port alone, I'll
  drop that commit and raise it separately.
- I left a few things alone to keep the diff focused: the `LeagueFixtuers` typo, the `leagueID` map
  (`EL2: 444` looks stale, and v4 accepts competition codes directly, though
  wtf's codes don't match football-data's), multi-group standings for
  competitions like the Champions League, and rendering penalty-shootout
  results via `score.duration`.
