### PR TITLE
fix(urlchecker): convert timeout value to time.Second

### DIFF
--- a/modules/urlcheck/widget.go
+++ b/modules/urlcheck/widget.go
@@ -30,7 +30,7 @@ func NewWidget(tviewApp *tview.Application, redrawChan chan bool, settings *Sett
 		settings: settings,
 		urlList:  make([]*urlResult, maxUrl),
 		client:   &http.Client{},
-		timeout:  time.Duration(settings.requestTimeout) + time.Second,
+		timeout:  time.Duration(settings.requestTimeout) * time.Second,
 	}
 
 	widget.init()


### PR DESCRIPTION
This is a 1-character change that multiplies the timeout setting value by `time.Second` rather than adding it.

Prior to this fix, if the desired timeout was 30 seconds, a timeout value of `29000000000` had to be supplied (29 x 10^9 nanoseconds + 1 second).

---

As an aside, I'm absolutely loving this dashboard. Thanks for all the hard work!