### PR TITLE
Fix Jira issue key column width being hardcoded

### DIFF
--- a/modules/jira/widget.go
+++ b/modules/jira/widget.go
@@ -115,7 +115,7 @@ func getLongestColumnLengths(issues []Issue) (int, int, int) {
 
 		issueKeyLength := len(issue.Key)
 		if issueKeyLength > longestKeyLength {
-			longestKeyLength = len("WTF-XXX") // issueKeyLength
+			longestKeyLength = issueKeyLength
 		}
 
 		statusNameLength := len(issue.IssueFields.IssueStatus.IName)

--- a/modules/jira/widget_test.go
+++ b/modules/jira/widget_test.go
@@ -1,0 +1,52 @@
+package jira
+
+import (
+	"testing"
+
+	"gotest.tools/assert"
+)
+
+func issue(key, issueType, status string) Issue {
+	return Issue{
+		Key: key,
+		IssueFields: &IssueFields{
+			IssueType:   &IssueType{Name: issueType},
+			IssueStatus: &IssueStatus{IName: status},
+		},
+	}
+}
+
+func TestGetLongestColumnLengths_UsesLongestIssueKey(t *testing.T) {
+	issues := []Issue{
+		issue("PROD-1901", "Task", "In Progress"),
+		issue("GRID-11658", "Bug", "Ready"),
+	}
+
+	_, longestKeyLength, _ := getLongestColumnLengths(issues)
+
+	// Must track the actual longest key ("GRID-11658"), otherwise shorter keys
+	// are padded to a different width and every column after them misaligns.
+	assert.Equal(t, len("GRID-11658"), longestKeyLength)
+}
+
+func TestGetLongestColumnLengths_KeysOfEqualLength(t *testing.T) {
+	issues := []Issue{
+		issue("WTF-1", "Bug", "Ready"),
+		issue("WTF-2", "Bug", "Ready"),
+	}
+
+	_, longestKeyLength, _ := getLongestColumnLengths(issues)
+
+	assert.Equal(t, len("WTF-1"), longestKeyLength)
+}
+
+func TestGetLongestColumnLengths_ClampsTypeAndStatus(t *testing.T) {
+	issues := []Issue{
+		issue("WTF-1", "Improvement", "Waiting for customer"),
+	}
+
+	longestIssueTypeLength, _, longestStatusNameLength := getLongestColumnLengths(issues)
+
+	assert.Equal(t, MaxIssueTypeLength, longestIssueTypeLength)
+	assert.Equal(t, MaxStatusNameLength, longestStatusNameLength)
+}


### PR DESCRIPTION
### Purpose

`getLongestColumnLengths()` in `modules/jira/widget.go` assigns `len("WTF-XXX")`
to `longestKeyLength` rather than the issue key's actual length. 7 characters is not enough for many Jira tickets.

example of the bug:
<img width="485" height="225" alt="Screenshot From 2026-08-31 11-40-16" src="https://github.com/user-attachments/assets/e67cca8e-5e28-4563-9b5f-f19d6e280b24" />

Change this line to expand longestKeyLength to the maximum in the issue list, not a max of 7 characters

Add unit tests
